### PR TITLE
Fix area and zone module PHP scripts

### DIFF
--- a/scripts/php/obtener_areas_zonas.php
+++ b/scripts/php/obtener_areas_zonas.php
@@ -1,15 +1,27 @@
 <?php
 header("Content-Type: application/json");
-require_once "../../config/conexion.php";
+// Conexión a la base de datos (se usan las mismas credenciales que en otros scripts)
+$servername = "localhost";
+$db_user    = "u296155119_Admin";
+$db_pass    = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+$conn = mysqli_connect($servername, $db_user, $db_pass, $database);
+if (!$conn) {
+    echo json_encode(["success" => false, "message" => "Error de conexión"]);
+    exit;
+}
 
 $resultado = [];
 
-$areas = $conn->query("SELECT * FROM area ORDER BY id_area DESC");
+// Obtener todas las áreas
+$areas = $conn->query("SELECT * FROM areas ORDER BY id DESC");
 while ($area = $areas->fetch_assoc()) {
-    $area_id = $area['id_area'];
+    $area_id = $area['id'];
     $zonas = [];
 
-    $zonas_query = $conn->prepare("SELECT * FROM zona WHERE id_area = ?");
+    // Obtener zonas asociadas a la área
+    $zonas_query = $conn->prepare("SELECT * FROM zonas WHERE area_id = ?");
     $zonas_query->bind_param("i", $area_id);
     $zonas_query->execute();
     $res = $zonas_query->get_result();

--- a/scripts/php/registrar_area.php
+++ b/scripts/php/registrar_area.php
@@ -1,6 +1,16 @@
 <?php
 header("Content-Type: application/json");
-require_once "../../config/conexion.php"; // ajusta si tu conexión está en otro lugar
+// Conexión a la base de datos
+$servername = "localhost";
+$db_user    = "u296155119_Admin";
+$db_pass    = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+$conn = mysqli_connect($servername, $db_user, $db_pass, $database);
+if (!$conn) {
+    echo json_encode(["success" => false, "message" => "Error de conexión"]);
+    exit;
+}
 
 $data = json_decode(file_get_contents("php://input"));
 $nombre = $data->areaName ?? '';
@@ -10,7 +20,7 @@ if (!$nombre) {
     exit;
 }
 
-$stmt = $conn->prepare("INSERT INTO area (nombre) VALUES (?)");
+$stmt = $conn->prepare("INSERT INTO areas (nombre) VALUES (?)");
 $stmt->bind_param("s", $nombre);
 
 if ($stmt->execute()) {

--- a/scripts/php/registrar_zona.php
+++ b/scripts/php/registrar_zona.php
@@ -1,6 +1,16 @@
 <?php
 header("Content-Type: application/json");
-require_once "../../config/conexion.php";
+// Conexión a la base de datos
+$servername = "localhost";
+$db_user    = "u296155119_Admin";
+$db_pass    = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+$conn = mysqli_connect($servername, $db_user, $db_pass, $database);
+if (!$conn) {
+    echo json_encode(["success" => false, "message" => "Error de conexión"]);
+    exit;
+}
 
 $data = json_decode(file_get_contents("php://input"));
 
@@ -17,7 +27,7 @@ if (!$nombre || !$id_area || !$ancho || !$alto || !$largo || !$tipo) {
     exit;
 }
 
-$stmt = $conn->prepare("INSERT INTO zona (nombre, id_area, ancho, alto, largo, subniveles, tipo_almacenamiento) VALUES (?, ?, ?, ?, ?, ?, ?)");
+$stmt = $conn->prepare("INSERT INTO zonas (nombre, area_id, ancho, alto, largo, subniveles, tipo_almacenamiento) VALUES (?, ?, ?, ?, ?, ?, ?)");
 $stmt->bind_param("sidddis", $nombre, $id_area, $ancho, $alto, $largo, $subniveles, $tipo);
 
 if ($stmt->execute()) {


### PR DESCRIPTION
## Summary
- fix connection path in `obtener_areas_zonas.php`
- use plural table names and local connection setup in `obtener_areas_zonas.php`
- update `registrar_area.php` and `registrar_zona.php` to include DB credentials directly
- align table names with existing ones

## Testing
- `php -l scripts/php/obtener_areas_zonas.php`
- `php -l scripts/php/registrar_area.php`
- `php -l scripts/php/registrar_zona.php`


------
https://chatgpt.com/codex/tasks/task_e_6881390517c8832c9d41556f6b8fc88f