### PR TITLE
Normalize logo paths

### DIFF
--- a/scripts/account_suscrip/account_suscrip.js
+++ b/scripts/account_suscrip/account_suscrip.js
@@ -46,11 +46,11 @@ function mainAccountSuscrip() {
     const e = data.empresa || {};
     empNomEl.textContent = e.nombre_empresa || '';
     empSecEl.textContent = e.sector_empresa || '';
-    if(e.logo_empresa){ empLogo.src = e.logo_empresa; }
+    if(e.logo_empresa){ empLogo.src = '/' + e.logo_empresa.replace(/^\/+/,''); }
 
     localStorage.setItem('empresa_nombre', e.nombre_empresa || '');
     localStorage.setItem('empresa_sector', e.sector_empresa || '');
-    localStorage.setItem('logo_empresa', e.logo_empresa || '');
+    localStorage.setItem('logo_empresa', e.logo_empresa ? '/' + e.logo_empresa.replace(/^\/+/,'') : '');
   }
 }
 
@@ -132,8 +132,9 @@ document.getElementById('btnGuardarCambiosEmpresa').addEventListener('click', as
     localStorage.setItem('empresa_nombre', formData.get('nombre_empresa'));
     localStorage.setItem('empresa_sector', formData.get('sector_empresa'));
     if (resp.logo_empresa) {
-      localStorage.setItem('logo_empresa', resp.logo_empresa);
-      empLogo.src = resp.logo_empresa;
+      const logoPath = '/' + resp.logo_empresa.replace(/^\/+/,'');
+      localStorage.setItem('logo_empresa', logoPath);
+      empLogo.src = logoPath;
     }
     modalEmpresa.hide();
     location.reload();

--- a/scripts/php/get_account_data.php
+++ b/scripts/php/get_account_data.php
@@ -64,6 +64,10 @@ if (!$empresa) {
         $config = $res3->fetch_assoc();
     }
 
+    if ($empresa && !empty($empresa['logo_empresa'])) {
+        $empresa['logo_empresa'] = '/' . ltrim($empresa['logo_empresa'], '/');
+    }
+
     echo json_encode([
         'success' => true,
         'usuario' => $usuario,

--- a/scripts/php/registro_empresa.php
+++ b/scripts/php/registro_empresa.php
@@ -40,7 +40,7 @@ if (isset($_FILES['logo_empresa']) && $_FILES['logo_empresa']['error'] === UPLOA
         echo json_encode(["success" => false, "message" => "Error al subir el logo"]);
         exit;
     }
-    $logo_empresa = 'images/logos/' . $filename;   // ruta guardada en DB
+    $logo_empresa = '/images/logos/' . $filename;   // ruta guardada en DB
 }
 
 $sql  = "INSERT INTO empresa (nombre_empresa, logo_empresa, sector_empresa, usuario_creador)

--- a/scripts/php/update_empresa.php
+++ b/scripts/php/update_empresa.php
@@ -49,7 +49,7 @@ if (isset($_FILES['logo_empresa']) && $_FILES['logo_empresa']['error'] === UPLOA
         echo json_encode(["success" => false, "message" => "Error al subir el logo"]);
         exit;
     }
-    $logo_empresa = 'images/logos/' . $filename;
+    $logo_empresa = '/images/logos/' . $filename;
 }
 
 $stmt = $conn->prepare("UPDATE empresa SET nombre_empresa = ?, logo_empresa = ?, sector_empresa = ? WHERE id_empresa = ?");


### PR DESCRIPTION
## Summary
- Ensure company logos and localStorage paths are absolute in account view
- Return absolute logo paths from PHP endpoints

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f9d5ffd88832cbfce66b5802c09ed