### PR TITLE
Show profile photo in user administration table

### DIFF
--- a/scripts/Admin_usuar/administracion_usuarios.js
+++ b/scripts/Admin_usuar/administracion_usuarios.js
@@ -19,8 +19,9 @@ function cargarUsuariosEmpresa() {
         conteoPorRol[u.rol] = (conteoPorRol[u.rol] || 0) + 1;
 
         const tr = document.createElement('tr');
+        const foto = u.foto_perfil ? `/${u.foto_perfil}` : '/images/profile.jpg';
         tr.innerHTML = `
-          <td>${u.nombre}</td>
+          <td class="user-cell"><img src="${foto}" class="user-photo" alt="Foto de ${u.nombre}"> ${u.nombre}</td>
           <td>${u.apellido}</td>
           <td>${u.correo}</td>
           <td>${u.rol}</td>

--- a/scripts/php/obtener_usuarios_empresa.php
+++ b/scripts/php/obtener_usuarios_empresa.php
@@ -19,7 +19,7 @@ try {
 $data = json_decode(file_get_contents("php://input"), true);
 $id_empresa = intval($data['id_empresa']);
 
-$sql = "SELECT u.id_usuario, u.nombre, u.apellido, u.correo, u.rol, u.telefono, u.fecha_nacimiento
+$sql = "SELECT u.id_usuario, u.nombre, u.apellido, u.correo, u.rol, u.telefono, u.fecha_nacimiento, u.foto_perfil
         FROM usuario u
         INNER JOIN usuario_empresa ue ON u.id_usuario = ue.id_usuario
         WHERE ue.id_empresa = ? AND u.rol != 'Administrador'";

--- a/styles/Admin_usuar/administracion_usuarios.css
+++ b/styles/Admin_usuar/administracion_usuarios.css
@@ -87,3 +87,17 @@
 .btn-eliminar:hover {
     background-color: #a71d2a;
 }
+
+/* Foto de perfil en la tabla */
+.user-cell {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.user-photo {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+}


### PR DESCRIPTION
## Summary
- Display user profile picture next to the name in the admin users table
- Fetch photo path from backend and style table cells for images

## Testing
- `npm test` *(fails: Missing script "test")*
- `php -l scripts/php/obtener_usuarios_empresa.php`
- `node --check scripts/Admin_usuar/administracion_usuarios.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5127deb24832c883881896e5eeec0