### PR TITLE
Sync account menu with topbar color

### DIFF
--- a/scripts/account_suscrip/account_suscrip.js
+++ b/scripts/account_suscrip/account_suscrip.js
@@ -1,5 +1,13 @@
 // Gestion de cuenta y suscripción
 
+function getContrastingColor(hexColor) {
+  const r = parseInt(hexColor.slice(1, 3), 16);
+  const g = parseInt(hexColor.slice(3, 5), 16);
+  const b = parseInt(hexColor.slice(5, 7), 16);
+  const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+  return brightness > 128 ? '#000000' : '#ffffff';
+}
+
 async function obtenerDatosCuenta(id_usuario) {
   const res = await fetch(`/scripts/php/get_account_data.php?usuario_id=${id_usuario}`);
   const data = await res.json();
@@ -31,6 +39,13 @@ function mainAccountSuscrip() {
     console.log("Respuesta get_account_data:", data);
 
     if(data.success){
+    const config = data.configuracion;
+    if (config && config.color_topbar) {
+      document.documentElement.style.setProperty('--topbar-color', config.color_topbar);
+      const textColor = getContrastingColor(config.color_topbar);
+      document.documentElement.style.setProperty('--topbar-text-color', textColor);
+    }
+
     const u = data.usuario;
     nombreEl.textContent = `${u.nombre} ${u.apellido}`;
     correoEl.textContent = u.correo;

--- a/styles/account_suscrip/account_suscrip.css
+++ b/styles/account_suscrip/account_suscrip.css
@@ -12,10 +12,10 @@ body {
 
 .account-menu {
   width: 200px;
-  background: linear-gradient(45deg, #6a11cb, #2575fc);
+  background: var(--topbar-color, linear-gradient(45deg, #6a11cb, #2575fc));
   border-radius: 8px;
   padding: 20px;
-  color: #fff;
+  color: var(--topbar-text-color, #fff);
 
 }
 


### PR DESCRIPTION
## Summary
- Use topbar theme variables for account menu background and text color
- Apply stored topbar color on account page with automatic contrasting text

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b25e6e0cd0832cab5ababa64f7451e