### PR TITLE
Implement subscription management features

### DIFF
--- a/pages/account_suscrip/account_suscrip.html
+++ b/pages/account_suscrip/account_suscrip.html
@@ -58,6 +58,39 @@
     </div>
   </div>
 
+  <!-- Comparativa de planes -->
+  <div class="card mb-4">
+    <div class="card-header">Beneficios por plan</div>
+    <div class="card-body">
+      <table class="table table-bordered" id="tablaPlanes">
+        <thead>
+          <tr>
+            <th>Característica</th>
+            <th>Gratis</th>
+            <th>Pro</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Usuarios incluidos</td>
+            <td>1</td>
+            <td>10</td>
+          </tr>
+          <tr>
+            <td>Soporte</td>
+            <td>Correo</td>
+            <td>Prioritario</td>
+          </tr>
+          <tr>
+            <td>Reportes</td>
+            <td>Básicos</td>
+            <td>Avanzados</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
   <!-- Modal editar usuario -->
   <div class="modal fade" id="modalEditarUsuario" tabindex="-1">
     <div class="modal-dialog">

--- a/scripts/account_suscrip/account_suscrip.js
+++ b/scripts/account_suscrip/account_suscrip.js
@@ -169,4 +169,57 @@ document.addEventListener('DOMContentLoaded', () => {
       console.error('Error al actualizar:', err);
     });
   });
+
+  // Cancelar suscripción con doble confirmación
+  const btnCancel = document.getElementById('btnCancelarSuscripcion');
+  if (btnCancel) {
+    btnCancel.addEventListener('click', () => {
+      if (confirm('¿Seguro que deseas cancelar la suscripción?') &&
+          confirm('Confirma nuevamente para cancelar')) {
+        const idEmpresa = localStorage.getItem('id_empresa');
+        const form = new URLSearchParams();
+        form.append('id_empresa', idEmpresa);
+        fetch('../../scripts/php/cancel_subscription.php', {
+          method: 'POST',
+          body: form
+        })
+          .then(res => res.json())
+          .then(data => {
+            if (data.success) {
+              alert('Suscripción cancelada');
+              location.reload();
+            } else {
+              alert(data.message || 'Error al cancelar');
+            }
+          });
+      }
+    });
+  }
+
+  // Actualizar plan de suscripción
+  const btnUpgrade = document.getElementById('btnActualizarPlan');
+  if (btnUpgrade) {
+    btnUpgrade.addEventListener('click', () => {
+      const nuevoPlan = prompt('Ingresa el nuevo plan (por ejemplo: Pro)');
+      if (nuevoPlan) {
+        const idEmpresa = localStorage.getItem('id_empresa');
+        const form = new URLSearchParams();
+        form.append('id_empresa', idEmpresa);
+        form.append('plan', nuevoPlan);
+        fetch('../../scripts/php/update_subscription_plan.php', {
+          method: 'POST',
+          body: form
+        })
+          .then(res => res.json())
+          .then(data => {
+            if (data.success) {
+              alert('Plan actualizado');
+              location.reload();
+            } else {
+              alert(data.message || 'Error al actualizar plan');
+            }
+          });
+      }
+    });
+  }
 });

--- a/scripts/php/cancel_subscription.php
+++ b/scripts/php/cancel_subscription.php
@@ -1,0 +1,36 @@
+<?php
+header('Content-Type: application/json');
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$servername = "localhost";
+$db_user    = "u296155119_Admin";
+$db_pass    = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+try {
+    $conn = new mysqli($servername, $db_user, $db_pass, $database);
+    $conn->set_charset('utf8mb4');
+} catch (mysqli_sql_exception $e) {
+    echo json_encode(["success" => false, "message" => "Error de conexión"]);
+    exit;
+}
+
+$id_empresa = $_POST['id_empresa'] ?? null;
+if (!$id_empresa) {
+    echo json_encode(['success' => false, 'message' => 'Falta id_empresa']);
+    exit;
+}
+
+try {
+    $stmt = $conn->prepare("UPDATE suscripciones SET activo = 0 WHERE id_empresa = ? AND activo = 1");
+    $stmt->bind_param("i", $id_empresa);
+    $stmt->execute();
+
+    if ($stmt->affected_rows > 0) {
+        echo json_encode(['success' => true]);
+    } else {
+        echo json_encode(['success' => false, 'message' => 'No se encontró suscripción activa']);
+    }
+} catch (Exception $e) {
+    echo json_encode(['success' => false, 'message' => 'Error: ' . $e->getMessage()]);
+}

--- a/scripts/php/update_subscription_plan.php
+++ b/scripts/php/update_subscription_plan.php
@@ -1,0 +1,38 @@
+<?php
+header('Content-Type: application/json');
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$servername = "localhost";
+$db_user    = "u296155119_Admin";
+$db_pass    = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+try {
+    $conn = new mysqli($servername, $db_user, $db_pass, $database);
+    $conn->set_charset('utf8mb4');
+} catch (mysqli_sql_exception $e) {
+    echo json_encode(["success" => false, "message" => "Error de conexión"]);
+    exit;
+}
+
+$id_empresa = $_POST['id_empresa'] ?? null;
+$plan       = $_POST['plan'] ?? null;
+
+if (!$id_empresa || !$plan) {
+    echo json_encode(['success' => false, 'message' => 'Datos incompletos']);
+    exit;
+}
+
+try {
+    $stmt = $conn->prepare("INSERT INTO suscripciones (id_empresa, plan, fecha_renovacion, activo) VALUES (?, ?, DATE_ADD(NOW(), INTERVAL 1 MONTH), 1)");
+    $stmt->bind_param("is", $id_empresa, $plan);
+    $stmt->execute();
+
+    if ($stmt->affected_rows > 0) {
+        echo json_encode(['success' => true]);
+    } else {
+        echo json_encode(['success' => false, 'message' => 'No se pudo actualizar']);
+    }
+} catch (Exception $e) {
+    echo json_encode(['success' => false, 'message' => 'Error: ' . $e->getMessage()]);
+}

--- a/styles/account_suscrip/account_suscrip.css
+++ b/styles/account_suscrip/account_suscrip.css
@@ -76,6 +76,11 @@ button {
   padding: 5px 10px;
 }
 
+#tablaPlanes th,
+#tablaPlanes td {
+  text-align: center;
+}
+
 @media (max-width: 768px) {
   section {
     padding: 15px;


### PR DESCRIPTION
## Summary
- build plan comparison table
- allow cancelling and upgrading subscription from the UI
- style subscription table
- add PHP endpoints to cancel or update a subscription

## Testing
- `npm install`
- `php -l scripts/php/cancel_subscription.php`
- `php -l scripts/php/update_subscription_plan.php`


------
https://chatgpt.com/codex/tasks/task_e_688823a9d988832ca2206ecf9938ffe7