### PR TITLE
Fix areas/zones module reload

### DIFF
--- a/pages/area_almac/areas_zonas.html
+++ b/pages/area_almac/areas_zonas.html
@@ -110,6 +110,7 @@
           <option value="piso">Piso</option>
           <option value="refrigeracion">Refrigeración</option>
         </select>
+
         <button type="submit" class="btn btn-primary">Guardar Zona</button>
 
     </div>

--- a/scripts/area_almac/areas_zonas.js
+++ b/scripts/area_almac/areas_zonas.js
@@ -1,3 +1,4 @@
+(() => {
 // Configuración de la API
 // Detectar la ruta base para que el módulo funcione si la aplicación
 // se aloja en la raíz o en un subdirectorio
@@ -467,5 +468,5 @@ if (document.readyState === 'loading') {
   initAreasZonas();
 }
 
-});
+})();
 


### PR DESCRIPTION
## Summary
- scope variables to avoid global redefinition errors
- restore previous layout markup

## Testing
- `node -c scripts/area_almac/areas_zonas.js`


------
https://chatgpt.com/codex/tasks/task_e_688699857608832cb189e91296900001