### PR TITLE
Fix session after account verification

### DIFF
--- a/scripts/regis_login/regist/registro_inter.js
+++ b/scripts/regis_login/regist/registro_inter.js
@@ -40,8 +40,21 @@ function verifyCode(email, code) {
     .then(response => response.json())
     .then(data => {
         if (data.success) {
-            // Si la verificación fue exitosa, redirigir al siguiente paso
-            window.location.href = `../../main_menu/main_menu.html?email=${encodeURIComponent(email)}`;
+            // Guardar la sesión en localStorage para que el menú principal la detecte
+            localStorage.setItem('usuario_id', data.id_usuario);
+            localStorage.setItem('usuario_nombre', data.nombre);
+            localStorage.setItem('usuario_email', data.correo);
+            localStorage.setItem('usuario_rol', data.rol);
+
+            if (data.id_empresa) {
+                localStorage.setItem('id_empresa', data.id_empresa);
+            }
+            if (data.empresa_nombre) {
+                localStorage.setItem('empresa_nombre', data.empresa_nombre);
+            }
+
+            // Redirigir directamente al menú principal
+            window.location.href = '../../main_menu/main_menu.html';
         } else {
             alert(data.message);  // Si hubo un error, mostramos el mensaje de error
         }


### PR DESCRIPTION
## Summary
- keep user logged in immediately after verifying their email
- store user details in the browser after verification

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688b8f083f10832c8e8f5bae43622b39