### PR TITLE
usar variables CSS para colores de menú

### DIFF
--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -693,10 +693,14 @@ function cargarConfiguracionVisual(idEmpresa) {
     .then(({ success, config }) => {
         if (success && config) {
             if (config.color_sidebar) {
-                document.querySelector('.sidebar').style.backgroundColor = config.color_sidebar;
+                document.documentElement.style.setProperty('--sidebar-color', config.color_sidebar);
+                const textColor = getContrastingColor(config.color_sidebar);
+                document.documentElement.style.setProperty('--sidebar-text-color', textColor);
             }
             if (config.color_topbar) {
-                document.querySelector('.topbar').style.backgroundColor = config.color_topbar;
+                document.documentElement.style.setProperty('--topbar-color', config.color_topbar);
+                const textColor = getContrastingColor(config.color_topbar);
+                document.documentElement.style.setProperty('--topbar-text-color', textColor);
             }
 
             if (config.orden_sidebar) {


### PR DESCRIPTION
## Summary
- set sidebar and topbar colors using CSS custom properties
- derive contrasting text colors with `getContrastingColor`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fcec2b1ac832ca55e0dd75e78be05