### PR TITLE
Fix areas and zones page with local storage

### DIFF
--- a/pages/area_almac_v2/gestion_areas_zonas.html
+++ b/pages/area_almac_v2/gestion_areas_zonas.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gestión de Áreas y Zonas</title>
+    <link rel="stylesheet" href="../../styles/Area_almac_v2/gestion_areas_zonas.css">
+    <script defer src="../../scripts/area_almac_v2/gestion_areas_zonas.js"></script>
+</head>
+<body>
+<div class="container">
+    <h1>Gestión de Áreas y Zonas</h1>
+    <div class="actions">
+        <button id="nuevaArea">Registrar nueva Área</button>
+        <button id="nuevaZona">Registrar nueva Zona</button>
+    </div>
+    <div id="formularios">
+        <form id="formArea">
+            <h2>Nueva Área</h2>
+            <label>Nombre</label>
+            <input type="text" id="areaNombre" required>
+            <label>Descripción</label>
+            <textarea id="areaDescripcion" required></textarea>
+            <label>Dimensiones (m)</label>
+            <input type="number" id="areaLargo" placeholder="Largo" min="0" step="0.01" required>
+            <input type="number" id="areaAncho" placeholder="Ancho" min="0" step="0.01" required>
+            <input type="number" id="areaAlto" placeholder="Alto" min="0" step="0.01" required>
+            <p>Volumen: <span id="areaVolumen">0</span> m³</p>
+            <button type="submit">Guardar Área</button>
+        </form>
+        <form id="formZona" class="hidden">
+            <h2>Nueva Zona</h2>
+            <label>Nombre</label>
+            <input type="text" id="zonaNombre" required>
+            <label>Área</label>
+            <select id="zonaArea" required></select>
+            <label>Descripción</label>
+            <textarea id="zonaDescripcion" required></textarea>
+            <label>Dimensiones (m)</label>
+            <input type="number" id="zonaLargo" placeholder="Largo" min="0" step="0.01" required>
+            <input type="number" id="zonaAncho" placeholder="Ancho" min="0" step="0.01" required>
+            <input type="number" id="zonaAlto" placeholder="Alto" min="0" step="0.01" required>
+            <p>Volumen: <span id="zonaVolumen">0</span> m³</p>
+            <label>Tipo de Zona</label>
+            <select id="zonaTipo" required></select>
+            <label>Subniveles</label>
+            <input type="number" id="zonaSubniveles" min="0" value="0">
+            <label>Distancia entre subniveles (cm)</label>
+            <input type="number" id="zonaDistancia" min="0" step="0.1" value="0">
+            <button type="submit">Guardar Zona</button>
+        </form>
+    </div>
+    <div id="resumen"></div>
+</div>
+</body>
+</html>

--- a/pages/main_menu/main_menu.html
+++ b/pages/main_menu/main_menu.html
@@ -19,7 +19,7 @@
             <a href="#" data-page="inicio" class="active">
                 <i class="fas fa-home"></i> <span>Inicio</span>
             </a>
-            <a data-page="area_almac/areas_zonas.html">
+            <a data-page="area_almac_v2/gestion_areas_zonas.html">
                 <i class="fas fa-map-marked-alt"></i> <span>Áreas y Zonas</span>
             </a>
             <a data-page="gest_inve/inventario.html">

--- a/scripts/area_almac_v2/gestion_areas_zonas.js
+++ b/scripts/area_almac_v2/gestion_areas_zonas.js
@@ -1,0 +1,171 @@
+(function() {
+  const areaBtn = document.getElementById('nuevaArea');
+  const zonaBtn = document.getElementById('nuevaZona');
+  const formArea = document.getElementById('formArea');
+  const formZona = document.getElementById('formZona');
+  const resumen = document.getElementById('resumen');
+  const volumenSpan = document.getElementById('areaVolumen');
+  const zonaVolumenSpan = document.getElementById('zonaVolumen');
+  const tipoSelect = document.getElementById('zonaTipo');
+  const areaSelect = document.getElementById('zonaArea');
+
+  const tiposZona = [
+    'Rack', 'Mostrador', 'Caja', 'Estantería', 'Refrigeración', 'Congelador',
+    'Piso', 'Contenedor', 'Palet', 'Carro', 'Cajón', 'Jaula', 'Estiba',
+    'Bodega', 'Silo', 'Tanque', 'Gabinete', 'Vitrina', 'Armario', 'Otro'
+  ];
+
+  function getAreas() {
+    const stored = localStorage.getItem('areas');
+    try { return stored ? JSON.parse(stored) : []; } catch (e) { return []; }
+  }
+
+  function getZonas() {
+    const stored = localStorage.getItem('zonas');
+    try { return stored ? JSON.parse(stored) : []; } catch (e) { return []; }
+  }
+
+  function saveAreas(data) {
+    localStorage.setItem('areas', JSON.stringify(data));
+  }
+
+  function saveZonas(data) {
+    localStorage.setItem('zonas', JSON.stringify(data));
+  }
+
+  function llenarTipos() {
+    tiposZona.forEach(t => {
+      const opt = document.createElement('option');
+      opt.value = t.toLowerCase();
+      opt.textContent = t;
+      tipoSelect.appendChild(opt);
+    });
+  }
+
+  function cargarAreas() {
+    const areas = getAreas();
+    areaSelect.innerHTML = '<option value="">Seleccione</option>';
+    areas.forEach(a => {
+      const opt = document.createElement('option');
+      opt.value = a.id;
+      opt.textContent = a.nombre;
+      areaSelect.appendChild(opt);
+    });
+  }
+
+  function mostrarResumenAreas() {
+    const areas = getAreas();
+    const zonas = getZonas();
+    resumen.innerHTML = '';
+    areas.forEach(area => {
+      const div = document.createElement('div');
+      div.className = 'resumen-item';
+      const vol = (area.largo * area.ancho * area.alto).toFixed(2);
+      div.innerHTML = `<h3>${area.nombre}</h3>
+        <p>${area.descripcion}</p>
+        <p>Dimensiones: ${area.largo} x ${area.ancho} x ${area.alto} m</p>
+        <p>Volumen: ${vol} m³</p>`;
+      const relacionadas = zonas.filter(z => z.area_id === area.id);
+      if (relacionadas.length) {
+        const ul = document.createElement('ul');
+        relacionadas.forEach(z => {
+          const li = document.createElement('li');
+          li.textContent = `${z.nombre} (${z.tipo})`;
+          ul.appendChild(li);
+        });
+        div.appendChild(ul);
+      }
+      resumen.appendChild(div);
+    });
+  }
+
+  function mostrarResumenZonas() {
+    const zonas = getZonas();
+    const areas = getAreas();
+    resumen.innerHTML = '';
+    zonas.forEach(z => {
+      const area = areas.find(a => a.id === z.area_id);
+      const div = document.createElement('div');
+      div.className = 'resumen-item';
+      const volumen = (z.largo * z.ancho * z.alto).toFixed(2);
+      div.innerHTML = `<h3>${z.nombre}</h3>
+        <p>${z.descripcion}</p>
+        <p>Dimensiones: ${z.largo} x ${z.ancho} x ${z.alto} m</p>
+        <p>Volumen: ${volumen} m³</p>
+        <p>Área: ${area ? area.nombre : 'Sin asignar'}</p>`;
+      resumen.appendChild(div);
+    });
+  }
+
+  function calcularVolumen() {
+    const largo = parseFloat(document.getElementById('areaLargo').value) || 0;
+    const ancho = parseFloat(document.getElementById('areaAncho').value) || 0;
+    const alto = parseFloat(document.getElementById('areaAlto').value) || 0;
+    volumenSpan.textContent = (largo * ancho * alto).toFixed(2);
+  }
+
+  function calcularVolumenZona() {
+    const largo = parseFloat(document.getElementById('zonaLargo').value) || 0;
+    const ancho = parseFloat(document.getElementById('zonaAncho').value) || 0;
+    const alto = parseFloat(document.getElementById('zonaAlto').value) || 0;
+    zonaVolumenSpan.textContent = (largo * ancho * alto).toFixed(2);
+  }
+
+  areaBtn.addEventListener('click', () => {
+    formArea.classList.remove('hidden');
+    formZona.classList.add('hidden');
+    mostrarResumenAreas();
+  });
+  zonaBtn.addEventListener('click', () => {
+    formZona.classList.remove('hidden');
+    formArea.classList.add('hidden');
+    cargarAreas();
+    mostrarResumenZonas();
+  });
+
+  formArea.addEventListener('input', calcularVolumen);
+  formZona.addEventListener('input', calcularVolumenZona);
+  formArea.addEventListener('submit', e => {
+    e.preventDefault();
+    const areas = getAreas();
+    const data = {
+      id: Date.now(),
+      nombre: document.getElementById('areaNombre').value,
+      descripcion: document.getElementById('areaDescripcion').value,
+      largo: parseFloat(document.getElementById('areaLargo').value),
+      ancho: parseFloat(document.getElementById('areaAncho').value),
+      alto: parseFloat(document.getElementById('areaAlto').value)
+    };
+    areas.push(data);
+    saveAreas(areas);
+    formArea.reset();
+    calcularVolumen();
+    mostrarResumenAreas();
+  });
+
+  formZona.addEventListener('submit', e => {
+    e.preventDefault();
+    const zonas = getZonas();
+    const data = {
+      id: Date.now(),
+      nombre: document.getElementById('zonaNombre').value,
+      descripcion: document.getElementById('zonaDescripcion').value,
+      largo: parseFloat(document.getElementById('zonaLargo').value),
+      ancho: parseFloat(document.getElementById('zonaAncho').value),
+      alto: parseFloat(document.getElementById('zonaAlto').value),
+      tipo: document.getElementById('zonaTipo').value,
+      subniveles: parseInt(document.getElementById('zonaSubniveles').value) || 0,
+      distancia: parseFloat(document.getElementById('zonaDistancia').value) || 0,
+      area_id: parseInt(document.getElementById('zonaArea').value) || null
+    };
+    zonas.push(data);
+    saveZonas(zonas);
+    formZona.reset();
+    mostrarResumenZonas();
+  });
+
+  llenarTipos();
+  formArea.classList.remove('hidden');
+  mostrarResumenAreas();
+})();
+

--- a/styles/Area_almac_v2/gestion_areas_zonas.css
+++ b/styles/Area_almac_v2/gestion_areas_zonas.css
@@ -1,0 +1,49 @@
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1rem;
+  font-family: Arial, sans-serif;
+}
+.actions {
+  margin-bottom: 1rem;
+}
+.actions button {
+  margin-right: 0.5rem;
+}
+.hidden {
+  display: none;
+}
+form {
+  margin: 1rem 0;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  background: #f9f9f9;
+}
+form label {
+  display: block;
+  margin-top: 0.5rem;
+}
+form input,
+form select,
+form textarea {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 0.25rem;
+  margin-bottom: 0.5rem;
+  box-sizing: border-box;
+}
+form textarea {
+  resize: vertical;
+  min-height: 60px;
+}
+#resumen {
+  margin-top: 1rem;
+  border-top: 1px solid #ccc;
+  padding-top: 1rem;
+}
+.resumen-item {
+  margin-bottom: 1rem;
+}
+.resumen-item h3 {
+  margin: 0 0 0.25rem 0;
+}


### PR DESCRIPTION
## Summary
- keep area/zona forms and show summaries
- store entries in localStorage instead of PHP endpoints
- toggle forms correctly when buttons are clicked

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688929d6bdc4832c98e5d42f2491f776