### PR TITLE
Enable QR scanning on all devices

### DIFF
--- a/scripts/gest_inve/inventario_basico.js
+++ b/scripts/gest_inve/inventario_basico.js
@@ -121,19 +121,15 @@ function poblarSelectProductos() {
 }
 
 btnScanQR.addEventListener('click', async () => {
-  if (!/Mobi|Android/i.test(navigator.userAgent)) {
-    alert('El escáner QR solo está disponible en dispositivos móviles');
-    return;
-  }
   if (!navigator.mediaDevices || !isSecureContext) {
-    alert('La cámara requiere HTTPS o localhost');
+    alert('La cámara no es compatible o se requiere HTTPS/localhost');
     return;
   }
   try {
-    const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } });
+    const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: { ideal: 'environment' } } });
     stream.getTracks().forEach(track => track.stop());
   } catch (e) {
-    alert('Permiso de cámara denegado');
+    alert('Permiso de cámara denegado o no disponible');
     return;
   }
   qrReader.classList.remove('d-none');
@@ -142,7 +138,7 @@ btnScanQR.addEventListener('click', async () => {
     qrScanner = new Html5Qrcode('qrReader');
   }
   qrScanner.start(
-    { facingMode: 'environment' },
+    { facingMode: { ideal: 'environment' } },
     { fps: 10, qrbox: 250 },
     async decodedText => {
       await qrScanner.stop();


### PR DESCRIPTION
## Summary
- allow QR scanning on desktops by removing mobile-only restriction
- verify camera support and prefer environment-facing camera when available

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0c6060960832c922f5d5efd5a8c8e