### PR TITLE
Ajustar color de texto según barras

### DIFF
--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -470,6 +470,14 @@ if (userImgEl) {
 let colorSidebarSeleccionado = null;
 let colorTopbarSeleccionado = null;
 
+function getContrastingColor(hexColor) {
+    const r = parseInt(hexColor.slice(1, 3), 16);
+    const g = parseInt(hexColor.slice(3, 5), 16);
+    const b = parseInt(hexColor.slice(5, 7), 16);
+    const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+    return brightness > 128 ? '#000000' : '#ffffff';
+}
+
 const openColorModal = document.getElementById('openColorModal');
 const colorModal = document.getElementById('colorModal');
 
@@ -490,6 +498,8 @@ document.querySelectorAll('#sidebarColors button').forEach(btn => {
         document.querySelectorAll('#sidebarColors button').forEach(b => b.style.border = '2px solid #ccc');
         btn.style.border = '3px solid black';
         document.documentElement.style.setProperty('--sidebar-color', colorSidebarSeleccionado);
+        const textColor = getContrastingColor(colorSidebarSeleccionado);
+        document.documentElement.style.setProperty('--sidebar-text-color', textColor);
     });
 });
 
@@ -499,6 +509,8 @@ document.querySelectorAll('#topbarColors button').forEach(btn => {
         document.querySelectorAll('#topbarColors button').forEach(b => b.style.border = '2px solid #ccc');
         btn.style.border = '3px solid black';
         document.documentElement.style.setProperty('--topbar-color', colorTopbarSeleccionado);
+        const textColor = getContrastingColor(colorTopbarSeleccionado);
+        document.documentElement.style.setProperty('--topbar-text-color', textColor);
     });
 });
 

--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -9,6 +9,8 @@
     --info-color: #2980b9;
     --sidebar-color: #20252a;
     --topbar-color: #20252a;
+    --sidebar-text-color: #ffffff;
+    --topbar-text-color: #ffffff;
     --sidebar-width: 280px;
     --topbar-height: 70px;
     --transition-speed: 0.3s;
@@ -30,7 +32,7 @@ body {
 /* Sidebar Styles */
 .sidebar {
     background-color: var(--sidebar-color);
-    color: white;
+    color: var(--sidebar-text-color);
     width: var(--sidebar-width);
     height: 100vh;
     position: fixed;
@@ -61,7 +63,7 @@ body {
 
 .sidebar-header i {
     margin-right: 10px;
-    color: var(--secondary-color);
+    color: var(--sidebar-text-color);
 }
 
 .sidebar-menu {
@@ -73,7 +75,7 @@ body {
 .sidebar-menu a {
     display: flex;
     align-items: center;
-    color: var(--light-color);
+    color: var(--sidebar-text-color);
     text-decoration: none;
     padding: 12px 25px;
     margin: 5px 0;
@@ -85,7 +87,7 @@ body {
 .sidebar-menu a:hover {
     background-color: rgba(255, 255, 255, 0.1);
     border-left: 4px solid var(--secondary-color);
-    color: white;
+    color: var(--sidebar-text-color);
 }
 
 .sidebar-menu a i {
@@ -127,7 +129,7 @@ body {
 .topbar-title {
     font-size: 1.3rem;
     font-weight: 500;
-    color: var(--dark-color);
+    color: var(--topbar-text-color);
 }
 
 .topbar-actions {
@@ -167,13 +169,13 @@ body {
 .notification-bell {
     position: relative;
     cursor: pointer;
-    color: var(--dark-color);
+    color: var(--topbar-text-color);
     font-size: 1.2rem;
 }
 
 .alert-settings {
     cursor: pointer;
-    color: var(--dark-color);
+    color: var(--topbar-text-color);
     font-size: 1.2rem;
     margin-left: 15px;
 }
@@ -217,10 +219,12 @@ body {
 .user-name {
     font-weight: 500;
     font-size: 0.9rem;
+    color: var(--topbar-text-color);
 }
 
 .user-role {
     font-size: 0.8rem;
+    color: var(--topbar-text-color);
 }
 
 .user-profile .dropdown {
@@ -263,11 +267,11 @@ body {
     border: none;
     cursor: pointer;
     font-size: 1.2rem;
-    color: #333;
+    color: var(--topbar-text-color);
 }
 
 .dropdown-toggle:hover {
-    color: #2980b9;
+    color: var(--topbar-text-color);
 }
 /* Main Content Styles */
 .content {
@@ -649,7 +653,7 @@ body {
 .menu-toggle {
     background: none;
     border: none;
-    color: var(--dark-color);
+    color: var(--topbar-text-color);
     font-size: 1.3rem;
     cursor: pointer;
     margin-right: 15px;


### PR DESCRIPTION
## Resumen
- Añadir variables CSS para manejar color del texto en sidebar y topbar
- Calcular color de contraste en JavaScript al seleccionar nuevos colores

## Pruebas
- `npm test` *(falla: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689fb6883960832cab694a79d9d7cc45