### PR TITLE
Improve tutorial display logic

### DIFF
--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -87,11 +87,12 @@ const skipTutorial = document.getElementById('skipTutorial');
 const closeTutorial = document.getElementById('closeTutorial');
 let tutorialHole = null;
 
-// Show tutorial on first visit
+// Show tutorial only the first time each user logs in
 function checkFirstVisit() {
-    if (!localStorage.getItem('optistock_visited')) {
+    const userId = localStorage.getItem('usuario_id');
+    if (!userId) return;
+    if (!localStorage.getItem(`tutorialShown_${userId}`)) {
         startTutorial();
-        localStorage.setItem('optistock_visited', 'true');
     }
 }
 
@@ -193,6 +194,10 @@ function endTutorial() {
         tutorialHole.remove();
         tutorialHole = null;
     }
+    const userId = localStorage.getItem('usuario_id');
+    if (userId) {
+        localStorage.setItem(`tutorialShown_${userId}`, 'true');
+    }
 }
 
 // Event Listeners
@@ -205,6 +210,19 @@ closeTutorial.addEventListener('click', endTutorial);
 
 // Check for first visit when page loads
 window.addEventListener('DOMContentLoaded', checkFirstVisit);
+
+// Reposition tutorial elements when the viewport changes
+window.addEventListener('resize', () => {
+    if (tutorialOverlayBg.style.display === 'block') {
+        showTutorialStep(currentStep);
+    }
+});
+
+window.addEventListener('scroll', () => {
+    if (tutorialOverlayBg.style.display === 'block') {
+        showTutorialStep(currentStep);
+    }
+}, true);
 
 // Menu item click handler
 const menuItems = document.querySelectorAll('.sidebar-menu a');

--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -815,4 +815,10 @@ body {
   .topbar-title {
     font-size: 1rem;
   }
+
+  .tutorial-card {
+    width: 95%;
+    max-width: none;
+    padding: 20px;
+  }
 }


### PR DESCRIPTION
## Summary
- display onboarding tutorial per user account
- mark tutorial as completed at the end
- reposition tutorial hints on resize or scroll
- adapt tutorial card to small screens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68869f07d3a4832c86af0a914cf16e30