### PR TITLE
Implement warehouse areas and zones module

### DIFF
--- a/optistock.sql
+++ b/optistock.sql
@@ -89,6 +89,39 @@ ALTER TABLE `empresa`
 ALTER TABLE `usuario`
   MODIFY `id_usuario` int(11) NOT NULL AUTO_INCREMENT;
 
+-- --------------------------------------------------------
+
+-- Estructura de tabla para la tabla `areas`
+
+CREATE TABLE `areas` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `nombre` varchar(100) NOT NULL,
+  `descripcion` text DEFAULT NULL,
+  `ancho` decimal(10,2) NOT NULL,
+  `alto` decimal(10,2) NOT NULL,
+  `largo` decimal(10,2) NOT NULL,
+  `volumen` decimal(15,2) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+-- Estructura de tabla para la tabla `zonas`
+
+CREATE TABLE `zonas` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `nombre` varchar(100) NOT NULL,
+  `descripcion` text DEFAULT NULL,
+  `ancho` decimal(10,2) NOT NULL,
+  `alto` decimal(10,2) NOT NULL,
+  `largo` decimal(10,2) NOT NULL,
+  `volumen` decimal(15,2) NOT NULL,
+  `area_id` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `area_id` (`area_id`),
+  CONSTRAINT `zonas_ibfk_1` FOREIGN KEY (`area_id`) REFERENCES `areas`(`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
 --
 -- Restricciones para tablas volcadas
 --

--- a/pages/area_almac/areas_zonas.html
+++ b/pages/area_almac/areas_zonas.html
@@ -34,6 +34,12 @@
         <h4>Registrar Área de Almacén</h4>
         <label for="areaName">Nombre del Área</label>
         <input type="text" name="areaName" id="areaName" placeholder="Nombre del Área" required />
+        <label for="areaDesc">Descripción</label>
+        <textarea id="areaDesc" name="areaDesc" rows="3" required></textarea>
+        <label>Dimensiones físicas (m)</label>
+        <input type="number" name="areaWidth" id="areaWidth" placeholder="Ancho" min="0.01" step="0.01" required />
+        <input type="number" name="areaHeight" id="areaHeight" placeholder="Alto" min="0.01" step="0.01" required />
+        <input type="number" name="areaLength" id="areaLength" placeholder="Largo" min="0.01" step="0.01" required />
         <button type="submit" class="btn btn-primary">Guardar Área</button>
       </form>
       <!-- Formulario Zona -->
@@ -41,6 +47,8 @@
         <h4>Registrar Zona de Almacenamiento</h4>
         <label for="zoneName">Nombre de la Zona</label>
         <input type="text" id="zoneName" name="zoneName" required />
+        <label for="zoneDesc">Descripción</label>
+        <textarea id="zoneDesc" name="zoneDesc" rows="3" required></textarea>
         <label for="zoneArea">Área asociada</label>
         <select name="zoneArea" id="zoneArea" required>
           <option value="">Seleccione un área</option>

--- a/scripts/area_almac/areas_zonas.js
+++ b/scripts/area_almac/areas_zonas.js
@@ -16,14 +16,11 @@ const errorContainer = document.getElementById('error-message');
 // Función para llamadas API mejorada
 async function fetchAPI(endpoint, method = 'GET', data = null) {
   try {
-    const options = { method, credentials: 'include' };
+    const options = { method, credentials: 'include', headers: {} };
 
     if (data && method !== 'GET') {
-      const formData = new FormData();
-      for (let key in data) {
-        formData.append(key, data[key]);
-      }
-      options.body = formData;
+      options.headers['Content-Type'] = 'application/json';
+      options.body = JSON.stringify(data);
     }
 
     const response = await fetch(endpoint, options);
@@ -107,6 +104,10 @@ async function mostrarFormulario(tipo, datos = null) {
       
       if (datos) {
         areaForm.areaName.value = datos.nombre;
+        areaForm.areaDesc.value = datos.descripcion || '';
+        areaForm.areaWidth.value = datos.ancho;
+        areaForm.areaHeight.value = datos.alto;
+        areaForm.areaLength.value = datos.largo;
         areaForm.dataset.id = datos.id;
       } else {
         areaForm.reset();
@@ -121,6 +122,7 @@ async function mostrarFormulario(tipo, datos = null) {
       
       if (datos) {
         zoneForm.zoneName.value = datos.nombre;
+        zoneForm.zoneDesc.value = datos.descripcion || '';
         zoneForm.zoneWidth.value = datos.ancho;
         zoneForm.zoneHeight.value = datos.alto;
         zoneForm.zoneLength.value = datos.largo;
@@ -251,20 +253,24 @@ function mostrarResumen(data) {
 areaForm.addEventListener('submit', async (e) => {
   e.preventDefault();
   const nombre = areaForm.areaName.value.trim();
+  const descripcion = areaForm.areaDesc.value.trim();
+  const ancho = parseFloat(areaForm.areaWidth.value);
+  const alto = parseFloat(areaForm.areaHeight.value);
+  const largo = parseFloat(areaForm.areaLength.value);
   const id = areaForm.dataset.id;
-  
-  if (!nombre) {
-    mostrarError('El nombre del área es obligatorio');
+
+  if (!nombre || isNaN(ancho) || isNaN(alto) || isNaN(largo)) {
+    mostrarError('Debe completar todos los campos del área');
     return;
   }
 
+  const areaData = { nombre, descripcion, ancho, alto, largo };
+
   try {
     if (id) {
-      // Edición
-      await fetchAPI(`${API_ENDPOINTS.areas}?id=${id}`, 'PUT', { nombre });
+      await fetchAPI(`${API_ENDPOINTS.areas}?id=${id}`, 'PUT', areaData);
     } else {
-      // Creación
-      await fetchAPI(API_ENDPOINTS.areas, 'POST', { nombre });
+      await fetchAPI(API_ENDPOINTS.areas, 'POST', areaData);
     }
     
     await cargarYMostrarRegistros();
@@ -281,6 +287,7 @@ zoneForm.addEventListener('submit', async (e) => {
 
   const id = zoneForm.dataset.id;
   const nombre = zoneForm.zoneName.value.trim();
+  const descripcion = zoneForm.zoneDesc.value.trim();
   const ancho = parseFloat(zoneForm.zoneWidth.value);
   const alto = parseFloat(zoneForm.zoneHeight.value);
   const largo = parseFloat(zoneForm.zoneLength.value);
@@ -289,7 +296,7 @@ zoneForm.addEventListener('submit', async (e) => {
   const sublevelsCount = parseInt(zoneForm.sublevelsCount.value) || 0;
 
   // Validaciones
-  if (!nombre || !tipo || isNaN(ancho) || isNaN(alto) || isNaN(largo)) {
+  if (!nombre || !descripcion || !tipo || isNaN(ancho) || isNaN(alto) || isNaN(largo)) {
     mostrarError('Debe completar todos los campos obligatorios con valores válidos.');
     return;
   }
@@ -319,6 +326,7 @@ zoneForm.addEventListener('submit', async (e) => {
   try {
     const zonaData = {
       nombre,
+      descripcion,
       ancho,
       alto,
       largo,
@@ -355,7 +363,7 @@ async function editarArea(id) {
 }
 
 async function eliminarArea(id) {
-  if (confirm('¿Está seguro de eliminar esta área? Las zonas asociadas quedarán sin área asignada.')) {
+  if (confirm('¿Está seguro de eliminar esta área?') && confirm('Esta acción es irreversible, confirme de nuevo.')) {
     try {
       await fetchAPI(`${API_ENDPOINTS.areas}?id=${id}`, 'DELETE');
       await cargarYMostrarRegistros();
@@ -375,7 +383,7 @@ async function editarZona(id) {
 }
 
 async function eliminarZona(id) {
-  if (confirm('¿Está seguro de eliminar esta zona?')) {
+  if (confirm('¿Está seguro de eliminar esta zona?') && confirm('Esta acción es irreversible, confirme de nuevo.')) {
     try {
       await fetchAPI(`${API_ENDPOINTS.zonas}?id=${id}`, 'DELETE');
       await cargarYMostrarRegistros();
@@ -401,33 +409,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     return;
   }
 
-  // Configurar eventos de formularios
-  if (areaForm) {
-    areaForm.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const nombre = e.target.areaName.value.trim();
-      const id = e.target.dataset.id;
-      
-      if (!nombre) {
-        mostrarError('El nombre del área es obligatorio');
-        return;
-      }
-
-      try {
-        if (id) {
-          await fetchAPI(`${API_ENDPOINTS.areas}?id=${id}`, 'PUT', { nombre });
-        } else {
-          await fetchAPI(API_ENDPOINTS.areas, 'POST', { nombre });
-        }
-        
-        await cargarYMostrarRegistros();
-        e.target.reset();
-        e.target.style.display = 'none';
-      } catch (error) {
-        console.error('Error guardando área:', error);
-      }
-    });
-  }
+  // No additional listeners: se configuran arriba
 
   // Cargar datos iniciales
   await cargarYMostrarRegistros();

--- a/scripts/php/guardar_areas.php
+++ b/scripts/php/guardar_areas.php
@@ -1,0 +1,88 @@
+<?php
+header('Content-Type: application/json');
+$servername = "localhost";
+$db_user    = "u296155119_Admin";
+$db_pass    = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+$conn = new mysqli($servername, $db_user, $db_pass, $database);
+if ($conn->connect_error) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Error de conexión']);
+    exit;
+}
+
+$method = $_SERVER['REQUEST_METHOD'];
+
+function getJsonInput() {
+    $input = file_get_contents('php://input');
+    $data = json_decode($input, true);
+    return $data ?: [];
+}
+
+if ($method === 'GET') {
+    $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    if ($id) {
+        $stmt = $conn->prepare('SELECT * FROM areas WHERE id = ?');
+        $stmt->bind_param('i', $id);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        echo json_encode($res->fetch_assoc() ?: []);
+    } else {
+        $result = $conn->query('SELECT * FROM areas');
+        $areas = [];
+        while ($row = $result->fetch_assoc()) {
+            $areas[] = $row;
+        }
+        echo json_encode($areas);
+    }
+    exit;
+}
+
+if ($method === 'POST') {
+    $data = getJsonInput();
+    $nombre = $data['nombre'] ?? '';
+    $descripcion = $data['descripcion'] ?? '';
+    $ancho = floatval($data['ancho'] ?? 0);
+    $alto = floatval($data['alto'] ?? 0);
+    $largo = floatval($data['largo'] ?? 0);
+    $volumen = $ancho * $alto * $largo;
+    if (!$nombre) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Nombre requerido']);
+        exit;
+    }
+    $stmt = $conn->prepare('INSERT INTO areas (nombre, descripcion, ancho, alto, largo, volumen) VALUES (?,?,?,?,?,?)');
+    $stmt->bind_param('ssdddd', $nombre, $descripcion, $ancho, $alto, $largo, $volumen);
+    $stmt->execute();
+    echo json_encode(['id' => $stmt->insert_id]);
+    exit;
+}
+
+if ($method === 'PUT') {
+    $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    $data = getJsonInput();
+    $nombre = $data['nombre'] ?? '';
+    $descripcion = $data['descripcion'] ?? '';
+    $ancho = floatval($data['ancho'] ?? 0);
+    $alto = floatval($data['alto'] ?? 0);
+    $largo = floatval($data['largo'] ?? 0);
+    $volumen = $ancho * $alto * $largo;
+    $stmt = $conn->prepare('UPDATE areas SET nombre=?, descripcion=?, ancho=?, alto=?, largo=?, volumen=? WHERE id=?');
+    $stmt->bind_param('ssddddi', $nombre, $descripcion, $ancho, $alto, $largo, $volumen, $id);
+    $stmt->execute();
+    echo json_encode(['success' => $stmt->affected_rows > 0]);
+    exit;
+}
+
+if ($method === 'DELETE') {
+    $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    $stmt = $conn->prepare('DELETE FROM areas WHERE id=?');
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    echo json_encode(['success' => true]);
+    exit;
+}
+
+http_response_code(405);
+echo json_encode(['error' => 'Método no permitido']);

--- a/scripts/php/guardar_zonas.php
+++ b/scripts/php/guardar_zonas.php
@@ -1,0 +1,90 @@
+<?php
+header('Content-Type: application/json');
+$servername = "localhost";
+$db_user    = "u296155119_Admin";
+$db_pass    = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+$conn = new mysqli($servername, $db_user, $db_pass, $database);
+if ($conn->connect_error) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Error de conexión']);
+    exit;
+}
+
+$method = $_SERVER['REQUEST_METHOD'];
+
+function getJsonInput() {
+    $input = file_get_contents('php://input');
+    $data = json_decode($input, true);
+    return $data ?: [];
+}
+
+if ($method === 'GET') {
+    $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    if ($id) {
+        $stmt = $conn->prepare('SELECT * FROM zonas WHERE id = ?');
+        $stmt->bind_param('i', $id);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        echo json_encode($res->fetch_assoc() ?: []);
+    } else {
+        $result = $conn->query('SELECT * FROM zonas');
+        $zonas = [];
+        while ($row = $result->fetch_assoc()) {
+            $zonas[] = $row;
+        }
+        echo json_encode($zonas);
+    }
+    exit;
+}
+
+if ($method === 'POST') {
+    $data = getJsonInput();
+    $nombre = $data['nombre'] ?? '';
+    $descripcion = $data['descripcion'] ?? '';
+    $ancho = floatval($data['ancho'] ?? 0);
+    $alto = floatval($data['alto'] ?? 0);
+    $largo = floatval($data['largo'] ?? 0);
+    $volumen = $ancho * $alto * $largo;
+    $area_id = isset($data['area_id']) ? intval($data['area_id']) : null;
+    if (!$nombre) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Nombre requerido']);
+        exit;
+    }
+    $stmt = $conn->prepare('INSERT INTO zonas (nombre, descripcion, ancho, alto, largo, volumen, area_id) VALUES (?,?,?,?,?,?,?)');
+    $stmt->bind_param('ssddddi', $nombre, $descripcion, $ancho, $alto, $largo, $volumen, $area_id);
+    $stmt->execute();
+    echo json_encode(['id' => $stmt->insert_id]);
+    exit;
+}
+
+if ($method === 'PUT') {
+    $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    $data = getJsonInput();
+    $nombre = $data['nombre'] ?? '';
+    $descripcion = $data['descripcion'] ?? '';
+    $ancho = floatval($data['ancho'] ?? 0);
+    $alto = floatval($data['alto'] ?? 0);
+    $largo = floatval($data['largo'] ?? 0);
+    $volumen = $ancho * $alto * $largo;
+    $area_id = isset($data['area_id']) ? intval($data['area_id']) : null;
+    $stmt = $conn->prepare('UPDATE zonas SET nombre=?, descripcion=?, ancho=?, alto=?, largo=?, volumen=?, area_id=? WHERE id=?');
+    $stmt->bind_param('ssddddii', $nombre, $descripcion, $ancho, $alto, $largo, $volumen, $area_id, $id);
+    $stmt->execute();
+    echo json_encode(['success' => $stmt->affected_rows > 0]);
+    exit;
+}
+
+if ($method === 'DELETE') {
+    $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    $stmt = $conn->prepare('DELETE FROM zonas WHERE id=?');
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    echo json_encode(['success' => true]);
+    exit;
+}
+
+http_response_code(405);
+echo json_encode(['error' => 'Método no permitido']);

--- a/styles/Area_almac/areas_zonas.css
+++ b/styles/Area_almac/areas_zonas.css
@@ -163,6 +163,16 @@ select {
   transition: border 0.2s;
 }
 
+textarea {
+  padding: 0.8rem 0.1rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--color-border);
+  font-size: 1.08rem;
+  background: #f8fafc;
+  transition: border 0.2s;
+  resize: vertical;
+}
+
 input:focus,
 select:focus {
   border-color: var(--color-primary);


### PR DESCRIPTION
## Summary
- define SQL tables for `areas` and `zonas`
- add backend scripts `guardar_areas.php` and `guardar_zonas.php`
- expand UI forms for area and zone management with descriptions and dimensions
- update JS logic for CRUD using new JSON API and double-confirm deletes
- tweak styles for new textarea fields

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_688142e8c9dc832c8f5ebfd3c2a696d0