### PR TITLE
Log basic area, zone, inventory, and user movements

### DIFF
--- a/pages/control_log/log.html
+++ b/pages/control_log/log.html
@@ -1,44 +1,66 @@
-<div class="module-wrapper">
-    <h2>Log de control</h2>
-    <p>Historial completo de movimientos del sistema</p>
+<div class="log-container">
+  <div class="module-wrapper">
+    <h2 class="mb-1">Log de control</h2>
+    <p class="text-muted">Historial completo de movimientos del sistema</p>
 
-    <div class="filters">
+    <div class="row g-3 align-items-end filters">
+      <div class="col-md-3">
+        <label for="filtroModulo" class="form-label">Módulo</label>
         <select id="filtroModulo" class="form-select">
-            <option value="">Todos los módulos</option>
-            <option value="Inventario">Inventario</option>
-            <option value="Usuarios">Usuarios</option>
-            <option value="Áreas">Áreas</option>
-            <option value="Zonas">Zonas</option>
-            <option value="Reportes">Reportes</option>
+          <option value="">Todos los módulos</option>
+          <option value="Inventario">Inventario</option>
+          <option value="Usuarios">Usuarios</option>
+          <option value="Áreas">Áreas</option>
+          <option value="Zonas">Zonas</option>
+          <option value="Reportes">Reportes</option>
         </select>
-        <input id="filtroUsuario" type="text" class="form-control" placeholder="ID de usuario">
+      </div>
+      <div class="col-md-3">
+        <label for="filtroUsuario" class="form-label">ID de usuario</label>
+        <input
+          id="filtroUsuario"
+          type="text"
+          class="form-control"
+          placeholder="ID de usuario"
+        />
+      </div>
+      <div class="col-md-3">
+        <label for="filtroRol" class="form-label">Rol</label>
         <select id="filtroRol" class="form-select">
-            <option value="">Todos los roles</option>
-            <option value="Administrador">Administrador</option>
-            <option value="Empleado">Empleado</option>
+          <option value="">Todos los roles</option>
+          <option value="Administrador">Administrador</option>
+          <option value="Empleado">Empleado</option>
         </select>
-        <button id="exportPdf" class="btn btn-secondary btn-export">Exportar PDF</button>
-        <button id="exportExcel" class="btn btn-secondary">Exportar Excel</button>
+      </div>
+      <div class="col-md-3 d-flex justify-content-end gap-2">
+        <button id="exportPdf" class="btn btn-outline-secondary btn-export">
+          Exportar PDF
+        </button>
+        <button id="exportExcel" class="btn btn-outline-secondary">
+          Exportar Excel
+        </button>
+      </div>
     </div>
 
     <div class="table-responsive">
-        <table id="logTable" class="table table-striped">
-            <thead>
-                <tr>
-                    <th>Fecha</th>
-                    <th>Hora</th>
-                    <th>Usuario</th>
-                    <th>Rol</th>
-                    <th>Módulo</th>
-                    <th>Acción</th>
-                </tr>
-            </thead>
-            <tbody id="logTableBody"></tbody>
-        </table>
+      <table id="logTable" class="table table-striped table-hover align-middle">
+        <thead>
+          <tr>
+            <th>Fecha</th>
+            <th>Hora</th>
+            <th>Usuario</th>
+            <th>Rol</th>
+            <th>Módulo</th>
+            <th>Acción</th>
+          </tr>
+        </thead>
+        <tbody id="logTableBody"></tbody>
+      </table>
     </div>
+  </div>
 </div>
 
-<link rel="stylesheet" href="../../styles/control_log/log.css">
+<link rel="stylesheet" href="../../styles/control_log/log.css" />
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>

--- a/scripts/php/editar_usuario_empresa.php
+++ b/scripts/php/editar_usuario_empresa.php
@@ -1,4 +1,5 @@
 <?php
+session_start();
 header('Content-Type: application/json');
 
 // Conexión a la base de datos
@@ -10,9 +11,11 @@ $database   = "u296155119_OptiStock";
 $conn = mysqli_connect($servername, $db_user, $db_pass, $database);
 
 if (!$conn) {
-    echo json_encode(["success" => false, "message" => "Error de conexión a la base de datos."]);
+    echo json_encode(["success" => false, "message" => "Error de conexión a la base de datos."]); 
     exit;
 }
+
+require_once __DIR__ . '/log_utils.php';
 
 // Obtener datos del request
 $data = json_decode(file_get_contents("php://input"), true);
@@ -38,6 +41,7 @@ $stmt = $conn->prepare($sql);
 $stmt->bind_param("sssssi", $nombre, $apellido, $telefono, $fecha_nacimiento, $rol, $id_usuario);
 
 if ($stmt->execute()) {
+    registrarLog($conn, $_SESSION['usuario_id'] ?? 0, 'Usuarios', "Edición de usuario empresa: $id_usuario");
     echo json_encode(["success" => true]);
 } else {
     echo json_encode(["success" => false, "message" => "Error al actualizar el usuario."]);

--- a/scripts/php/eliminar_usuario_empresa.php
+++ b/scripts/php/eliminar_usuario_empresa.php
@@ -1,4 +1,5 @@
 <?php
+session_start();
 header('Content-Type: application/json');
 
 $servername = "localhost";
@@ -11,6 +12,8 @@ if (!$conn) {
     echo json_encode(["success" => false, "message" => "Error de conexión"]);
     exit;
 }
+
+require_once __DIR__ . '/log_utils.php';
 
 $data = json_decode(file_get_contents("php://input"), true);
 $correo = $data['correo'] ?? null;
@@ -45,6 +48,7 @@ try {
     $stmt->execute();
 
     $conn->commit();
+    registrarLog($conn, $_SESSION['usuario_id'] ?? 0, 'Usuarios', "Eliminación de usuario empresa: $correo");
     echo json_encode(["success" => true]);
 } catch (Exception $e) {
     $conn->rollback();

--- a/scripts/php/log_utils.php
+++ b/scripts/php/log_utils.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Inserta un registro en la tabla log_control.
+ *
+ * @param mysqli $conn       Conexión activa a la BD.
+ * @param int    $idUsuario  ID del usuario que realizó la acción.
+ * @param string $modulo     Nombre del módulo (e.g. "Áreas", "Zonas", "Inventario").
+ * @param string $accion     Descripción corta de la acción realizada.
+ */
+function registrarLog($conn, $idUsuario, $modulo, $accion) {
+    if (!$idUsuario) {
+        return; // sin usuario no se registra
+    }
+    $stmt = $conn->prepare(
+        "INSERT INTO log_control (id_usuario, modulo, accion, fecha, hora) VALUES (?, ?, ?, CURDATE(), CURTIME())"
+    );
+    $stmt->bind_param("iss", $idUsuario, $modulo, $accion);
+    $stmt->execute();
+    $stmt->close();
+}
+?>

--- a/scripts/php/registrar_area.php
+++ b/scripts/php/registrar_area.php
@@ -1,6 +1,7 @@
 <?php
+session_start();
 header("Content-Type: application/json");
-// Conexión a la base de datos
+
 $servername = "localhost";
 $db_user    = "u296155119_Admin";
 $db_pass    = "4Dmin123o";
@@ -12,7 +13,9 @@ if (!$conn) {
     exit;
 }
 
-$data = json_decode(file_get_contents("php://input"));
+require_once __DIR__ . '/log_utils.php';
+
+$data   = json_decode(file_get_contents("php://input"));
 $nombre = $data->areaName ?? '';
 
 if (!$nombre) {
@@ -24,6 +27,7 @@ $stmt = $conn->prepare("INSERT INTO areas (nombre) VALUES (?)");
 $stmt->bind_param("s", $nombre);
 
 if ($stmt->execute()) {
+    registrarLog($conn, $_SESSION['usuario_id'] ?? 0, 'Áreas', "Creación de área: $nombre");
     echo json_encode(["success" => true, "message" => "Área registrada con éxito."]);
 } else {
     echo json_encode(["success" => false, "message" => "Error al registrar área."]);

--- a/scripts/php/registrar_zona.php
+++ b/scripts/php/registrar_zona.php
@@ -1,6 +1,7 @@
 <?php
+session_start();
 header("Content-Type: application/json");
-// Conexión a la base de datos
+
 $servername = "localhost";
 $db_user    = "u296155119_Admin";
 $db_pass    = "4Dmin123o";
@@ -11,6 +12,8 @@ if (!$conn) {
     echo json_encode(["success" => false, "message" => "Error de conexión"]);
     exit;
 }
+
+require_once __DIR__ . '/log_utils.php';
 
 $data = json_decode(file_get_contents("php://input"));
 
@@ -31,6 +34,7 @@ $stmt = $conn->prepare("INSERT INTO zonas (nombre, area_id, ancho, alto, largo, 
 $stmt->bind_param("sidddis", $nombre, $id_area, $ancho, $alto, $largo, $subniveles, $tipo);
 
 if ($stmt->execute()) {
+    registrarLog($conn, $_SESSION['usuario_id'] ?? 0, 'Zonas', "Creación de zona: $nombre");
     echo json_encode(["success" => true, "message" => "Zona registrada con éxito."]);
 } else {
     echo json_encode(["success" => false, "message" => "Error al registrar zona."]);

--- a/scripts/php/registro.php
+++ b/scripts/php/registro.php
@@ -3,6 +3,8 @@ header('Content-Type: application/json');
 ini_set('display_errors', 1);
 error_reporting(E_ALL);
 
+require_once __DIR__ . '/log_utils.php';
+
 $response = ["success" => false, "message" => ""]; // Respuesta inicial
 
 try {
@@ -46,6 +48,8 @@ try {
         throw new Exception("Error al registrar el usuario: " . mysqli_error($conn));
     }
 
+    $id_usuario = mysqli_insert_id($conn);
+
     // 7. Generar código de verificación
     $codigo_verificacion = mt_rand(100000, 999999);
     session_start();
@@ -60,6 +64,8 @@ try {
     if (!mail($correo, $mail_subject, $mail_message, $mail_headers)) {
         throw new Exception("Error al enviar el correo de verificación.");
     }
+
+    registrarLog($conn, $id_usuario, 'Usuarios', "Registro de usuario: $correo");
 
     // Respuesta de éxito
     $response["success"] = true;

--- a/scripts/php/registro_usuario_empresa.php
+++ b/scripts/php/registro_usuario_empresa.php
@@ -1,4 +1,5 @@
 <?php
+session_start();
 header('Content-Type: application/json');
 
 $servername = "localhost";
@@ -11,6 +12,8 @@ if (!$conn) {
     echo json_encode(["success" => false, "message" => "Error de conexión"]);
     exit;
 }
+
+require_once __DIR__ . '/log_utils.php';
 
 $data = json_decode(file_get_contents("php://input"), true);
 
@@ -43,6 +46,7 @@ if ($stmt1->execute()) {
     $stmt2 = $conn->prepare($query2);
     $stmt2->bind_param("ii", $id_usuario, $id_empresa);
     if ($stmt2->execute()) {
+        registrarLog($conn, $_SESSION['usuario_id'] ?? 0, 'Usuarios', "Registro de usuario empresa: $correo");
         echo json_encode(["success" => true]);
     } else {
         echo json_encode(["success" => false, "message" => "Error al vincular con empresa"]);

--- a/scripts/php/update_user.php
+++ b/scripts/php/update_user.php
@@ -1,4 +1,6 @@
 <?php
+session_start();
+
 $servername = "localhost";
 $db_user    = "u296155119_Admin";
 $db_pass    = "4Dmin123o";
@@ -9,6 +11,8 @@ if (!$conn) {
     echo json_encode(["success" => false, "message" => "Error de conexión"]);
     exit;
 }
+
+require_once __DIR__ . '/log_utils.php';
 
 $usuario_id = $_POST['id_usuario'] ?? null;
 $nombre     = $_POST['nombre'] ?? null;
@@ -58,6 +62,8 @@ try {
     $res3 = $stmt3->get_result();
     $row = $res3->fetch_assoc();
     $ruta_foto = $row ? $row['foto_perfil'] : null;
+
+    registrarLog($conn, $_SESSION['usuario_id'] ?? 0, 'Usuarios', "Actualización de usuario: $usuario_id");
 
     echo json_encode([
         'success' => true,

--- a/styles/control_log/log.css
+++ b/styles/control_log/log.css
@@ -1,24 +1,68 @@
-/* Estilos para la interfaz del log de control */
+/* Estilos mejorados para el módulo de log de control */
+:root {
+  --color-primary: #2563eb;
+  --color-primary-hover: #1d4ed8;
+  --color-bg: #f4f7fc;
+  --color-panel: #fff;
+  --color-border: #e5e7eb;
+  --color-title: #22223b;
+  --color-text: #3a3a3a;
+  --radius: 10px;
+  --shadow: 0 2px 12px rgba(59, 130, 246, 0.08);
+  --font-main: "Segoe UI", Arial, sans-serif;
+}
+
+.log-container {
+  background: var(--color-bg);
+  padding: 1rem;
+  font-family: var(--font-main);
+}
+
 .module-wrapper {
-    margin-bottom: 20px;
+  background: var(--color-panel);
+  box-shadow: var(--shadow);
+  border-radius: var(--radius);
+  padding: 1.5rem;
 }
 
-.filters {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
-    margin-bottom: 15px;
+.module-wrapper h2 {
+  color: var(--color-title);
+  font-weight: 700;
 }
 
-.filters select,
-.filters input {
-    padding: 0.4rem;
+.module-wrapper p {
+  color: var(--color-text);
+  margin-bottom: 1.5rem;
 }
 
-.table-responsive {
-    margin-top: 10px;
+.filters .form-label {
+  font-weight: 500;
+  color: var(--color-title);
 }
 
 .btn-export {
-    margin-right: 10px;
+  margin-right: 0.5rem;
+}
+
+.btn-outline-secondary:hover {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.table-responsive {
+  margin-top: 1rem;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+#logTable th {
+  background: var(--color-primary);
+  color: #fff;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+#logTable tbody tr:hover {
+  background: #eef2ff;
 }


### PR DESCRIPTION
## Summary
- log user self-registration into log_control
- log enterprise user creation, updates, edits, and deletions
- provide session-based logging for user management scripts
- refine activity log page with a card layout, labeled filters, and styled table to match other modules

## Testing
- `php -l scripts/php/registro.php`
- `php -l scripts/php/registro_usuario_empresa.php`
- `php -l scripts/php/update_user.php`
- `php -l scripts/php/editar_usuario_empresa.php`
- `php -l scripts/php/eliminar_usuario_empresa.php`
- `npx prettier --check pages/control_log/log.html styles/control_log/log.css`


------
https://chatgpt.com/codex/tasks/task_e_68bf6671ce78832cb769a1603d2bc49f