### PR TITLE
Verifica entorno seguro y solicita permiso de cámara antes de iniciar el escáner QR

### DIFF
--- a/scripts/gest_inve/inventario_basico.js
+++ b/scripts/gest_inve/inventario_basico.js
@@ -120,9 +120,20 @@ function poblarSelectProductos() {
   });
 }
 
-btnScanQR.addEventListener('click', () => {
+btnScanQR.addEventListener('click', async () => {
   if (!/Mobi|Android/i.test(navigator.userAgent)) {
     alert('El escáner QR solo está disponible en dispositivos móviles');
+    return;
+  }
+  if (!navigator.mediaDevices || !isSecureContext) {
+    alert('La cámara requiere HTTPS o localhost');
+    return;
+  }
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } });
+    stream.getTracks().forEach(track => track.stop());
+  } catch (e) {
+    alert('Permiso de cámara denegado');
     return;
   }
   scanModal.show();


### PR DESCRIPTION
## Resumen
- Verifica el contexto seguro y la disponibilidad de `navigator.mediaDevices` antes de activar el escáner QR.
- Solicita permiso de cámara con `getUserMedia`; si se rechaza, se avisa al usuario y no se inicia el escaneo.

## Testing
- `npm test` *(falla: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b9f14f30f4832c9e74c2630f5e5782