### PR TITLE
Ensure contrasting text colors loaded correctly

### DIFF
--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -41,6 +41,14 @@ function sendPushNotification(title, message) {
     }
 }
 
+function getContrastingColor(hexColor) {
+    const r = parseInt(hexColor.slice(1, 3), 16);
+    const g = parseInt(hexColor.slice(3, 5), 16);
+    const b = parseInt(hexColor.slice(5, 7), 16);
+    const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+    return brightness > 128 ? '#000000' : '#ffffff';
+}
+
 
 const metricsData = {
     highRotation: [
@@ -470,14 +478,6 @@ if (userImgEl) {
 let colorSidebarSeleccionado = null;
 let colorTopbarSeleccionado = null;
 
-function getContrastingColor(hexColor) {
-    const r = parseInt(hexColor.slice(1, 3), 16);
-    const g = parseInt(hexColor.slice(3, 5), 16);
-    const b = parseInt(hexColor.slice(5, 7), 16);
-    const brightness = (r * 299 + g * 587 + b * 114) / 1000;
-    return brightness > 128 ? '#000000' : '#ffffff';
-}
-
 const openColorModal = document.getElementById('openColorModal');
 const colorModal = document.getElementById('colorModal');
 
@@ -693,10 +693,14 @@ function cargarConfiguracionVisual(idEmpresa) {
     .then(({ success, config }) => {
         if (success && config) {
             if (config.color_sidebar) {
-                document.querySelector('.sidebar').style.backgroundColor = config.color_sidebar;
+                document.documentElement.style.setProperty('--sidebar-color', config.color_sidebar);
+                const textColor = getContrastingColor(config.color_sidebar);
+                document.documentElement.style.setProperty('--sidebar-text-color', textColor);
             }
             if (config.color_topbar) {
-                document.querySelector('.topbar').style.backgroundColor = config.color_topbar;
+                document.documentElement.style.setProperty('--topbar-color', config.color_topbar);
+                const textColor = getContrastingColor(config.color_topbar);
+                document.documentElement.style.setProperty('--topbar-text-color', textColor);
             }
 
             if (config.orden_sidebar) {


### PR DESCRIPTION
## Summary
- Move `getContrastingColor` helper to global scope so saved theme colors load with proper contrast

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689fcec2b1ac832ca55e0dd75e78be05