### PR TITLE
Mostrar rol y fecha legible en accesos recientes

### DIFF
--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -104,9 +104,10 @@ function loadMetrics() {
 
 function formatRelativeDate(date) {
     const now = new Date();
-    const diffMs = now - date;
-    const diffDays = Math.floor(diffMs / 86400000);
-    if (diffDays === 0) return "Hoy";
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const targetDay = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+    let diffDays = Math.round((today - targetDay) / 86400000);
+    if (diffDays <= 0) return "Hoy";
     if (diffDays === 1) return "Ayer";
     if (diffDays < 30) return `${diffDays} días`;
     const diffMonths = Math.floor(diffDays / 30);
@@ -140,13 +141,9 @@ function loadAccessLogs() {
                 const imgSrc = log.foto_perfil || '/images/profile.jpg';
                 li.innerHTML =
                     '<div class="activity-icon"><img src="' + imgSrc + '" class="activity-avatar" alt="' + log.nombre + '"></div>' +
-                    '<div class="activity-details"><div class="activity-description">' + log.nombre + ' ' + log.apellido + ' - ' + log.rol + ' - ' + log.accion + '</div>' +
+                    '<div class="activity-details"><div class="activity-description">' +
+                    log.nombre + ' ' + log.apellido + ' - ' + log.rol + ' - ' + log.accion + '</div>' +
                     '<div class="activity-time">' + dateStr + ' ' + timeStr + '</div></div>';
-
-                li.innerHTML =
-                    '<div class="activity-icon"><img src="' + (log.foto_perfil || '/images/profile.jpg') + '" class="activity-avatar" alt="' + log.nombre + '"></div>' +
-                    '<div class="activity-details"><div class="activity-description">' + log.nombre + ' ' + log.apellido + ' - ' + log.accion + '</div>' +
-                    '<div class="activity-time">' + log.fecha + '</div></div>';
 
                 accessLogsList.appendChild(li);
             });


### PR DESCRIPTION
### Summary
- Include role and 12-hour formatted timestamp with relative date labels in access log entries
- Prevent negative day differences when calculating relative dates for access logs

### Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae558a2ae8832cb5c9e54d39cb1ff7