### PR TITLE
Revert areas/zones layout update

### DIFF
--- a/scripts/area_almac/areas_zonas.js
+++ b/scripts/area_almac/areas_zonas.js
@@ -467,5 +467,3 @@ if (document.readyState === 'loading') {
   initAreasZonas();
 }
 
-});
-


### PR DESCRIPTION
## Summary
- revert "Applying previous commit" to bring back the original areas and zones design
- remove stray bracket to fix `areas_zonas.js` syntax

## Testing
- `node -c scripts/area_almac/areas_zonas.js`


------
https://chatgpt.com/codex/tasks/task_e_688699857608832cb189e91296900001