### PR TITLE
Fix dynamic script loading for logs

### DIFF
--- a/scripts/Admin_usuar/administracion_usuarios.js
+++ b/scripts/Admin_usuar/administracion_usuarios.js
@@ -12,6 +12,7 @@ function cargarUsuariosEmpresa() {
       if (!data.success) return;
 
       const tbody = document.querySelector('#tablaUsuariosEmpresa tbody');
+      if (!tbody) return;
       tbody.innerHTML = ''; // limpiar tabla
       const conteoPorRol = {};
 


### PR DESCRIPTION
## Summary
- remove previous dynamic scripts before loading new pages to avoid duplicate variables
- guard user-management table population when target elements are missing

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0bae6c588832c80aaeabd24a62aeb