### PR TITLE
Allow separate topbar color selection

### DIFF
--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -500,15 +500,11 @@ colorModal.addEventListener('click', (e) => {
 document.querySelectorAll('#sidebarColors button').forEach(btn => {
     btn.addEventListener('click', () => {
         colorSidebarSeleccionado = btn.dataset.color;
-        // Usa el mismo color para el topbar
-        colorTopbarSeleccionado = btn.dataset.color;
         document.querySelectorAll('#sidebarColors button').forEach(b => b.style.border = '2px solid #ccc');
         btn.style.border = '3px solid black';
         document.documentElement.style.setProperty('--sidebar-color', colorSidebarSeleccionado);
-        document.documentElement.style.setProperty('--topbar-color', colorTopbarSeleccionado);
         const textColor = getContrastingColor(colorSidebarSeleccionado);
         document.documentElement.style.setProperty('--sidebar-text-color', textColor);
-        document.documentElement.style.setProperty('--topbar-text-color', textColor);
     });
 });
 

--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -8,8 +8,7 @@
     --warning-color: #f39c12;
     --info-color: #2980b9;
     --sidebar-color: #20252a;
-    /* El topbar usará el mismo color que la barra lateral */
-    --topbar-color: var(--sidebar-color);
+    --topbar-color: #454b52; /* Color predeterminado del topbar */
     --sidebar-text-color: #ffffff;
     --topbar-text-color: #ffffff;
     --sidebar-width: 280px;


### PR DESCRIPTION
## Summary
- Let sidebar and topbar colors be chosen independently
- Set a default topbar color instead of mirroring the sidebar

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4afe14ca8832cbd05192965b96953