### PR TITLE
Point menu to new inventory page

### DIFF
--- a/optistock.sql
+++ b/optistock.sql
@@ -149,9 +149,12 @@ COMMIT;
 -- Estructura de tabla para la tabla `categorias`
 CREATE TABLE `categorias` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id_empresa` int(11) NOT NULL,
   `nombre` varchar(100) NOT NULL,
   `descripcion` text DEFAULT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `id_empresa` (`id_empresa`),
+  CONSTRAINT `categorias_ibfk_1` FOREIGN KEY (`id_empresa`) REFERENCES `empresa`(`id_empresa`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------
@@ -159,27 +162,35 @@ CREATE TABLE `categorias` (
 CREATE TABLE `subcategorias` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `categoria_id` int(11) DEFAULT NULL,
+  `id_empresa` int(11) NOT NULL,
   `nombre` varchar(100) NOT NULL,
   `descripcion` text DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `categoria_id` (`categoria_id`),
-  CONSTRAINT `subcategorias_ibfk_1` FOREIGN KEY (`categoria_id`) REFERENCES `categorias`(`id`) ON DELETE SET NULL
+  KEY `id_empresa` (`id_empresa`),
+  CONSTRAINT `subcategorias_ibfk_1` FOREIGN KEY (`categoria_id`) REFERENCES `categorias`(`id`) ON DELETE SET NULL,
+  CONSTRAINT `subcategorias_ibfk_2` FOREIGN KEY (`id_empresa`) REFERENCES `empresa`(`id_empresa`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------
 -- Estructura de tabla para la tabla `productos`
 CREATE TABLE `productos` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id_empresa` int(11) NOT NULL,
   `nombre` varchar(150) NOT NULL,
   `descripcion` text DEFAULT NULL,
   `categoria_id` int(11) DEFAULT NULL,
   `subcategoria_id` int(11) DEFAULT NULL,
+  `dimensiones` varchar(100) DEFAULT NULL,
+  `imagen` varchar(255) DEFAULT NULL,
   `stock` int(11) NOT NULL DEFAULT 0,
   `precio_compra` decimal(10,2) NOT NULL DEFAULT 0.00,
   PRIMARY KEY (`id`),
   KEY `categoria_id` (`categoria_id`),
   KEY `subcategoria_id` (`subcategoria_id`),
+  KEY `id_empresa` (`id_empresa`),
   CONSTRAINT `productos_ibfk_1` FOREIGN KEY (`categoria_id`) REFERENCES `categorias`(`id`) ON DELETE SET NULL,
-  CONSTRAINT `productos_ibfk_2` FOREIGN KEY (`subcategoria_id`) REFERENCES `subcategorias`(`id`) ON DELETE SET NULL
+  CONSTRAINT `productos_ibfk_2` FOREIGN KEY (`subcategoria_id`) REFERENCES `subcategorias`(`id`) ON DELETE SET NULL,
+  CONSTRAINT `productos_ibfk_3` FOREIGN KEY (`id_empresa`) REFERENCES `empresa`(`id_empresa`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 

--- a/pages/gest_inve/inventario_basico.html
+++ b/pages/gest_inve/inventario_basico.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Inventario Básico</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="../../styles/gest_inve/inventario_basico.css">
+</head>
+<body class="p-4">
+    <div class="mb-3">
+        <button id="btnProductos" class="btn btn-primary me-2">Productos</button>
+        <button id="btnCategorias" class="btn btn-secondary me-2">Categorías</button>
+        <button id="btnSubcategorias" class="btn btn-secondary">Subcategorías</button>
+    </div>
+
+    <div id="productoFormContainer" class="mb-4">
+        <h4>Nuevo Producto</h4>
+        <form id="productoForm">
+            <div class="row mb-2">
+                <div class="col-md-6">
+                    <input type="text" id="prodNombre" class="form-control" placeholder="Nombre del producto" required>
+                </div>
+                <div class="col-md-6">
+                    <input type="text" id="prodDimensiones" class="form-control" placeholder="Dimensiones">
+                </div>
+            </div>
+            <div class="row mb-2">
+                <div class="col-md-6">
+                    <select id="prodCategoria" class="form-select">
+                        <option value="">Seleccione categoría</option>
+                    </select>
+                </div>
+                <div class="col-md-6">
+                    <select id="prodSubcategoria" class="form-select">
+                        <option value="">Seleccione subcategoría</option>
+                    </select>
+                </div>
+            </div>
+            <div class="row mb-2">
+                <div class="col-md-6">
+                    <input type="number" id="prodStock" class="form-control" placeholder="Stock inicial" min="0" value="0">
+                </div>
+                <div class="col-md-6">
+                    <input type="number" id="prodPrecio" class="form-control" placeholder="Precio de compra" min="0" step="0.01" value="0">
+                </div>
+            </div>
+            <div class="mb-2">
+                <textarea id="prodDescripcion" class="form-control" placeholder="Descripción"></textarea>
+            </div>
+            <div class="mb-3">
+                <input type="file" id="prodImagen" class="form-control">
+            </div>
+            <button type="submit" class="btn btn-success">Guardar producto</button>
+        </form>
+    </div>
+
+    <div id="categoriaFormContainer" class="mb-4 d-none">
+        <h4>Nueva Categoría</h4>
+        <form id="categoriaForm">
+            <div class="mb-2">
+                <input type="text" id="catNombre" class="form-control" placeholder="Nombre" required>
+            </div>
+            <div class="mb-2">
+                <textarea id="catDescripcion" class="form-control" placeholder="Descripción"></textarea>
+            </div>
+            <button type="submit" class="btn btn-success">Guardar categoría</button>
+        </form>
+    </div>
+
+    <div id="subcategoriaFormContainer" class="mb-4 d-none">
+        <h4>Nueva Subcategoría</h4>
+        <form id="subcategoriaForm">
+            <div class="mb-2">
+                <select id="subcatCategoria" class="form-select" required>
+                    <option value="">Seleccione categoría</option>
+                </select>
+            </div>
+            <div class="mb-2">
+                <input type="text" id="subcatNombre" class="form-control" placeholder="Nombre" required>
+            </div>
+            <div class="mb-2">
+                <textarea id="subcatDescripcion" class="form-control" placeholder="Descripción"></textarea>
+            </div>
+            <button type="submit" class="btn btn-success">Guardar subcategoría</button>
+        </form>
+    </div>
+
+    <h3>Resumen del inventario</h3>
+    <table class="table" id="tablaResumen">
+        <thead id="tablaHead">
+        </thead>
+        <tbody>
+        </tbody>
+    </table>
+
+    <script src="../../scripts/gest_inve/inventario_basico.js"></script>
+</body>
+</html>

--- a/pages/main_menu/main_menu.html
+++ b/pages/main_menu/main_menu.html
@@ -22,7 +22,7 @@
             <a data-page="area_almac/areas_zonas.html">
                 <i class="fas fa-map-marked-alt"></i> <span>Áreas y Zonas</span>
             </a>
-            <a data-page="gest_inve/inventario.html">
+            <a data-page="gest_inve/inventario_basico.html">
                 <i class="fas fa-boxes"></i> <span>Gestión de Inventario</span>
             </a>
             <a data-page="admin_usuar/administracion_usuarios.html">

--- a/scripts/gest_inve/inventario_basico.js
+++ b/scripts/gest_inve/inventario_basico.js
@@ -1,0 +1,307 @@
+(() => {
+  const BASE_URL = window.location.pathname.includes('pages/') ? '../../' : './';
+  const API = {
+    categorias: `${BASE_URL}scripts/php/guardar_categorias.php`,
+    subcategorias: `${BASE_URL}scripts/php/guardar_subcategorias.php`,
+    productos: `${BASE_URL}scripts/php/guardar_productos.php`
+  };
+  const empresaId = localStorage.getItem('id_empresa');
+  if (!empresaId) return;
+
+  let categorias = [];
+  let subcategorias = [];
+  let productos = [];
+  let vistaActual = 'producto';
+  let editProdId = null;
+  let editCatId = null;
+  let editSubcatId = null;
+
+  const btnProductos = document.getElementById('btnProductos');
+  const btnCategorias = document.getElementById('btnCategorias');
+  const btnSubcategorias = document.getElementById('btnSubcategorias');
+
+  const productoFormContainer = document.getElementById('productoFormContainer');
+  const categoriaFormContainer = document.getElementById('categoriaFormContainer');
+  const subcategoriaFormContainer = document.getElementById('subcategoriaFormContainer');
+
+  const prodForm = document.getElementById('productoForm');
+  const catForm = document.getElementById('categoriaForm');
+  const subcatForm = document.getElementById('subcategoriaForm');
+  const prodCategoria = document.getElementById('prodCategoria');
+  const prodSubcategoria = document.getElementById('prodSubcategoria');
+  const subcatCategoria = document.getElementById('subcatCategoria');
+  const tablaResumen = document.querySelector('#tablaResumen tbody');
+  const tablaHead = document.getElementById('tablaHead');
+
+  async function fetchAPI(url, method = 'GET', data) {
+    const options = { method };
+    if (data) {
+      options.headers = { 'Content-Type': 'application/json' };
+      options.body = JSON.stringify(data);
+    }
+    const res = await fetch(url, options);
+    if (!res.ok) throw new Error('Solicitud inválida');
+    return res.json();
+  }
+
+  function mostrar(seccion) {
+    productoFormContainer.classList.add('d-none');
+    categoriaFormContainer.classList.add('d-none');
+    subcategoriaFormContainer.classList.add('d-none');
+    vistaActual = seccion;
+    renderResumen();
+    if (seccion === 'producto') productoFormContainer.classList.remove('d-none');
+    if (seccion === 'categoria') categoriaFormContainer.classList.remove('d-none');
+    if (seccion === 'subcategoria') subcategoriaFormContainer.classList.remove('d-none');
+  }
+
+  btnProductos.addEventListener('click', () => mostrar('producto'));
+  btnCategorias.addEventListener('click', () => mostrar('categoria'));
+  btnSubcategorias.addEventListener('click', () => mostrar('subcategoria'));
+
+  function actualizarSelectCategorias() {
+    [prodCategoria, subcatCategoria].forEach(select => {
+      select.innerHTML = '<option value="">Seleccione categoría</option>';
+      categorias.forEach(c => {
+        const opt = document.createElement('option');
+        opt.value = c.id;
+        opt.textContent = c.nombre;
+        select.appendChild(opt);
+      });
+    });
+  }
+
+  function actualizarSelectSubcategorias() {
+    prodSubcategoria.innerHTML = '<option value="">Seleccione subcategoría</option>';
+    subcategorias.forEach(sc => {
+      const opt = document.createElement('option');
+      opt.value = sc.id;
+      opt.textContent = sc.nombre;
+      prodSubcategoria.appendChild(opt);
+    });
+  }
+
+  async function cargarCategorias() {
+    categorias = await fetchAPI(`${API.categorias}?empresa_id=${empresaId}`);
+    actualizarSelectCategorias();
+  }
+
+  async function cargarSubcategorias() {
+    subcategorias = await fetchAPI(`${API.subcategorias}?empresa_id=${empresaId}`);
+    actualizarSelectSubcategorias();
+  }
+
+  async function cargarProductos() {
+    productos = await fetchAPI(`${API.productos}?empresa_id=${empresaId}`);
+  }
+
+  function renderResumen() {
+    tablaResumen.innerHTML = '';
+    tablaHead.innerHTML = '';
+    if (vistaActual === 'producto') {
+      tablaHead.innerHTML = `
+        <tr>
+          <th>Nombre</th>
+          <th>Descripción</th>
+          <th>Categoría</th>
+          <th>Subcategoría</th>
+          <th>Dimensiones</th>
+          <th>Stock</th>
+          <th>Precio compra</th>
+          <th>Acciones</th>
+        </tr>`;
+      productos.forEach(p => {
+        const cat = categorias.find(c => c.id == p.categoria_id)?.nombre || '';
+        const sub = subcategorias.find(s => s.id == p.subcategoria_id)?.nombre || '';
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td>${p.nombre}</td>
+          <td>${p.descripcion || ''}</td>
+          <td>${cat}</td>
+          <td>${sub}</td>
+          <td>${p.dimensiones || ''}</td>
+          <td>${p.stock}</td>
+          <td>${p.precio_compra}</td>
+          <td>
+            <button class="btn btn-sm btn-primary me-1" data-accion="edit" data-tipo="producto" data-id="${p.id}">Editar</button>
+            <button class="btn btn-sm btn-danger" data-accion="del" data-tipo="producto" data-id="${p.id}">Eliminar</button>
+          </td>`;
+        tablaResumen.appendChild(tr);
+      });
+    } else if (vistaActual === 'categoria') {
+      tablaHead.innerHTML = `
+        <tr>
+          <th>Nombre</th>
+          <th>Descripción</th>
+          <th>Subcategorías</th>
+          <th>Acciones</th>
+        </tr>`;
+      categorias.forEach(c => {
+        const subcats = subcategorias.filter(sc => sc.categoria_id == c.id).map(sc => sc.nombre).join(', ');
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td>${c.nombre}</td>
+          <td>${c.descripcion || ''}</td>
+          <td>${subcats}</td>
+          <td>
+            <button class="btn btn-sm btn-primary me-1" data-accion="edit" data-tipo="categoria" data-id="${c.id}">Editar</button>
+            <button class="btn btn-sm btn-danger" data-accion="del" data-tipo="categoria" data-id="${c.id}">Eliminar</button>
+          </td>`;
+        tablaResumen.appendChild(tr);
+      });
+    } else if (vistaActual === 'subcategoria') {
+      tablaHead.innerHTML = `
+        <tr>
+          <th>Nombre</th>
+          <th>Categoría</th>
+          <th>Descripción</th>
+          <th>Acciones</th>
+        </tr>`;
+      subcategorias.forEach(sc => {
+        const cat = categorias.find(c => c.id == sc.categoria_id)?.nombre || '';
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td>${sc.nombre}</td>
+          <td>${cat}</td>
+          <td>${sc.descripcion || ''}</td>
+          <td>
+            <button class="btn btn-sm btn-primary me-1" data-accion="edit" data-tipo="subcategoria" data-id="${sc.id}">Editar</button>
+            <button class="btn btn-sm btn-danger" data-accion="del" data-tipo="subcategoria" data-id="${sc.id}">Eliminar</button>
+          </td>`;
+        tablaResumen.appendChild(tr);
+      });
+    }
+  }
+
+  catForm.addEventListener('submit', async e => {
+    e.preventDefault();
+    const data = {
+      nombre: catForm.catNombre.value,
+      descripcion: catForm.catDescripcion.value,
+      empresa_id: parseInt(empresaId)
+    };
+    if (editCatId) {
+      await fetchAPI(`${API.categorias}?id=${editCatId}&empresa_id=${empresaId}`, 'PUT', data);
+      editCatId = null;
+    } else {
+      await fetchAPI(API.categorias, 'POST', data);
+    }
+    catForm.reset();
+    await cargarCategorias();
+    await cargarSubcategorias();
+    renderResumen();
+  });
+
+  subcatForm.addEventListener('submit', async e => {
+    e.preventDefault();
+    const data = {
+      nombre: subcatForm.subcatNombre.value,
+      descripcion: subcatForm.subcatDescripcion.value,
+      categoria_id: parseInt(subcatCategoria.value) || null,
+      empresa_id: parseInt(empresaId)
+    };
+    if (editSubcatId) {
+      await fetchAPI(`${API.subcategorias}?id=${editSubcatId}&empresa_id=${empresaId}`, 'PUT', data);
+      editSubcatId = null;
+    } else {
+      await fetchAPI(API.subcategorias, 'POST', data);
+    }
+    subcatForm.reset();
+    await cargarSubcategorias();
+    renderResumen();
+  });
+
+  prodForm.addEventListener('submit', async e => {
+    e.preventDefault();
+    const categoria_id = parseInt(prodCategoria.value) || null;
+    if (!categoria_id) alert('Advertencia: faltan campos por rellenar');
+    const data = {
+      nombre: prodForm.prodNombre.value,
+      descripcion: prodForm.prodDescripcion.value,
+      categoria_id,
+      subcategoria_id: parseInt(prodSubcategoria.value) || null,
+      dimensiones: prodForm.prodDimensiones.value,
+      stock: parseInt(prodForm.prodStock.value) || 0,
+      precio_compra: parseFloat(prodForm.prodPrecio.value) || 0,
+      empresa_id: parseInt(empresaId)
+    };
+    if (editProdId) {
+      await fetchAPI(`${API.productos}?id=${editProdId}&empresa_id=${empresaId}`, 'PUT', data);
+      editProdId = null;
+    } else {
+      await fetchAPI(API.productos, 'POST', data);
+    }
+    prodForm.reset();
+    await cargarProductos();
+    renderResumen();
+  });
+
+  tablaResumen.addEventListener('click', async e => {
+    const id = parseInt(e.target.dataset.id);
+    const tipo = e.target.dataset.tipo;
+    const accion = e.target.dataset.accion;
+    if (!accion) return;
+    if (accion === 'del') {
+      if (confirm('¿Eliminar?')) {
+        if (tipo === 'producto') {
+          await fetchAPI(`${API.productos}?id=${id}&empresa_id=${empresaId}`, 'DELETE');
+        } else if (tipo === 'categoria') {
+          await fetchAPI(`${API.categorias}?id=${id}&empresa_id=${empresaId}`, 'DELETE');
+        } else if (tipo === 'subcategoria') {
+          await fetchAPI(`${API.subcategorias}?id=${id}&empresa_id=${empresaId}`, 'DELETE');
+        }
+        await cargarCategorias();
+        await cargarSubcategorias();
+        await cargarProductos();
+        renderResumen();
+      }
+    }
+    if (accion === 'edit') {
+      if (tipo === 'producto') {
+        const p = productos.find(pr => pr.id == id);
+        if (p) {
+          mostrar('producto');
+          prodForm.prodNombre.value = p.nombre;
+          prodForm.prodDescripcion.value = p.descripcion || '';
+          prodCategoria.value = p.categoria_id || '';
+          await cargarSubcategorias();
+          prodSubcategoria.value = p.subcategoria_id || '';
+          prodForm.prodDimensiones.value = p.dimensiones || '';
+          prodForm.prodStock.value = p.stock;
+          prodForm.prodPrecio.value = p.precio_compra;
+          editProdId = id;
+        }
+      } else if (tipo === 'categoria') {
+        const c = categorias.find(cat => cat.id == id);
+        if (c) {
+          mostrar('categoria');
+          catForm.catNombre.value = c.nombre;
+          catForm.catDescripcion.value = c.descripcion || '';
+          editCatId = id;
+        }
+      } else if (tipo === 'subcategoria') {
+        const sc = subcategorias.find(s => s.id == id);
+        if (sc) {
+          mostrar('subcategoria');
+          subcatCategoria.value = sc.categoria_id || '';
+          subcatForm.subcatNombre.value = sc.nombre;
+          subcatForm.subcatDescripcion.value = sc.descripcion || '';
+          editSubcatId = id;
+        }
+      }
+    }
+  });
+
+  async function init() {
+    await cargarCategorias();
+    await cargarSubcategorias();
+    await cargarProductos();
+    renderResumen();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -133,7 +133,7 @@ const tutorialSteps = [
     {
         title: "Gestión de Inventario",
         content: "El corazón del sistema. Aquí podrás registrar nuevos productos, actualizar existencias, realizar transferencias y gestionar todo tu inventario de manera eficiente.",
-        element: document.querySelector('.sidebar-menu a[href="pages/inventario/gestion_inventario.html"]')
+        element: document.querySelector('.sidebar-menu a[data-page="gest_inve/inventario_basico.html"]')
     },
     {
         title: "Administración de Usuarios",

--- a/scripts/php/guardar_categorias.php
+++ b/scripts/php/guardar_categorias.php
@@ -22,14 +22,27 @@ function getJsonInput() {
 
 if ($method === 'GET') {
     $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    $empresaId = isset($_GET['empresa_id']) ? intval($_GET['empresa_id']) : 0;
     if ($id) {
-        $stmt = $conn->prepare('SELECT * FROM categorias WHERE id = ?');
-        $stmt->bind_param('i', $id);
+        if ($empresaId) {
+            $stmt = $conn->prepare('SELECT * FROM categorias WHERE id = ? AND id_empresa = ?');
+            $stmt->bind_param('ii', $id, $empresaId);
+        } else {
+            $stmt = $conn->prepare('SELECT * FROM categorias WHERE id = ?');
+            $stmt->bind_param('i', $id);
+        }
         $stmt->execute();
         $res = $stmt->get_result();
         echo json_encode($res->fetch_assoc() ?: []);
     } else {
-        $result = $conn->query('SELECT * FROM categorias');
+        if ($empresaId) {
+            $stmt = $conn->prepare('SELECT * FROM categorias WHERE id_empresa = ?');
+            $stmt->bind_param('i', $empresaId);
+            $stmt->execute();
+            $result = $stmt->get_result();
+        } else {
+            $result = $conn->query('SELECT * FROM categorias');
+        }
         $items = [];
         while ($row = $result->fetch_assoc()) {
             $items[] = $row;
@@ -43,13 +56,14 @@ if ($method === 'POST') {
     $data = getJsonInput();
     $nombre = $data['nombre'] ?? '';
     $descripcion = $data['descripcion'] ?? '';
-    if (!$nombre) {
+    $empresaId = intval($data['empresa_id'] ?? 0);
+    if (!$nombre || $empresaId <= 0) {
         http_response_code(400);
-        echo json_encode(['error' => 'Nombre requerido']);
+        echo json_encode(['error' => 'Datos incompletos']);
         exit;
     }
-    $stmt = $conn->prepare('INSERT INTO categorias (nombre, descripcion) VALUES (?, ?)');
-    $stmt->bind_param('ss', $nombre, $descripcion);
+    $stmt = $conn->prepare('INSERT INTO categorias (id_empresa, nombre, descripcion) VALUES (?,?,?)');
+    $stmt->bind_param('iss', $empresaId, $nombre, $descripcion);
     $stmt->execute();
     echo json_encode(['id' => $stmt->insert_id]);
     exit;
@@ -57,11 +71,17 @@ if ($method === 'POST') {
 
 if ($method === 'PUT') {
     $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    $empresaId = isset($_GET['empresa_id']) ? intval($_GET['empresa_id']) : 0;
     $data = getJsonInput();
     $nombre = $data['nombre'] ?? '';
     $descripcion = $data['descripcion'] ?? '';
-    $stmt = $conn->prepare('UPDATE categorias SET nombre=?, descripcion=? WHERE id=?');
-    $stmt->bind_param('ssi', $nombre, $descripcion, $id);
+    if ($empresaId) {
+        $stmt = $conn->prepare('UPDATE categorias SET nombre=?, descripcion=? WHERE id=? AND id_empresa=?');
+        $stmt->bind_param('ssii', $nombre, $descripcion, $id, $empresaId);
+    } else {
+        $stmt = $conn->prepare('UPDATE categorias SET nombre=?, descripcion=? WHERE id=?');
+        $stmt->bind_param('ssi', $nombre, $descripcion, $id);
+    }
     $stmt->execute();
     echo json_encode(['success' => $stmt->affected_rows > 0]);
     exit;
@@ -69,8 +89,14 @@ if ($method === 'PUT') {
 
 if ($method === 'DELETE') {
     $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
-    $stmt = $conn->prepare('DELETE FROM categorias WHERE id=?');
-    $stmt->bind_param('i', $id);
+    $empresaId = isset($_GET['empresa_id']) ? intval($_GET['empresa_id']) : 0;
+    if ($empresaId) {
+        $stmt = $conn->prepare('DELETE FROM categorias WHERE id=? AND id_empresa=?');
+        $stmt->bind_param('ii', $id, $empresaId);
+    } else {
+        $stmt = $conn->prepare('DELETE FROM categorias WHERE id=?');
+        $stmt->bind_param('i', $id);
+    }
     $stmt->execute();
     echo json_encode(['success' => true]);
     exit;

--- a/scripts/php/guardar_productos.php
+++ b/scripts/php/guardar_productos.php
@@ -22,14 +22,27 @@ function getJsonInput() {
 
 if ($method === 'GET') {
     $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    $empresaId = isset($_GET['empresa_id']) ? intval($_GET['empresa_id']) : 0;
     if ($id) {
-        $stmt = $conn->prepare('SELECT * FROM productos WHERE id = ?');
-        $stmt->bind_param('i', $id);
+        if ($empresaId) {
+            $stmt = $conn->prepare('SELECT * FROM productos WHERE id = ? AND id_empresa = ?');
+            $stmt->bind_param('ii', $id, $empresaId);
+        } else {
+            $stmt = $conn->prepare('SELECT * FROM productos WHERE id = ?');
+            $stmt->bind_param('i', $id);
+        }
         $stmt->execute();
         $res = $stmt->get_result();
         echo json_encode($res->fetch_assoc() ?: []);
     } else {
-        $result = $conn->query('SELECT * FROM productos');
+        if ($empresaId) {
+            $stmt = $conn->prepare('SELECT * FROM productos WHERE id_empresa = ?');
+            $stmt->bind_param('i', $empresaId);
+            $stmt->execute();
+            $result = $stmt->get_result();
+        } else {
+            $result = $conn->query('SELECT * FROM productos');
+        }
         $items = [];
         while ($row = $result->fetch_assoc()) {
             $items[] = $row;
@@ -45,15 +58,18 @@ if ($method === 'POST') {
     $descripcion = $data['descripcion'] ?? '';
     $categoria_id = isset($data['categoria_id']) ? intval($data['categoria_id']) : null;
     $subcategoria_id = isset($data['subcategoria_id']) ? intval($data['subcategoria_id']) : null;
+    $dimensiones = $data['dimensiones'] ?? null;
+    $imagen = $data['imagen'] ?? null;
     $stock = intval($data['stock'] ?? 0);
     $precio = floatval($data['precio_compra'] ?? 0);
-    if (!$nombre) {
+    $empresaId = intval($data['empresa_id'] ?? 0);
+    if (!$nombre || $empresaId <= 0) {
         http_response_code(400);
-        echo json_encode(['error' => 'Nombre requerido']);
+        echo json_encode(['error' => 'Datos incompletos']);
         exit;
     }
-    $stmt = $conn->prepare('INSERT INTO productos (nombre, descripcion, categoria_id, subcategoria_id, stock, precio_compra) VALUES (?, ?, ?, ?, ?, ?)');
-    $stmt->bind_param('ssiiid', $nombre, $descripcion, $categoria_id, $subcategoria_id, $stock, $precio);
+    $stmt = $conn->prepare('INSERT INTO productos (id_empresa, nombre, descripcion, categoria_id, subcategoria_id, dimensiones, imagen, stock, precio_compra) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
+    $stmt->bind_param('issiisssd', $empresaId, $nombre, $descripcion, $categoria_id, $subcategoria_id, $dimensiones, $imagen, $stock, $precio);
     $stmt->execute();
     echo json_encode(['id' => $stmt->insert_id]);
     exit;
@@ -61,15 +77,23 @@ if ($method === 'POST') {
 
 if ($method === 'PUT') {
     $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    $empresaId = isset($_GET['empresa_id']) ? intval($_GET['empresa_id']) : 0;
     $data = getJsonInput();
     $nombre = $data['nombre'] ?? '';
     $descripcion = $data['descripcion'] ?? '';
     $categoria_id = isset($data['categoria_id']) ? intval($data['categoria_id']) : null;
     $subcategoria_id = isset($data['subcategoria_id']) ? intval($data['subcategoria_id']) : null;
+    $dimensiones = $data['dimensiones'] ?? null;
+    $imagen = $data['imagen'] ?? null;
     $stock = intval($data['stock'] ?? 0);
     $precio = floatval($data['precio_compra'] ?? 0);
-    $stmt = $conn->prepare('UPDATE productos SET nombre=?, descripcion=?, categoria_id=?, subcategoria_id=?, stock=?, precio_compra=? WHERE id=?');
-    $stmt->bind_param('ssiiidi', $nombre, $descripcion, $categoria_id, $subcategoria_id, $stock, $precio, $id);
+    if ($empresaId) {
+        $stmt = $conn->prepare('UPDATE productos SET nombre=?, descripcion=?, categoria_id=?, subcategoria_id=?, dimensiones=?, imagen=?, stock=?, precio_compra=? WHERE id=? AND id_empresa=?');
+        $stmt->bind_param('ssiisssdii', $nombre, $descripcion, $categoria_id, $subcategoria_id, $dimensiones, $imagen, $stock, $precio, $id, $empresaId);
+    } else {
+        $stmt = $conn->prepare('UPDATE productos SET nombre=?, descripcion=?, categoria_id=?, subcategoria_id=?, dimensiones=?, imagen=?, stock=?, precio_compra=? WHERE id=?');
+        $stmt->bind_param('ssiisssdi', $nombre, $descripcion, $categoria_id, $subcategoria_id, $dimensiones, $imagen, $stock, $precio, $id);
+    }
     $stmt->execute();
     echo json_encode(['success' => $stmt->affected_rows > 0]);
     exit;
@@ -77,8 +101,14 @@ if ($method === 'PUT') {
 
 if ($method === 'DELETE') {
     $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
-    $stmt = $conn->prepare('DELETE FROM productos WHERE id=?');
-    $stmt->bind_param('i', $id);
+    $empresaId = isset($_GET['empresa_id']) ? intval($_GET['empresa_id']) : 0;
+    if ($empresaId) {
+        $stmt = $conn->prepare('DELETE FROM productos WHERE id=? AND id_empresa=?');
+        $stmt->bind_param('ii', $id, $empresaId);
+    } else {
+        $stmt = $conn->prepare('DELETE FROM productos WHERE id=?');
+        $stmt->bind_param('i', $id);
+    }
     $stmt->execute();
     echo json_encode(['success' => true]);
     exit;

--- a/scripts/php/guardar_subcategorias.php
+++ b/scripts/php/guardar_subcategorias.php
@@ -22,14 +22,27 @@ function getJsonInput() {
 
 if ($method === 'GET') {
     $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    $empresaId = isset($_GET['empresa_id']) ? intval($_GET['empresa_id']) : 0;
     if ($id) {
-        $stmt = $conn->prepare('SELECT * FROM subcategorias WHERE id = ?');
-        $stmt->bind_param('i', $id);
+        if ($empresaId) {
+            $stmt = $conn->prepare('SELECT * FROM subcategorias WHERE id = ? AND id_empresa = ?');
+            $stmt->bind_param('ii', $id, $empresaId);
+        } else {
+            $stmt = $conn->prepare('SELECT * FROM subcategorias WHERE id = ?');
+            $stmt->bind_param('i', $id);
+        }
         $stmt->execute();
         $res = $stmt->get_result();
         echo json_encode($res->fetch_assoc() ?: []);
     } else {
-        $result = $conn->query('SELECT * FROM subcategorias');
+        if ($empresaId) {
+            $stmt = $conn->prepare('SELECT * FROM subcategorias WHERE id_empresa = ?');
+            $stmt->bind_param('i', $empresaId);
+            $stmt->execute();
+            $result = $stmt->get_result();
+        } else {
+            $result = $conn->query('SELECT * FROM subcategorias');
+        }
         $items = [];
         while ($row = $result->fetch_assoc()) {
             $items[] = $row;
@@ -44,13 +57,14 @@ if ($method === 'POST') {
     $categoria_id = isset($data['categoria_id']) ? intval($data['categoria_id']) : null;
     $nombre = $data['nombre'] ?? '';
     $descripcion = $data['descripcion'] ?? '';
-    if (!$nombre) {
+    $empresaId = intval($data['empresa_id'] ?? 0);
+    if (!$nombre || $empresaId <= 0) {
         http_response_code(400);
-        echo json_encode(['error' => 'Nombre requerido']);
+        echo json_encode(['error' => 'Datos incompletos']);
         exit;
     }
-    $stmt = $conn->prepare('INSERT INTO subcategorias (categoria_id, nombre, descripcion) VALUES (?, ?, ?)');
-    $stmt->bind_param('iss', $categoria_id, $nombre, $descripcion);
+    $stmt = $conn->prepare('INSERT INTO subcategorias (categoria_id, id_empresa, nombre, descripcion) VALUES (?, ?, ?, ?)');
+    $stmt->bind_param('iiss', $categoria_id, $empresaId, $nombre, $descripcion);
     $stmt->execute();
     echo json_encode(['id' => $stmt->insert_id]);
     exit;
@@ -58,12 +72,18 @@ if ($method === 'POST') {
 
 if ($method === 'PUT') {
     $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    $empresaId = isset($_GET['empresa_id']) ? intval($_GET['empresa_id']) : 0;
     $data = getJsonInput();
     $categoria_id = isset($data['categoria_id']) ? intval($data['categoria_id']) : null;
     $nombre = $data['nombre'] ?? '';
     $descripcion = $data['descripcion'] ?? '';
-    $stmt = $conn->prepare('UPDATE subcategorias SET categoria_id=?, nombre=?, descripcion=? WHERE id=?');
-    $stmt->bind_param('issi', $categoria_id, $nombre, $descripcion, $id);
+    if ($empresaId) {
+        $stmt = $conn->prepare('UPDATE subcategorias SET categoria_id=?, nombre=?, descripcion=? WHERE id=? AND id_empresa=?');
+        $stmt->bind_param('issii', $categoria_id, $nombre, $descripcion, $id, $empresaId);
+    } else {
+        $stmt = $conn->prepare('UPDATE subcategorias SET categoria_id=?, nombre=?, descripcion=? WHERE id=?');
+        $stmt->bind_param('issi', $categoria_id, $nombre, $descripcion, $id);
+    }
     $stmt->execute();
     echo json_encode(['success' => $stmt->affected_rows > 0]);
     exit;
@@ -71,8 +91,14 @@ if ($method === 'PUT') {
 
 if ($method === 'DELETE') {
     $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
-    $stmt = $conn->prepare('DELETE FROM subcategorias WHERE id=?');
-    $stmt->bind_param('i', $id);
+    $empresaId = isset($_GET['empresa_id']) ? intval($_GET['empresa_id']) : 0;
+    if ($empresaId) {
+        $stmt = $conn->prepare('DELETE FROM subcategorias WHERE id=? AND id_empresa=?');
+        $stmt->bind_param('ii', $id, $empresaId);
+    } else {
+        $stmt = $conn->prepare('DELETE FROM subcategorias WHERE id=?');
+        $stmt->bind_param('i', $id);
+    }
     $stmt->execute();
     echo json_encode(['success' => true]);
     exit;

--- a/styles/gest_inve/inventario_basico.css
+++ b/styles/gest_inve/inventario_basico.css
@@ -1,0 +1,8 @@
+body {
+  font-family: Arial, sans-serif;
+}
+
+table th, table td {
+  border: 1px solid #ccc;
+  padding: 4px;
+}


### PR DESCRIPTION
## Summary
- update main menu link to the simplified inventory module
- adjust tutorial step to look for the new link
- persist products, categories and subcategories to database using company scoping

## Testing
- `npm install`
- `node -c scripts/gest_inve/inventario_basico.js`
- `node -c scripts/main_menu/main_menu.js`
- `php -l scripts/php/guardar_categorias.php`
- `php -l scripts/php/guardar_subcategorias.php`
- `php -l scripts/php/guardar_productos.php`


------
https://chatgpt.com/codex/tasks/task_e_68892872b0bc832ca60eddb9afe2904a