### PR TITLE
Implement subscription management features

### DIFF
--- a/pages/account_suscrip/account_suscrip.html
+++ b/pages/account_suscrip/account_suscrip.html
@@ -1,60 +1,90 @@
 <div class="container py-4">
   <link rel="stylesheet" href="../../styles/account_suscrip/account_suscrip.css">
-  <h2 class="mb-3">Tu cuenta</h2>
-  <p class="text-muted">Gestiona tus datos personales, configuración empresarial y suscripción.</p>
+  <h2 class="mb-3">Configuración de cuenta</h2>
+  <div class="account-wrapper">
+    <nav class="account-menu">
+      <ul>
+        <li class="active" data-target="secUser">Perfil</li>
+        <li data-target="secEmpresa">Empresa</li>
+        <li data-target="secVisual">Diseño</li>
+        <li data-target="secSuscripcion">Suscripción</li>
+        <li data-target="secPlanes">Planes</li>
+      </ul>
+    </nav>
 
-  <!-- Información de usuario -->
-  <div class="card mb-4">
-    <div class="card-header d-flex justify-content-between align-items-center">
-      <span>Información personal</span>
-      <button class="btn btn-outline-primary btn-sm" id="btnEditarUsuario">Editar</button>
-    </div>
-    <div class="card-body" id="usuarioInfo">
-      <div class="row">
-        <div class="col-md-3 text-center">
-          <img id="fotoPerfil" class="img-thumbnail rounded-circle mb-2" width="120" height="120">
+    <div class="account-content">
+      <section id="secUser" class="account-section active">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+          <span class="fw-bold">Información personal</span>
+          <button class="btn btn-outline-primary btn-sm" id="btnEditarUsuario">Editar</button>
         </div>
-        <div class="col-md-9">
-          <p><strong>Nombre:</strong> <span id="nombreCompleto"></span></p>
-          <p><strong>Correo:</strong> <span id="correoUsuario"></span></p>
-          <p><strong>Teléfono:</strong> <span id="telefonoUsuario"></span></p>
+        <div class="row">
+          <div class="col-md-3 text-center">
+            <img id="fotoPerfil" class="img-thumbnail rounded-circle mb-2" width="120" height="120">
+          </div>
+          <div class="col-md-9">
+            <p><strong>Nombre:</strong> <span id="nombreCompleto"></span></p>
+            <p><strong>Correo:</strong> <span id="correoUsuario"></span></p>
+            <p><strong>Teléfono:</strong> <span id="telefonoUsuario"></span></p>
+          </div>
         </div>
-      </div>
-    </div>
-  </div>
+      </section>
 
-  <!-- Información empresarial -->
-  <div class="card mb-4">
-    <div class="card-header d-flex justify-content-between align-items-center">
-      <span>Información empresarial</span>
-      <button class="btn btn-outline-primary btn-sm" id="btnEditarEmpresa">Editar</button>
-    </div>
-    <div class="card-body" id="empresaInfo">
-      <p><strong>Nombre de empresa:</strong> <span id="nombreEmpresa"></span></p>
-      <p><strong>Sector:</strong> <span id="sectorEmpresa"></span></p>
-      <p><strong>Logo:</strong><br> <img id="logoEmpresa" height="60"></p>
-    </div>
-  </div>
+      <section id="secEmpresa" class="account-section">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+          <span class="fw-bold">Información empresarial</span>
+          <button class="btn btn-outline-primary btn-sm" id="btnEditarEmpresa">Editar</button>
+        </div>
+        <p><strong>Nombre de empresa:</strong> <span id="nombreEmpresa"></span></p>
+        <p><strong>Sector:</strong> <span id="sectorEmpresa"></span></p>
+        <p><strong>Logo:</strong><br> <img id="logoEmpresa" height="60"></p>
+      </section>
 
-  <!-- Personalización visual -->
-  <div class="card mb-4">
-    <div class="card-header">Personalización visual</div>
-    <div class="card-body">
-      <label>Color Sidebar: <input type="color" id="colorSidebar" disabled></label>
-      <label class="ms-3">Color Topbar: <input type="color" id="colorTopbar" disabled></label>
-      <button class="btn btn-sm btn-primary ms-3" id="btnGuardarColores">Guardar</button>
-    </div>
-  </div>
+      <section id="secVisual" class="account-section">
+        <span class="fw-bold d-block mb-2">Personalización visual</span>
+        <label>Color Sidebar: <input type="color" id="colorSidebar" disabled></label>
+        <label class="ms-3">Color Topbar: <input type="color" id="colorTopbar" disabled></label>
+        <button class="btn btn-sm btn-primary ms-3" id="btnGuardarColores">Guardar</button>
+      </section>
 
-  <!-- Información de suscripción -->
-  <div class="card mb-4">
-    <div class="card-header">Suscripción actual</div>
-    <div class="card-body">
-      <p><strong>Plan:</strong> <span id="planActual">Gratuito</span></p>
-      <p><strong>Renovación:</strong> <span id="fechaRenovacion">-</span></p>
-      <p><strong>Método de pago:</strong> <span id="metodoPago">-</span></p>
-      <button class="btn btn-outline-success btn-sm" id="btnActualizarPlan">Actualizar plan</button>
-      <button class="btn btn-outline-danger btn-sm" id="btnCancelarSuscripcion">Cancelar suscripción</button>
+      <section id="secSuscripcion" class="account-section">
+        <span class="fw-bold d-block mb-2">Suscripción actual</span>
+        <p><strong>Plan:</strong> <span id="planActual">Gratuito</span></p>
+        <p><strong>Renovación:</strong> <span id="fechaRenovacion">-</span></p>
+        <p><strong>Método de pago:</strong> <span id="metodoPago">-</span></p>
+        <button class="btn btn-outline-success btn-sm" id="btnActualizarPlan">Actualizar plan</button>
+        <button class="btn btn-outline-danger btn-sm" id="btnCancelarSuscripcion">Cancelar suscripción</button>
+      </section>
+
+      <section id="secPlanes" class="account-section">
+        <span class="fw-bold d-block mb-2">Beneficios por plan</span>
+        <table class="table table-bordered" id="tablaPlanes">
+          <thead>
+            <tr>
+              <th>Característica</th>
+              <th>Gratis</th>
+              <th>Pro</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Usuarios incluidos</td>
+              <td>1</td>
+              <td>10</td>
+            </tr>
+            <tr>
+              <td>Soporte</td>
+              <td>Correo</td>
+              <td>Prioritario</td>
+            </tr>
+            <tr>
+              <td>Reportes</td>
+              <td>Básicos</td>
+              <td>Avanzados</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
     </div>
   </div>
 
@@ -102,7 +132,5 @@
       </div>
     </div>
   </div>
-
 </div>
-
 <script src="../../scripts/account_suscrip/account_suscrip.js"></script>

--- a/scripts/account_suscrip/account_suscrip.js
+++ b/scripts/account_suscrip/account_suscrip.js
@@ -14,7 +14,6 @@ async function loadAccountData(id) {
   }
 }
 
-document.addEventListener('DOMContentLoaded', async () => {
 
 document.addEventListener('DOMContentLoaded', () => {
 
@@ -169,4 +168,75 @@ document.addEventListener('DOMContentLoaded', () => {
       console.error('Error al actualizar:', err);
     });
   });
-});
+
+  // Cancelar suscripción con doble confirmación
+  const btnCancel = document.getElementById('btnCancelarSuscripcion');
+  if (btnCancel) {
+    btnCancel.addEventListener('click', () => {
+      if (confirm('¿Seguro que deseas cancelar la suscripción?') &&
+          confirm('Confirma nuevamente para cancelar')) {
+        const idEmpresa = localStorage.getItem('id_empresa');
+        const form = new URLSearchParams();
+        form.append('id_empresa', idEmpresa);
+        fetch('../../scripts/php/cancel_subscription.php', {
+          method: 'POST',
+          body: form
+        })
+          .then(res => res.json())
+          .then(data => {
+            if (data.success) {
+              alert('Suscripción cancelada');
+              location.reload();
+            } else {
+              alert(data.message || 'Error al cancelar');
+            }
+          });
+      }
+    });
+  }
+
+  // Actualizar plan de suscripción
+  const btnUpgrade = document.getElementById('btnActualizarPlan');
+  if (btnUpgrade) {
+    btnUpgrade.addEventListener('click', () => {
+      const nuevoPlan = prompt('Ingresa el nuevo plan (por ejemplo: Pro)');
+      if (nuevoPlan) {
+        const idEmpresa = localStorage.getItem('id_empresa');
+        const form = new URLSearchParams();
+        form.append('id_empresa', idEmpresa);
+        form.append('plan', nuevoPlan);
+        fetch('../../scripts/php/update_subscription_plan.php', {
+          method: 'POST',
+          body: form
+        })
+          .then(res => res.json())
+          .then(data => {
+            if (data.success) {
+              alert('Plan actualizado');
+              location.reload();
+            } else {
+              alert(data.message || 'Error al actualizar plan');
+            }
+          });
+      }
+    });
+  }
+  // Navegación de secciones
+  const menuItems = document.querySelectorAll(".account-menu li");
+  const sections = document.querySelectorAll(".account-section");
+  menuItems.forEach(item => {
+    item.addEventListener("click", () => {
+      menuItems.forEach(i => i.classList.remove("active"));
+      item.classList.add("active");
+      const target = item.getAttribute("data-target");
+      sections.forEach(sec => {
+        if (sec.id === target) {
+          sec.classList.add("active");
+        } else {
+          sec.classList.remove("active");
+        }
+      });
+    });
+  });
+}); // cierre DOMContentLoaded
+

--- a/scripts/php/cancel_subscription.php
+++ b/scripts/php/cancel_subscription.php
@@ -1,0 +1,36 @@
+<?php
+header('Content-Type: application/json');
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$servername = "localhost";
+$db_user    = "u296155119_Admin";
+$db_pass    = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+try {
+    $conn = new mysqli($servername, $db_user, $db_pass, $database);
+    $conn->set_charset('utf8mb4');
+} catch (mysqli_sql_exception $e) {
+    echo json_encode(["success" => false, "message" => "Error de conexión"]);
+    exit;
+}
+
+$id_empresa = $_POST['id_empresa'] ?? null;
+if (!$id_empresa) {
+    echo json_encode(['success' => false, 'message' => 'Falta id_empresa']);
+    exit;
+}
+
+try {
+    $stmt = $conn->prepare("UPDATE suscripciones SET activo = 0 WHERE id_empresa = ? AND activo = 1");
+    $stmt->bind_param("i", $id_empresa);
+    $stmt->execute();
+
+    if ($stmt->affected_rows > 0) {
+        echo json_encode(['success' => true]);
+    } else {
+        echo json_encode(['success' => false, 'message' => 'No se encontró suscripción activa']);
+    }
+} catch (Exception $e) {
+    echo json_encode(['success' => false, 'message' => 'Error: ' . $e->getMessage()]);
+}

--- a/scripts/php/update_subscription_plan.php
+++ b/scripts/php/update_subscription_plan.php
@@ -1,0 +1,38 @@
+<?php
+header('Content-Type: application/json');
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$servername = "localhost";
+$db_user    = "u296155119_Admin";
+$db_pass    = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+try {
+    $conn = new mysqli($servername, $db_user, $db_pass, $database);
+    $conn->set_charset('utf8mb4');
+} catch (mysqli_sql_exception $e) {
+    echo json_encode(["success" => false, "message" => "Error de conexión"]);
+    exit;
+}
+
+$id_empresa = $_POST['id_empresa'] ?? null;
+$plan       = $_POST['plan'] ?? null;
+
+if (!$id_empresa || !$plan) {
+    echo json_encode(['success' => false, 'message' => 'Datos incompletos']);
+    exit;
+}
+
+try {
+    $stmt = $conn->prepare("INSERT INTO suscripciones (id_empresa, plan, fecha_renovacion, activo) VALUES (?, ?, DATE_ADD(NOW(), INTERVAL 1 MONTH), 1)");
+    $stmt->bind_param("is", $id_empresa, $plan);
+    $stmt->execute();
+
+    if ($stmt->affected_rows > 0) {
+        echo json_encode(['success' => true]);
+    } else {
+        echo json_encode(['success' => false, 'message' => 'No se pudo actualizar']);
+    }
+} catch (Exception $e) {
+    echo json_encode(['success' => false, 'message' => 'Error: ' . $e->getMessage()]);
+}

--- a/styles/account_suscrip/account_suscrip.css
+++ b/styles/account_suscrip/account_suscrip.css
@@ -1,88 +1,70 @@
 body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background-color: #f8f9fa;
+  background-color: #eef1f7;
   color: #333;
 }
 
-h2 {
-  font-size: 1.8rem;
-  margin-bottom: 10px;
-  font-weight: bold;
+.account-wrapper {
+  display: flex;
+  gap: 20px;
+  margin-top: 20px;
 }
 
-p {
-  color: #666;
-  margin-bottom: 30px;
-}
-
-section {
-  background: #fff;
+.account-menu {
+  width: 200px;
+  background: linear-gradient(45deg, #6a11cb, #2575fc);
   border-radius: 8px;
   padding: 20px;
-  margin-bottom: 30px;
-  box-shadow: 0 0 8px rgba(0,0,0,0.05);
+  color: #fff;
 }
 
-.profile-img {
-  width: 80px;
-  height: 80px;
-  object-fit: cover;
-  border-radius: 50%;
-  border: 2px solid #ddd;
-  margin-bottom: 15px;
+.account-menu ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
 }
 
-#editUserBtn,
-button {
-  border-radius: 6px;
-  padding: 6px 12px;
-  font-size: 0.9rem;
+.account-menu li {
+  padding: 10px 15px;
+  margin-bottom: 5px;
+  cursor: pointer;
+  border-radius: 4px;
 }
 
-#editUserBtn {
-  float: right;
+.account-menu li.active,
+.account-menu li:hover {
+  background: rgba(255, 255, 255, 0.2);
 }
 
-.form-label {
-  font-weight: bold;
-  margin-top: 10px;
+.account-content {
+  flex-grow: 1;
 }
 
-.modal-footer button {
-  min-width: 120px;
+.account-section {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  padding: 20px;
+  margin-bottom: 20px;
+  display: none;
 }
 
-.color-selector {
-  display: flex;
-  align-items: center;
-  gap: 10px;
+.account-section.active {
+  display: block;
 }
 
-.subscription-info {
-  margin-top: 10px;
-}
-
-.subscription-info p {
-  margin: 2px 0;
-}
-
-.btn-danger {
-  background-color: #dc3545;
-  border-color: #dc3545;
-}
-
-.btn-outline-primary {
-  border-radius: 5px;
-  padding: 5px 10px;
+#tablaPlanes th,
+#tablaPlanes td {
+  text-align: center;
 }
 
 @media (max-width: 768px) {
-  section {
-    padding: 15px;
+  .account-wrapper {
+    flex-direction: column;
   }
 
-  .profile-img {
-    width: 60px;
-    height: 60px;
+  .account-menu {
+    width: 100%;
+    margin-bottom: 20px;
   }
 }


### PR DESCRIPTION
## Summary
- build plan comparison table
- allow cancelling and upgrading subscription from the UI
- style subscription table
- add PHP endpoints to cancel or update a subscription
- redesign account page with a sidebar navigation

## Testing
- `npm install`
- `php -l scripts/php/cancel_subscription.php`
- `php -l scripts/php/update_subscription_plan.php`


------
https://chatgpt.com/codex/tasks/task_e_688823a9d988832ca2206ecf9938ffe7