### PR TITLE
Filter access logs by company and admin

### DIFF
--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -127,8 +127,12 @@ function formatTime(date) {
 }
 function loadAccessLogs() {
     if (!accessLogsList) return;
-    fetch("/scripts/php/get_access_logs.php")
-        .then(res => res.json())
+    const idEmpresa = localStorage.getItem('id_empresa') || '';
+    fetch(`/scripts/php/get_access_logs.php?id_empresa=${idEmpresa}`)
+        .then(res => {
+            if (!res.ok) throw new Error('Error al obtener los accesos');
+            return res.json();
+        })
         .then(data => {
             if (!data.success) return;
             accessLogsList.innerHTML = "";
@@ -139,15 +143,17 @@ function loadAccessLogs() {
                 const timeStr = formatTime(date);
                 const dateStr = formatRelativeDate(date);
                 const imgSrc = log.foto_perfil || '/images/profile.jpg';
+                const fullName = `${log.nombre} ${log.apellido}`.trim();
                 li.innerHTML =
-                    '<div class="activity-icon"><img src="' + imgSrc + '" class="activity-avatar" alt="' + log.nombre + '"></div>' +
+                    '<div class="activity-icon"><img src="' + imgSrc + '" class="activity-avatar" alt="' + fullName + '"></div>' +
                     '<div class="activity-details"><div class="activity-description">' +
-                    log.nombre + ' - ' + log.rol + ' - ' + log.accion + '</div>' +
+                    fullName + ' - ' + log.rol + ' - ' + log.accion + '</div>' +
                     '<div class="activity-time">' + dateStr + ' ' + timeStr + '</div></div>';
 
                 accessLogsList.appendChild(li);
             });
-        });
+        })
+        .catch(err => console.error('Error loading access logs:', err));
 }
 
 

--- a/scripts/php/get_access_logs.php
+++ b/scripts/php/get_access_logs.php
@@ -8,28 +8,47 @@ $database   = "u296155119_OptiStock";
 
 $conn = mysqli_connect($servername, $db_user, $db_pass, $database);
 if (!$conn) {
+    http_response_code(500);
     echo json_encode(["success" => false, "message" => "Error de conexión a la base de datos."]);
     exit;
 }
 
+$id_empresa = intval($_GET['id_empresa'] ?? 0);
 
 $sql = "SELECT ra.accion, ra.fecha, u.nombre, u.apellido, u.rol, u.foto_perfil
-
         FROM registro_accesos ra
         JOIN usuario u ON ra.id_usuario = u.id_usuario
+        LEFT JOIN usuario_empresa ue ON u.id_usuario = ue.id_usuario
+        WHERE ue.id_empresa = ? OR u.id_usuario = (
+            SELECT usuario_creador FROM empresa WHERE id_empresa = ?
+        )
         ORDER BY ra.fecha DESC
         LIMIT 5";
-$result = mysqli_query($conn, $sql);
+
+$stmt = mysqli_prepare($conn, $sql);
+if (!$stmt) {
+    http_response_code(500);
+    echo json_encode(["success" => false, "message" => "Error al preparar la consulta."]);
+    exit;
+}
+
+mysqli_stmt_bind_param($stmt, "ii", $id_empresa, $id_empresa);
+if (!mysqli_stmt_execute($stmt)) {
+    http_response_code(500);
+    echo json_encode(["success" => false, "message" => "Error al ejecutar la consulta."]);
+    exit;
+}
+
+$result = mysqli_stmt_get_result($stmt);
 
 $logs = [];
 while ($row = mysqli_fetch_assoc($result)) {
-
     $foto = $row['foto_perfil'] ?? '';
     $row['foto_perfil'] = '/' . ltrim($foto ?: 'images/profile.jpg', '/');
-
     $logs[] = $row;
 }
 
+mysqli_stmt_close($stmt);
 mysqli_close($conn);
 
 echo json_encode(["success" => true, "logs" => $logs]);


### PR DESCRIPTION
## Summary
- limit access log queries to the requesting company while including the company's administrator
- show each user's full name when rendering recent access logs in the dashboard
- handle API failures with clearer errors to avoid crashes when loading access logs

## Testing
- `npm test` (fails: Missing script: "test")
- `php -l scripts/php/get_access_logs.php`
- `node --check scripts/main_menu/main_menu.js`


------
https://chatgpt.com/codex/tasks/task_e_68b23c7a2890832c9b29797419f1965f