### PR TITLE
Filter access logs by company and admin

### DIFF
--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -127,7 +127,8 @@ function formatTime(date) {
 }
 function loadAccessLogs() {
     if (!accessLogsList) return;
-    fetch("/scripts/php/get_access_logs.php")
+    const idEmpresa = localStorage.getItem('id_empresa') || '';
+    fetch(`/scripts/php/get_access_logs.php?id_empresa=${idEmpresa}`)
         .then(res => res.json())
         .then(data => {
             if (!data.success) return;
@@ -139,10 +140,11 @@ function loadAccessLogs() {
                 const timeStr = formatTime(date);
                 const dateStr = formatRelativeDate(date);
                 const imgSrc = log.foto_perfil || '/images/profile.jpg';
+                const fullName = `${log.nombre} ${log.apellido}`.trim();
                 li.innerHTML =
-                    '<div class="activity-icon"><img src="' + imgSrc + '" class="activity-avatar" alt="' + log.nombre + '"></div>' +
+                    '<div class="activity-icon"><img src="' + imgSrc + '" class="activity-avatar" alt="' + fullName + '"></div>' +
                     '<div class="activity-details"><div class="activity-description">' +
-                    log.nombre + ' - ' + log.rol + ' - ' + log.accion + '</div>' +
+                    fullName + ' - ' + log.rol + ' - ' + log.accion + '</div>' +
                     '<div class="activity-time">' + dateStr + ' ' + timeStr + '</div></div>';
 
                 accessLogsList.appendChild(li);

--- a/scripts/php/get_access_logs.php
+++ b/scripts/php/get_access_logs.php
@@ -13,13 +13,21 @@ if (!$conn) {
 }
 
 
-$sql = "SELECT ra.accion, ra.fecha, u.nombre, u.apellido, u.rol, u.foto_perfil
+$id_empresa = intval($_GET['id_empresa'] ?? 0);
 
+$sql = "SELECT ra.accion, ra.fecha, u.nombre, u.apellido, u.rol, u.foto_perfil
         FROM registro_accesos ra
         JOIN usuario u ON ra.id_usuario = u.id_usuario
+        LEFT JOIN usuario_empresa ue ON u.id_usuario = ue.id_usuario
+        JOIN empresa e ON e.id_empresa = ?
+        WHERE ue.id_empresa = e.id_empresa OR u.id_usuario = e.usuario_creador
         ORDER BY ra.fecha DESC
         LIMIT 5";
-$result = mysqli_query($conn, $sql);
+
+$stmt = mysqli_prepare($conn, $sql);
+mysqli_stmt_bind_param($stmt, "i", $id_empresa);
+mysqli_stmt_execute($stmt);
+$result = mysqli_stmt_get_result($stmt);
 
 $logs = [];
 while ($row = mysqli_fetch_assoc($result)) {


### PR DESCRIPTION
## Summary
- limit access log queries to the requesting company while including the company's administrator
- show each user's full name when rendering recent access logs in the dashboard

## Testing
- `npm test` (fails: Missing script)
- `php -l scripts/php/get_access_logs.php`
- `node --check scripts/main_menu/main_menu.js`


------
https://chatgpt.com/codex/tasks/task_e_68b23c7a2890832c9b29797419f1965f