### PR TITLE
Filtrar log por empresa y conservar filtros

### DIFF
--- a/pages/control_log/log.html
+++ b/pages/control_log/log.html
@@ -68,13 +68,10 @@
           </select>
         </div>
         <div class="col-md-3">
-          <label for="filtroUsuario" class="form-label">ID de usuario</label>
-          <input
-            id="filtroUsuario"
-            type="text"
-            class="form-control"
-            placeholder="ID de usuario"
-          />
+          <label for="filtroUsuario" class="form-label">Usuario</label>
+          <select id="filtroUsuario" class="form-select">
+            <option value="">Todos los usuarios</option>
+          </select>
         </div>
         <div class="col-md-3">
           <label for="filtroRol" class="form-label">Rol</label>

--- a/scripts/control_log/log.js
+++ b/scripts/control_log/log.js
@@ -6,30 +6,80 @@ const tablaBody = document.getElementById('logTableBody');
 const exportPdfBtn = document.getElementById('exportPdf');
 const exportExcelBtn = document.getElementById('exportExcel');
 
+const ID_EMPRESA = localStorage.getItem('id_empresa') || '';
+const LOGS_STORAGE_KEY = ID_EMPRESA ? `logsEmpresa_${ID_EMPRESA}` : 'logsEmpresa';
+const FILTERS_STORAGE_KEY = ID_EMPRESA ? `logsFiltros_${ID_EMPRESA}` : 'logsFiltros';
+
 let registros = [];
+let filtrosGuardados = {};
+let savedUserFilter = '';
+let actualizandoOpcionesUsuario = false;
 
 const { jsPDF } = window.jspdf;
 
-async function cargarRegistros() {
+function cargarFiltrosGuardados() {
     try {
-        const params = new URLSearchParams();
-        if (filtroModulo.value) params.append('modulo', filtroModulo.value);
-        if (filtroUsuario.value) params.append('usuario', filtroUsuario.value);
-        if (filtroRol.value) params.append('rol', filtroRol.value);
+        filtrosGuardados = JSON.parse(localStorage.getItem(FILTERS_STORAGE_KEY)) || {};
+    } catch (error) {
+        filtrosGuardados = {};
+    }
 
-        const res = await fetch(`../../scripts/php/get_logs.php?${params.toString()}`);
-        const data = await res.json();
-        if (data.success) {
-            registros = data.logs;
-            mostrarRegistros(registros);
-        }
-    } catch (err) {
-        console.error('Error cargando logs', err);
+    if (filtrosGuardados.modulo) {
+        filtroModulo.value = filtrosGuardados.modulo;
+    }
+    if (filtrosGuardados.rol) {
+        filtroRol.value = filtrosGuardados.rol;
+    }
+    savedUserFilter = filtrosGuardados.usuario || '';
+}
+
+function mostrarLogsGuardados() {
+    let guardados = [];
+    try {
+        guardados = JSON.parse(localStorage.getItem(LOGS_STORAGE_KEY)) || [];
+    } catch (error) {
+        guardados = [];
+    }
+
+    if (Array.isArray(guardados) && guardados.length > 0) {
+        registros = guardados;
+        mostrarRegistros(registros);
+    }
+}
+
+function guardarRegistrosEnCache(datos) {
+    try {
+        localStorage.setItem(LOGS_STORAGE_KEY, JSON.stringify(datos));
+    } catch (error) {
+        console.warn('No se pudieron guardar los logs en caché', error);
+    }
+}
+
+function guardarFiltros() {
+    filtrosGuardados = {
+        modulo: filtroModulo.value || '',
+        usuario: filtroUsuario.value || '',
+        rol: filtroRol.value || ''
+    };
+    savedUserFilter = filtrosGuardados.usuario;
+
+    try {
+        localStorage.setItem(FILTERS_STORAGE_KEY, JSON.stringify(filtrosGuardados));
+    } catch (error) {
+        console.warn('No se pudieron guardar los filtros', error);
     }
 }
 
 function mostrarRegistros(datos) {
     tablaBody.innerHTML = '';
+
+    if (!Array.isArray(datos) || datos.length === 0) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = '<td colspan="6" class="text-center text-muted">Sin registros disponibles.</td>';
+        tablaBody.appendChild(tr);
+        return;
+    }
+
     datos.forEach(reg => {
         const tr = document.createElement('tr');
         tr.innerHTML = `
@@ -44,10 +94,111 @@ function mostrarRegistros(datos) {
     });
 }
 
-[filtroModulo, filtroUsuario, filtroRol].forEach(el => {
-    el.addEventListener('change', cargarRegistros);
+function actualizarOpcionesUsuario(usuarios) {
+    if (!Array.isArray(usuarios)) {
+        return;
+    }
+
+    actualizandoOpcionesUsuario = true;
+    const targetValue = filtroUsuario.value || savedUserFilter || '';
+
+    filtroUsuario.innerHTML = '<option value="">Todos los usuarios</option>';
+
+    usuarios.forEach(user => {
+        const option = document.createElement('option');
+        option.value = user.id_usuario;
+        const rol = user.rol ? ` (${user.rol})` : '';
+        option.textContent = `${user.nombre}${rol}`;
+        filtroUsuario.appendChild(option);
+    });
+
+    let finalValue = '';
+    if (targetValue) {
+        filtroUsuario.value = String(targetValue);
+        if (filtroUsuario.value === String(targetValue)) {
+            finalValue = String(targetValue);
+        } else {
+            filtroUsuario.value = '';
+        }
+    } else {
+        filtroUsuario.value = '';
+    }
+
+    actualizandoOpcionesUsuario = false;
+    savedUserFilter = finalValue;
+}
+
+async function cargarRegistros() {
+    if (!ID_EMPRESA) {
+        console.warn('No se encontró el identificador de la empresa en el navegador.');
+        return;
+    }
+
+    try {
+        const params = new URLSearchParams();
+        params.append('empresa', ID_EMPRESA);
+
+        if (filtroModulo.value) {
+            params.append('modulo', filtroModulo.value);
+        }
+
+        const usuarioFiltro = filtroUsuario.value || savedUserFilter;
+        if (usuarioFiltro) {
+            params.append('usuario', usuarioFiltro);
+        }
+
+        if (filtroRol.value) {
+            params.append('rol', filtroRol.value);
+        }
+
+        const res = await fetch(`../../scripts/php/get_logs.php?${params.toString()}`, {
+            cache: 'no-store'
+        });
+
+        if (!res.ok) {
+            throw new Error(`Error HTTP ${res.status}`);
+        }
+
+        const data = await res.json();
+
+        if (!data.success) {
+            console.warn('La consulta de logs no fue exitosa:', data.message || 'Respuesta sin éxito');
+            return;
+        }
+
+        if (Array.isArray(data.usuarios)) {
+            actualizarOpcionesUsuario(data.usuarios);
+        }
+
+        registros = Array.isArray(data.logs) ? data.logs : [];
+        mostrarRegistros(registros);
+        guardarRegistrosEnCache(registros);
+        guardarFiltros();
+    } catch (err) {
+        console.error('Error cargando logs', err);
+    }
+}
+
+filtroModulo.addEventListener('change', () => {
+    guardarFiltros();
+    cargarRegistros();
 });
 
+filtroRol.addEventListener('change', () => {
+    guardarFiltros();
+    cargarRegistros();
+});
+
+filtroUsuario.addEventListener('change', () => {
+    if (actualizandoOpcionesUsuario) {
+        return;
+    }
+    guardarFiltros();
+    cargarRegistros();
+});
+
+cargarFiltrosGuardados();
+mostrarLogsGuardados();
 cargarRegistros();
 
 exportPdfBtn.addEventListener('click', () => {

--- a/scripts/php/get_logs.php
+++ b/scripts/php/get_logs.php
@@ -1,4 +1,5 @@
 <?php
+session_start();
 header("Content-Type: application/json");
 
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
@@ -16,38 +17,51 @@ try {
     exit;
 }
 
-$modulo  = $_GET['modulo']  ?? '';
-$usuario = $_GET['usuario'] ?? '';
-$rol     = $_GET['rol']     ?? '';
+$empresaId = intval($_GET['empresa'] ?? ($_SESSION['id_empresa'] ?? 0));
+
+if ($empresaId <= 0) {
+    echo json_encode(["success" => false, "message" => "Empresa no especificada."]);
+    $conn->close();
+    exit;
+}
+
+$modulo  = trim($_GET['modulo']  ?? '');
+$usuario = trim($_GET['usuario'] ?? '');
+$rol     = trim($_GET['rol']     ?? '');
 
 $sql = "SELECT l.fecha, l.hora, CONCAT(u.nombre,' ',u.apellido) AS usuario, u.rol, l.modulo, l.accion
         FROM log_control l
         JOIN usuario u ON l.id_usuario = u.id_usuario
-        WHERE 1";
-$params = [];
-$types  = '';
+        WHERE u.id_usuario IN (
+            SELECT usuario_creador FROM empresa WHERE id_empresa = ?
+            UNION
+            SELECT id_usuario FROM usuario_empresa WHERE id_empresa = ?
+        )";
+
+$params = [$empresaId, $empresaId];
+$types  = 'ii';
 
 if ($modulo !== '') {
-    $sql .= " AND l.modulo = ?";
-    $types .= 's';
+    $sql    .= " AND l.modulo = ?";
+    $types  .= 's';
     $params[] = $modulo;
 }
+
 if ($usuario !== '') {
-    $sql .= " AND u.id_usuario = ?";
-    $types .= 'i';
+    $sql    .= " AND u.id_usuario = ?";
+    $types  .= 'i';
     $params[] = intval($usuario);
 }
+
 if ($rol !== '') {
-    $sql .= " AND u.rol = ?";
-    $types .= 's';
+    $sql    .= " AND u.rol = ?";
+    $types  .= 's';
     $params[] = $rol;
 }
 
 $sql .= " ORDER BY l.fecha DESC, l.hora DESC";
 $stmt = $conn->prepare($sql);
-if ($types) {
-    $stmt->bind_param($types, ...$params);
-}
+$stmt->bind_param($types, ...$params);
 $stmt->execute();
 $result = $stmt->get_result();
 
@@ -55,6 +69,32 @@ $logs = [];
 while ($row = $result->fetch_assoc()) {
     $logs[] = $row;
 }
+$stmt->close();
 
-echo json_encode(["success" => true, "logs" => $logs]);
+$usuariosSql = "SELECT DISTINCT u.id_usuario, CONCAT(u.nombre, ' ', u.apellido) AS nombre, u.rol
+        FROM usuario u
+        WHERE u.id_usuario IN (
+            SELECT usuario_creador FROM empresa WHERE id_empresa = ?
+            UNION
+            SELECT id_usuario FROM usuario_empresa WHERE id_empresa = ?
+        )
+        ORDER BY nombre";
+
+$usuariosStmt = $conn->prepare($usuariosSql);
+$usuariosStmt->bind_param('ii', $empresaId, $empresaId);
+$usuariosStmt->execute();
+$usuariosResult = $usuariosStmt->get_result();
+
+$usuarios = [];
+while ($user = $usuariosResult->fetch_assoc()) {
+    $usuarios[] = $user;
+}
+
+$usuariosStmt->close();
 $conn->close();
+
+echo json_encode([
+    "success"  => true,
+    "logs"     => $logs,
+    "usuarios" => $usuarios
+]);


### PR DESCRIPTION
## Summary
- reemplazar el filtro de usuario por un selector y persistir los filtros y resultados del log en localStorage para que no se vacíen al recargar
- actualizar el cliente del log para enviar el id de la empresa, rellenar el selector de usuarios y reutilizar los datos guardados mientras llegan nuevos registros
- ajustar el servicio PHP para filtrar el log por empresa y devolver los usuarios asociados a esa empresa

## Testing
- php -l scripts/php/get_logs.php


------
https://chatgpt.com/codex/tasks/task_e_68c85d7d5cc0832ca0662c2d0e1d69a8