### PR TITLE
Filter access logs by company

### DIFF
--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -127,7 +127,8 @@ function formatTime(date) {
 }
 function loadAccessLogs() {
     if (!accessLogsList) return;
-    fetch("/scripts/php/get_access_logs.php")
+    const idEmpresa = localStorage.getItem('id_empresa') || '';
+    fetch(`/scripts/php/get_access_logs.php?id_empresa=${idEmpresa}`)
         .then(res => res.json())
         .then(data => {
             if (!data.success) return;

--- a/scripts/php/get_access_logs.php
+++ b/scripts/php/get_access_logs.php
@@ -13,13 +13,20 @@ if (!$conn) {
 }
 
 
-$sql = "SELECT ra.accion, ra.fecha, u.nombre, u.apellido, u.rol, u.foto_perfil
+$id_empresa = intval($_GET['id_empresa'] ?? 0);
 
+$sql = "SELECT ra.accion, ra.fecha, u.nombre, u.apellido, u.rol, u.foto_perfil
         FROM registro_accesos ra
         JOIN usuario u ON ra.id_usuario = u.id_usuario
+        LEFT JOIN usuario_empresa ue ON u.id_usuario = ue.id_usuario
+        WHERE ue.id_empresa = ? OR u.id_usuario = (SELECT usuario_creador FROM empresa WHERE id_empresa = ?)
         ORDER BY ra.fecha DESC
         LIMIT 5";
-$result = mysqli_query($conn, $sql);
+
+$stmt = mysqli_prepare($conn, $sql);
+mysqli_stmt_bind_param($stmt, "ii", $id_empresa, $id_empresa);
+mysqli_stmt_execute($stmt);
+$result = mysqli_stmt_get_result($stmt);
 
 $logs = [];
 while ($row = mysqli_fetch_assoc($result)) {


### PR DESCRIPTION
## Summary
- limit access log queries to the requesting company using its `id_empresa`
- include the company id when fetching recent access logs from the dashboard

## Testing
- `npm test` (fails: Missing script)
- `php -l scripts/php/get_access_logs.php`
- `node --check scripts/main_menu/main_menu.js`


------
https://chatgpt.com/codex/tasks/task_e_68b23c7a2890832c9b29797419f1965f