### PR TITLE
Remove debug output from account page

### DIFF
--- a/scripts/account_suscrip/account_suscrip.js
+++ b/scripts/account_suscrip/account_suscrip.js
@@ -1,17 +1,11 @@
-console.log('Script cargado'); 
-
 document.addEventListener('DOMContentLoaded', () => {
   // Obtener datos de localStorage
-  console.log('DOM listo');
   const el = document.getElementById('nombreCompleto');
   if (el) {
     el.textContent = 'Prueba de carga JS correcta';
-    console.log('Elemento nombreCompleto actualizado');
   } else {
     console.error('Elemento nombreCompleto NO encontrado');
   }
-
-  alert('JS ejecutado');
   
   const usuarioId = localStorage.getItem('usuario_id');
   const usuarioEmail = localStorage.getItem('usuario_email');


### PR DESCRIPTION
## Summary
- clean up initial debug statements in account_suscrip.js

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688819db7284832c8f2acc90fafb4f64