### PR TITLE
Redirect to login after Google registration

### DIFF
--- a/pages/regis_login/login/login.html
+++ b/pages/regis_login/login/login.html
@@ -16,6 +16,7 @@
     <div class="d-flex flex-column align-items-center">
         <div class="login-container text-center">
             <h3 class="mb-4">INICIA SESIÓN CON TU CUENTA</h3>
+            <div id="status-message" class="alert alert-success d-none"></div>
             <form id="loginForm" method="POST">
                 <div class="mb-3">
                     <input type="email" id="email" name="correo" class="form-control" placeholder="Correo" required>

--- a/scripts/php/regist_google.php
+++ b/scripts/php/regist_google.php
@@ -28,7 +28,8 @@ $stmt = $conn->prepare("UPDATE usuario SET nombre = ?, apellido = ?, fecha_nacim
 $stmt->bind_param("sssss",$nombre, $apellido, $fecha_nacimiento, $telefono, $correo);
 
 if ($stmt->execute()) {
-    echo "Datos actualizados correctamente. Puedes usar <a href='../../main_menu/main_menu.html'>tu cuenta</a>";
+    header("Location: ../../pages/regis_login/login/login.html?msg=created");
+    exit;
 } else {
     echo "Error al guardar los datos.";
 }

--- a/scripts/regis_login/login/login.js
+++ b/scripts/regis_login/login/login.js
@@ -5,7 +5,16 @@ document.addEventListener("DOMContentLoaded", function () {
         // Si ya está logueado, redirigir directamente al menú principal
         window.location.href = "../../main_menu/main_menu.html";
         return;  // Salir de la función para evitar más redirecciones
-    } 
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('msg') === 'created') {
+        const statusDiv = document.getElementById('status-message');
+        if (statusDiv) {
+            statusDiv.textContent = 'Usuario creado. Ahora puedes iniciar sesión.';
+            statusDiv.classList.remove('d-none');
+        }
+    }
 
     // Función para manejar la respuesta del login con Google
     function handleCredentialResponse(response) {


### PR DESCRIPTION
## Summary
- Redirect after Google-based registration to the login page with a success flag
- Display a confirmation message on the login page when `msg=created`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba270a0038832c8c73ad46c7c68ba6