### PR TITLE
Enable mysqli error reporting

### DIFF
--- a/scripts/php/get_account_data.php
+++ b/scripts/php/get_account_data.php
@@ -1,13 +1,17 @@
 <?php
 header('Content-Type: application/json');
 
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
 $servername = "localhost";
 $db_user    = "u296155119_Admin";
 $db_pass    = "4Dmin123o";
 $database   = "u296155119_OptiStock";
 
-$conn = mysqli_connect($servername, $db_user, $db_pass, $database);
-if (!$conn) {
+try {
+    $conn = new mysqli($servername, $db_user, $db_pass, $database);
+    $conn->set_charset('utf8mb4');
+} catch (mysqli_sql_exception $e) {
     echo json_encode(["success" => false, "message" => "Error de conexión"]);
     exit;
 }

--- a/scripts/php/get_logs.php
+++ b/scripts/php/get_logs.php
@@ -1,12 +1,17 @@
 <?php
 header("Content-Type: application/json");
 
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
 $servername = "localhost";
 $db_user    = "u296155119_Admin";
 $db_pass    = "4Dmin123o";
 $database   = "u296155119_OptiStock";
-$conn = mysqli_connect($servername, $db_user, $db_pass, $database);
-if (!$conn) {
+
+try {
+    $conn = new mysqli($servername, $db_user, $db_pass, $database);
+    $conn->set_charset('utf8mb4');
+} catch (mysqli_sql_exception $e) {
     echo json_encode(["success" => false, "message" => "DB fail"]);
     exit;
 }
@@ -53,4 +58,3 @@ while ($row = $result->fetch_assoc()) {
 
 echo json_encode(["success" => true, "logs" => $logs]);
 $conn->close();
-?>

--- a/scripts/php/guardar_areas.php
+++ b/scripts/php/guardar_areas.php
@@ -1,12 +1,17 @@
 <?php
 header('Content-Type: application/json');
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
 $servername = "localhost";
 $db_user    = "u296155119_Admin";
 $db_pass    = "4Dmin123o";
 $database   = "u296155119_OptiStock";
 
-$conn = new mysqli($servername, $db_user, $db_pass, $database);
-if ($conn->connect_error) {
+try {
+    $conn = new mysqli($servername, $db_user, $db_pass, $database);
+    $conn->set_charset('utf8mb4');
+} catch (mysqli_sql_exception $e) {
     http_response_code(500);
     echo json_encode(['error' => 'Error de conexión']);
     exit;
@@ -55,8 +60,8 @@ if ($method === 'POST') {
     $alto = floatval($data['alto'] ?? 0);
     $largo = floatval($data['largo'] ?? 0);
     $volumen = $ancho * $alto * $largo;
-    $empresa_id = intval($data['empresa_id'] ?? 0);
-    if (!$nombre || !$empresa_id) {
+    $empresa_id = isset($data['empresa_id']) ? intval($data['empresa_id']) : 0;
+    if (!$nombre || $empresa_id <= 0) {
         http_response_code(400);
         echo json_encode(['error' => 'Datos incompletos']);
         exit;

--- a/scripts/php/guardar_zonas.php
+++ b/scripts/php/guardar_zonas.php
@@ -1,12 +1,17 @@
 <?php
 header('Content-Type: application/json');
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
 $servername = "localhost";
 $db_user    = "u296155119_Admin";
 $db_pass    = "4Dmin123o";
 $database   = "u296155119_OptiStock";
 
-$conn = new mysqli($servername, $db_user, $db_pass, $database);
-if ($conn->connect_error) {
+try {
+    $conn = new mysqli($servername, $db_user, $db_pass, $database);
+    $conn->set_charset('utf8mb4');
+} catch (mysqli_sql_exception $e) {
     http_response_code(500);
     echo json_encode(['error' => 'Error de conexión']);
     exit;
@@ -65,9 +70,9 @@ if ($method === 'POST') {
     $tipo = $data['tipo_almacenamiento'] ?? null;
     $subniveles = isset($data['subniveles']) ? json_encode($data['subniveles']) : null;
     $area_id = isset($data['area_id']) ? intval($data['area_id']) : null;
-    $empresa_id = intval($data['empresa_id'] ?? 0);
+    $empresa_id = isset($data['empresa_id']) ? intval($data['empresa_id']) : 0;
 
-    if (!$nombre || !$empresa_id) {
+    if (!$nombre || $empresa_id <= 0) {
         http_response_code(400);
         echo json_encode(['error' => 'Datos incompletos']);
         exit;

--- a/scripts/php/obtener_areas_zonas.php
+++ b/scripts/php/obtener_areas_zonas.php
@@ -1,13 +1,17 @@
 <?php
 header("Content-Type: application/json");
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 // Conexión a la base de datos (se usan las mismas credenciales que en otros scripts)
 $servername = "localhost";
 $db_user    = "u296155119_Admin";
 $db_pass    = "4Dmin123o";
 $database   = "u296155119_OptiStock";
 
-$conn = mysqli_connect($servername, $db_user, $db_pass, $database);
-if (!$conn) {
+try {
+    $conn = new mysqli($servername, $db_user, $db_pass, $database);
+    $conn->set_charset('utf8mb4');
+} catch (mysqli_sql_exception $e) {
     echo json_encode(["success" => false, "message" => "Error de conexión"]);
     exit;
 }

--- a/scripts/php/obtener_usuarios_empresa.php
+++ b/scripts/php/obtener_usuarios_empresa.php
@@ -1,12 +1,17 @@
 <?php
 header("Content-Type: application/json");
 
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
 $servername = "localhost";
 $db_user    = "u296155119_Admin";
 $db_pass    = "4Dmin123o";
 $database   = "u296155119_OptiStock";
-$conn = mysqli_connect($servername, $db_user, $db_pass, $database);
-if (!$conn) {
+
+try {
+    $conn = new mysqli($servername, $db_user, $db_pass, $database);
+    $conn->set_charset('utf8mb4');
+} catch (mysqli_sql_exception $e) {
     echo json_encode(["success" => false, "message" => "DB fail"]);
     exit;
 }


### PR DESCRIPTION
## Summary
- enable strict MySQLi error reporting on PHP endpoints
- validate `empresa_id` before inserting

## Testing
- `php -l scripts/php/guardar_zonas.php`
- `php -l scripts/php/guardar_areas.php`
- `php -l scripts/php/obtener_areas_zonas.php`
- `php -l scripts/php/obtener_usuarios_empresa.php`
- `php -l scripts/php/get_account_data.php`
- `php -l scripts/php/get_logs.php`


------
https://chatgpt.com/codex/tasks/task_e_6888162da764832c91e251d0f426ed0a