### PR TITLE
Add basic inventory management module

### DIFF
--- a/optistock.sql
+++ b/optistock.sql
@@ -136,3 +136,42 @@ COMMIT;
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+
+-- --------------------------------------------------------
+-- Estructura de tabla para la tabla `categorias`
+CREATE TABLE `categorias` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `nombre` varchar(100) NOT NULL,
+  `descripcion` text DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+-- Estructura de tabla para la tabla `subcategorias`
+CREATE TABLE `subcategorias` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `categoria_id` int(11) DEFAULT NULL,
+  `nombre` varchar(100) NOT NULL,
+  `descripcion` text DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `categoria_id` (`categoria_id`),
+  CONSTRAINT `subcategorias_ibfk_1` FOREIGN KEY (`categoria_id`) REFERENCES `categorias`(`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+-- Estructura de tabla para la tabla `productos`
+CREATE TABLE `productos` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `nombre` varchar(150) NOT NULL,
+  `descripcion` text DEFAULT NULL,
+  `categoria_id` int(11) DEFAULT NULL,
+  `subcategoria_id` int(11) DEFAULT NULL,
+  `stock` int(11) NOT NULL DEFAULT 0,
+  `precio_compra` decimal(10,2) NOT NULL DEFAULT 0.00,
+  PRIMARY KEY (`id`),
+  KEY `categoria_id` (`categoria_id`),
+  KEY `subcategoria_id` (`subcategoria_id`),
+  CONSTRAINT `productos_ibfk_1` FOREIGN KEY (`categoria_id`) REFERENCES `categorias`(`id`) ON DELETE SET NULL,
+  CONSTRAINT `productos_ibfk_2` FOREIGN KEY (`subcategoria_id`) REFERENCES `subcategorias`(`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+

--- a/pages/gest_inve/inventario.html
+++ b/pages/gest_inve/inventario.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Gestión de Inventario</title>
+    <link rel="stylesheet" href="../../styles/gest_inve/inventario.css">
+    <script src="../../scripts/gest_inve/inventario.js" defer></script>
+</head>
+<body>
+<div class="inventory-wrapper">
+    <h2>Gestión de Inventario</h2>
+
+    <section class="categorias-section">
+        <h3>Categorías</h3>
+        <form id="categoriaForm" autocomplete="off">
+            <input type="hidden" id="categoriaId">
+            <input type="text" id="categoriaNombre" placeholder="Nombre" required>
+            <textarea id="categoriaDesc" placeholder="Descripción"></textarea>
+            <button type="submit">Guardar</button>
+        </form>
+        <ul id="categoriasLista"></ul>
+    </section>
+
+    <section class="subcategorias-section">
+        <h3>Subcategorías</h3>
+        <form id="subcategoriaForm" autocomplete="off">
+            <input type="hidden" id="subcategoriaId">
+            <select id="subcategoriaCategoria" required></select>
+            <input type="text" id="subcategoriaNombre" placeholder="Nombre" required>
+            <textarea id="subcategoriaDesc" placeholder="Descripción"></textarea>
+            <button type="submit">Guardar</button>
+        </form>
+        <ul id="subcategoriasLista"></ul>
+    </section>
+
+    <section class="productos-section">
+        <h3>Productos</h3>
+        <form id="productoForm" autocomplete="off">
+            <input type="hidden" id="productoId">
+            <input type="text" id="productoNombre" placeholder="Nombre" required>
+            <textarea id="productoDesc" placeholder="Descripción"></textarea>
+            <select id="productoCategoria" required></select>
+            <select id="productoSubcategoria" required></select>
+            <input type="number" id="productoStock" placeholder="Stock" min="0" value="0">
+            <input type="number" id="productoPrecio" placeholder="Precio compra" min="0" step="0.01" value="0">
+            <button type="submit">Guardar</button>
+        </form>
+        <ul id="productosLista"></ul>
+    </section>
+</div>
+</body>
+</html>

--- a/scripts/gest_inve/inventario.js
+++ b/scripts/gest_inve/inventario.js
@@ -1,0 +1,164 @@
+const API = {
+  categorias: '/scripts/php/guardar_categorias.php',
+  subcategorias: '/scripts/php/guardar_subcategorias.php',
+  productos: '/scripts/php/guardar_productos.php'
+};
+
+async function fetchAPI(url, method = 'GET', data) {
+  const options = { method };
+  if (data) {
+    options.headers = { 'Content-Type': 'application/json' };
+    options.body = JSON.stringify(data);
+  }
+  const res = await fetch(url, options);
+  if (!res.ok) throw new Error('Error en la solicitud');
+  return res.json();
+}
+
+// Cargar listas iniciales
+async function cargarCategorias() {
+  const data = await fetchAPI(API.categorias);
+  const selectCat = document.getElementById('subcategoriaCategoria');
+  const prodCat = document.getElementById('productoCategoria');
+  selectCat.innerHTML = '<option value="">Categoría</option>';
+  prodCat.innerHTML = '<option value="">Categoría</option>';
+  data.forEach(c => {
+    const opt1 = document.createElement('option');
+    opt1.value = c.id;
+    opt1.textContent = c.nombre;
+    selectCat.appendChild(opt1);
+    const opt2 = opt1.cloneNode(true);
+    prodCat.appendChild(opt2);
+  });
+  listarCategorias(data);
+}
+
+async function cargarSubcategorias() {
+  const data = await fetchAPI(API.subcategorias);
+  const select = document.getElementById('productoSubcategoria');
+  select.innerHTML = '<option value="">Subcategoría</option>';
+  data.forEach(s => {
+    const opt = document.createElement('option');
+    opt.value = s.id;
+    opt.textContent = s.nombre;
+    select.appendChild(opt);
+  });
+  listarSubcategorias(data);
+}
+
+async function cargarProductos() {
+  const data = await fetchAPI(API.productos);
+  listarProductos(data);
+}
+
+function listarCategorias(lista) {
+  const ul = document.getElementById('categoriasLista');
+  ul.innerHTML = '';
+  lista.forEach(item => {
+    const li = document.createElement('li');
+    li.textContent = item.nombre;
+    li.onclick = () => editarCategoria(item);
+    ul.appendChild(li);
+  });
+}
+
+function listarSubcategorias(lista) {
+  const ul = document.getElementById('subcategoriasLista');
+  ul.innerHTML = '';
+  lista.forEach(item => {
+    const li = document.createElement('li');
+    li.textContent = item.nombre;
+    li.onclick = () => editarSubcategoria(item);
+    ul.appendChild(li);
+  });
+}
+
+function listarProductos(lista) {
+  const ul = document.getElementById('productosLista');
+  ul.innerHTML = '';
+  lista.forEach(item => {
+    const li = document.createElement('li');
+    li.textContent = `${item.nombre} - Stock: ${item.stock}`;
+    li.onclick = () => editarProducto(item);
+    ul.appendChild(li);
+  });
+}
+
+// Formularios
+const categoriaForm = document.getElementById('categoriaForm');
+const subcategoriaForm = document.getElementById('subcategoriaForm');
+const productoForm = document.getElementById('productoForm');
+
+categoriaForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const id = document.getElementById('categoriaId').value;
+  const data = {
+    nombre: document.getElementById('categoriaNombre').value,
+    descripcion: document.getElementById('categoriaDesc').value
+  };
+  if (id) await fetchAPI(`${API.categorias}?id=${id}`, 'PUT', data);
+  else await fetchAPI(API.categorias, 'POST', data);
+  categoriaForm.reset();
+  await cargarCategorias();
+});
+
+subcategoriaForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const id = document.getElementById('subcategoriaId').value;
+  const data = {
+    categoria_id: document.getElementById('subcategoriaCategoria').value,
+    nombre: document.getElementById('subcategoriaNombre').value,
+    descripcion: document.getElementById('subcategoriaDesc').value
+  };
+  if (id) await fetchAPI(`${API.subcategorias}?id=${id}`, 'PUT', data);
+  else await fetchAPI(API.subcategorias, 'POST', data);
+  subcategoriaForm.reset();
+  await cargarSubcategorias();
+});
+
+productoForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const id = document.getElementById('productoId').value;
+  const data = {
+    nombre: document.getElementById('productoNombre').value,
+    descripcion: document.getElementById('productoDesc').value,
+    categoria_id: document.getElementById('productoCategoria').value,
+    subcategoria_id: document.getElementById('productoSubcategoria').value,
+    stock: parseInt(document.getElementById('productoStock').value || '0'),
+    precio_compra: parseFloat(document.getElementById('productoPrecio').value || '0')
+  };
+  if (id) await fetchAPI(`${API.productos}?id=${id}`, 'PUT', data);
+  else await fetchAPI(API.productos, 'POST', data);
+  productoForm.reset();
+  await cargarProductos();
+});
+
+function editarCategoria(item) {
+  document.getElementById('categoriaId').value = item.id;
+  document.getElementById('categoriaNombre').value = item.nombre;
+  document.getElementById('categoriaDesc').value = item.descripcion || '';
+}
+
+function editarSubcategoria(item) {
+  document.getElementById('subcategoriaId').value = item.id;
+  document.getElementById('subcategoriaCategoria').value = item.categoria_id || '';
+  document.getElementById('subcategoriaNombre').value = item.nombre;
+  document.getElementById('subcategoriaDesc').value = item.descripcion || '';
+}
+
+function editarProducto(item) {
+  document.getElementById('productoId').value = item.id;
+  document.getElementById('productoNombre').value = item.nombre;
+  document.getElementById('productoDesc').value = item.descripcion || '';
+  document.getElementById('productoCategoria').value = item.categoria_id || '';
+  document.getElementById('productoSubcategoria').value = item.subcategoria_id || '';
+  document.getElementById('productoStock').value = item.stock;
+  document.getElementById('productoPrecio').value = item.precio_compra;
+}
+
+// Inicializar
+(async function(){
+  await cargarCategorias();
+  await cargarSubcategorias();
+  await cargarProductos();
+})();

--- a/scripts/php/guardar_categorias.php
+++ b/scripts/php/guardar_categorias.php
@@ -1,0 +1,81 @@
+<?php
+header('Content-Type: application/json');
+$servername = "localhost";
+$db_user    = "u296155119_Admin";
+$db_pass    = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+$conn = new mysqli($servername, $db_user, $db_pass, $database);
+if ($conn->connect_error) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Error de conexión']);
+    exit;
+}
+
+$method = $_SERVER['REQUEST_METHOD'];
+
+function getJsonInput() {
+    $input = file_get_contents('php://input');
+    $data = json_decode($input, true);
+    return $data ?: [];
+}
+
+if ($method === 'GET') {
+    $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    if ($id) {
+        $stmt = $conn->prepare('SELECT * FROM categorias WHERE id = ?');
+        $stmt->bind_param('i', $id);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        echo json_encode($res->fetch_assoc() ?: []);
+    } else {
+        $result = $conn->query('SELECT * FROM categorias');
+        $items = [];
+        while ($row = $result->fetch_assoc()) {
+            $items[] = $row;
+        }
+        echo json_encode($items);
+    }
+    exit;
+}
+
+if ($method === 'POST') {
+    $data = getJsonInput();
+    $nombre = $data['nombre'] ?? '';
+    $descripcion = $data['descripcion'] ?? '';
+    if (!$nombre) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Nombre requerido']);
+        exit;
+    }
+    $stmt = $conn->prepare('INSERT INTO categorias (nombre, descripcion) VALUES (?, ?)');
+    $stmt->bind_param('ss', $nombre, $descripcion);
+    $stmt->execute();
+    echo json_encode(['id' => $stmt->insert_id]);
+    exit;
+}
+
+if ($method === 'PUT') {
+    $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    $data = getJsonInput();
+    $nombre = $data['nombre'] ?? '';
+    $descripcion = $data['descripcion'] ?? '';
+    $stmt = $conn->prepare('UPDATE categorias SET nombre=?, descripcion=? WHERE id=?');
+    $stmt->bind_param('ssi', $nombre, $descripcion, $id);
+    $stmt->execute();
+    echo json_encode(['success' => $stmt->affected_rows > 0]);
+    exit;
+}
+
+if ($method === 'DELETE') {
+    $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    $stmt = $conn->prepare('DELETE FROM categorias WHERE id=?');
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    echo json_encode(['success' => true]);
+    exit;
+}
+
+http_response_code(405);
+echo json_encode(['error' => 'Método no permitido']);
+?>

--- a/scripts/php/guardar_productos.php
+++ b/scripts/php/guardar_productos.php
@@ -1,0 +1,89 @@
+<?php
+header('Content-Type: application/json');
+$servername = "localhost";
+$db_user    = "u296155119_Admin";
+$db_pass    = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+$conn = new mysqli($servername, $db_user, $db_pass, $database);
+if ($conn->connect_error) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Error de conexión']);
+    exit;
+}
+
+$method = $_SERVER['REQUEST_METHOD'];
+
+function getJsonInput() {
+    $input = file_get_contents('php://input');
+    $data = json_decode($input, true);
+    return $data ?: [];
+}
+
+if ($method === 'GET') {
+    $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    if ($id) {
+        $stmt = $conn->prepare('SELECT * FROM productos WHERE id = ?');
+        $stmt->bind_param('i', $id);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        echo json_encode($res->fetch_assoc() ?: []);
+    } else {
+        $result = $conn->query('SELECT * FROM productos');
+        $items = [];
+        while ($row = $result->fetch_assoc()) {
+            $items[] = $row;
+        }
+        echo json_encode($items);
+    }
+    exit;
+}
+
+if ($method === 'POST') {
+    $data = getJsonInput();
+    $nombre = $data['nombre'] ?? '';
+    $descripcion = $data['descripcion'] ?? '';
+    $categoria_id = isset($data['categoria_id']) ? intval($data['categoria_id']) : null;
+    $subcategoria_id = isset($data['subcategoria_id']) ? intval($data['subcategoria_id']) : null;
+    $stock = intval($data['stock'] ?? 0);
+    $precio = floatval($data['precio_compra'] ?? 0);
+    if (!$nombre) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Nombre requerido']);
+        exit;
+    }
+    $stmt = $conn->prepare('INSERT INTO productos (nombre, descripcion, categoria_id, subcategoria_id, stock, precio_compra) VALUES (?, ?, ?, ?, ?, ?)');
+    $stmt->bind_param('ssiiid', $nombre, $descripcion, $categoria_id, $subcategoria_id, $stock, $precio);
+    $stmt->execute();
+    echo json_encode(['id' => $stmt->insert_id]);
+    exit;
+}
+
+if ($method === 'PUT') {
+    $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    $data = getJsonInput();
+    $nombre = $data['nombre'] ?? '';
+    $descripcion = $data['descripcion'] ?? '';
+    $categoria_id = isset($data['categoria_id']) ? intval($data['categoria_id']) : null;
+    $subcategoria_id = isset($data['subcategoria_id']) ? intval($data['subcategoria_id']) : null;
+    $stock = intval($data['stock'] ?? 0);
+    $precio = floatval($data['precio_compra'] ?? 0);
+    $stmt = $conn->prepare('UPDATE productos SET nombre=?, descripcion=?, categoria_id=?, subcategoria_id=?, stock=?, precio_compra=? WHERE id=?');
+    $stmt->bind_param('ssiiidi', $nombre, $descripcion, $categoria_id, $subcategoria_id, $stock, $precio, $id);
+    $stmt->execute();
+    echo json_encode(['success' => $stmt->affected_rows > 0]);
+    exit;
+}
+
+if ($method === 'DELETE') {
+    $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    $stmt = $conn->prepare('DELETE FROM productos WHERE id=?');
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    echo json_encode(['success' => true]);
+    exit;
+}
+
+http_response_code(405);
+echo json_encode(['error' => 'Método no permitido']);
+?>

--- a/scripts/php/guardar_subcategorias.php
+++ b/scripts/php/guardar_subcategorias.php
@@ -1,0 +1,83 @@
+<?php
+header('Content-Type: application/json');
+$servername = "localhost";
+$db_user    = "u296155119_Admin";
+$db_pass    = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+$conn = new mysqli($servername, $db_user, $db_pass, $database);
+if ($conn->connect_error) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Error de conexión']);
+    exit;
+}
+
+$method = $_SERVER['REQUEST_METHOD'];
+
+function getJsonInput() {
+    $input = file_get_contents('php://input');
+    $data = json_decode($input, true);
+    return $data ?: [];
+}
+
+if ($method === 'GET') {
+    $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    if ($id) {
+        $stmt = $conn->prepare('SELECT * FROM subcategorias WHERE id = ?');
+        $stmt->bind_param('i', $id);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        echo json_encode($res->fetch_assoc() ?: []);
+    } else {
+        $result = $conn->query('SELECT * FROM subcategorias');
+        $items = [];
+        while ($row = $result->fetch_assoc()) {
+            $items[] = $row;
+        }
+        echo json_encode($items);
+    }
+    exit;
+}
+
+if ($method === 'POST') {
+    $data = getJsonInput();
+    $categoria_id = isset($data['categoria_id']) ? intval($data['categoria_id']) : null;
+    $nombre = $data['nombre'] ?? '';
+    $descripcion = $data['descripcion'] ?? '';
+    if (!$nombre) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Nombre requerido']);
+        exit;
+    }
+    $stmt = $conn->prepare('INSERT INTO subcategorias (categoria_id, nombre, descripcion) VALUES (?, ?, ?)');
+    $stmt->bind_param('iss', $categoria_id, $nombre, $descripcion);
+    $stmt->execute();
+    echo json_encode(['id' => $stmt->insert_id]);
+    exit;
+}
+
+if ($method === 'PUT') {
+    $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    $data = getJsonInput();
+    $categoria_id = isset($data['categoria_id']) ? intval($data['categoria_id']) : null;
+    $nombre = $data['nombre'] ?? '';
+    $descripcion = $data['descripcion'] ?? '';
+    $stmt = $conn->prepare('UPDATE subcategorias SET categoria_id=?, nombre=?, descripcion=? WHERE id=?');
+    $stmt->bind_param('issi', $categoria_id, $nombre, $descripcion, $id);
+    $stmt->execute();
+    echo json_encode(['success' => $stmt->affected_rows > 0]);
+    exit;
+}
+
+if ($method === 'DELETE') {
+    $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    $stmt = $conn->prepare('DELETE FROM subcategorias WHERE id=?');
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    echo json_encode(['success' => true]);
+    exit;
+}
+
+http_response_code(405);
+echo json_encode(['error' => 'Método no permitido']);
+?>

--- a/styles/gest_inve/inventario.css
+++ b/styles/gest_inve/inventario.css
@@ -1,0 +1,5 @@
+.inventory-wrapper { padding: 1rem; }
+section { margin-bottom: 2rem; }
+form input, form textarea, form select { display:block; margin-bottom:0.5rem; }
+ul { list-style: none; padding-left: 0; }
+li { cursor: pointer; padding: 0.25rem 0; }


### PR DESCRIPTION
## Summary
- create tables for categories, subcategories and products
- add PHP endpoints for CRUD operations of categories, subcategories and products
- add inventory management page with forms and lists
- add JS logic to handle basic inventory actions
- include minimal CSS styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68814e78c2b4832c811334ac51bff3a9