### PR TITLE
Ensure all user actions are recorded in log_control

### DIFF
--- a/scripts/php/cancel_subscription.php
+++ b/scripts/php/cancel_subscription.php
@@ -1,6 +1,14 @@
 <?php
 header('Content-Type: application/json');
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+require_once __DIR__ . '/log_utils.php';
+
+$usuarioId = obtenerUsuarioIdSesion();
+if (!$usuarioId) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'message' => 'Sesión no válida']);
+    exit;
+}
 
 $servername = "localhost";
 $db_user    = "u296155119_Admin";
@@ -27,6 +35,7 @@ try {
     $stmt->execute();
 
     if ($stmt->affected_rows > 0) {
+        registrarLog($conn, $usuarioId, 'Suscripciones', "Cancelación de suscripción para la empresa {$id_empresa}");
         echo json_encode(['success' => true]);
     } else {
         echo json_encode(['success' => false, 'message' => 'No se encontró suscripción activa']);
@@ -34,3 +43,4 @@ try {
 } catch (Exception $e) {
     echo json_encode(['success' => false, 'message' => 'Error: ' . $e->getMessage()]);
 }
+

--- a/scripts/php/guardar_configuracion_empresa.php
+++ b/scripts/php/guardar_configuracion_empresa.php
@@ -4,6 +4,15 @@ header("Content-Type: application/json");
 ini_set('display_errors', 1);
 error_reporting(E_ALL);
 
+require_once __DIR__ . '/log_utils.php';
+
+$usuarioId = obtenerUsuarioIdSesion();
+if (!$usuarioId) {
+    http_response_code(401);
+    echo json_encode(["success" => false, "message" => "Sesión no válida"]);
+    exit;
+}
+
 $servername = "localhost";
 $db_user    = "u296155119_Admin";
 $db_pass    = "4Dmin123o";
@@ -38,9 +47,11 @@ if (!$stmt) {
 $stmt->bind_param("isss", $id_empresa, $colorSidebar, $colorTopbar, $ordenSidebar);
 
 if ($stmt->execute()) {
+    registrarLog($conn, $usuarioId, 'Configuración', "Actualización de configuración para empresa {$id_empresa}");
     echo json_encode(["success" => true]);
 } else {
     echo json_encode(["success" => false, "message" => "Error al ejecutar: " . $stmt->error]);
 }
 
 ?>
+

--- a/scripts/php/log_utils.php
+++ b/scripts/php/log_utils.php
@@ -1,21 +1,68 @@
 <?php
 /**
+ * Devuelve el identificador del usuario autenticado en sesión.
+ *
+ * @return int|null
+ */
+function obtenerUsuarioIdSesion()
+{
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
+
+    return isset($_SESSION['usuario_id']) ? (int) $_SESSION['usuario_id'] : null;
+}
+
+/**
  * Inserta un registro en la tabla log_control.
  *
- * @param mysqli $conn       Conexión activa a la BD.
- * @param int    $idUsuario  ID del usuario que realizó la acción.
- * @param string $modulo     Nombre del módulo (e.g. "Áreas", "Zonas", "Inventario").
- * @param string $accion     Descripción corta de la acción realizada.
+ * @param mysqli     $conn      Conexión activa a la BD.
+ * @param int|null   $idUsuario ID del usuario que realizó la acción. Si es null, se usa la sesión actual.
+ * @param string     $modulo    Nombre del módulo (e.g. "Áreas", "Zonas", "Inventario").
+ * @param string     $accion    Descripción corta de la acción realizada.
+ *
+ * @return bool Verdadero si el registro se insertó correctamente.
  */
-function registrarLog($conn, $idUsuario, $modulo, $accion) {
-    if (!$idUsuario) {
-        return; // sin usuario no se registra
+function registrarLog($conn, $idUsuario, $modulo, $accion)
+{
+    if (!($conn instanceof mysqli)) {
+        return false;
     }
+
+    if (!$idUsuario) {
+        $idUsuario = obtenerUsuarioIdSesion();
+    }
+
+    if (!$idUsuario) {
+        error_log('registrarLog: no se encontró usuario para registrar la acción: ' . $accion);
+        return false;
+    }
+
     $stmt = $conn->prepare(
-        "INSERT INTO log_control (id_usuario, modulo, accion, fecha, hora) VALUES (?, ?, ?, CURDATE(), CURTIME())"
+        'INSERT INTO log_control (id_usuario, modulo, accion, fecha, hora) VALUES (?, ?, ?, CURDATE(), CURTIME())'
     );
-    $stmt->bind_param("iss", $idUsuario, $modulo, $accion);
-    $stmt->execute();
+
+    if (!$stmt) {
+        error_log('registrarLog: error en prepare: ' . $conn->error);
+        return false;
+    }
+
+    $stmt->bind_param('iss', $idUsuario, $modulo, $accion);
+
+    $ok = false;
+
+    try {
+        $ok = $stmt->execute();
+        if (!$ok) {
+            error_log('registrarLog: error en execute: ' . $stmt->error);
+        }
+    } catch (mysqli_sql_exception $e) {
+        error_log('registrarLog: excepción: ' . $e->getMessage());
+        $ok = false;
+    }
+
     $stmt->close();
+
+    return $ok;
 }
 ?>

--- a/scripts/php/movimiento.php
+++ b/scripts/php/movimiento.php
@@ -2,6 +2,15 @@
 header('Content-Type: application/json');
 ini_set('display_errors',1); error_reporting(E_ALL);
 
+require_once __DIR__ . '/log_utils.php';
+
+$usuarioId = obtenerUsuarioIdSesion();
+if (!$usuarioId) {
+  http_response_code(401);
+  echo json_encode(['error'=>'Sesión expirada']);
+  exit;
+}
+
 // 1) Conexión
 $conn = new mysqli("localhost","u296155119_Admin","4Dmin123o","u296155119_OptiStock");
 if($conn->connect_error){
@@ -48,5 +57,8 @@ if(!$stmt->execute()){
   exit;
 }
 
+registrarLog($conn, $usuarioId, 'Inventario', ucfirst($tipo) . " manual de {$cantidad} unidad(es) del producto {$producto_id}");
+
 // 7) Responder éxito
 echo json_encode(['success'=>true]);
+

--- a/scripts/php/pass_recuperar.php
+++ b/scripts/php/pass_recuperar.php
@@ -4,6 +4,8 @@ ini_set('display_errors', 1);
 error_reporting(E_ALL);
 session_start(); // Muy importante para usar $_SESSION
 
+require_once __DIR__ . '/log_utils.php';
+
 $response = ["success" => false, "message" => ""];
 
 try {
@@ -31,6 +33,9 @@ try {
         throw new Exception("El correo no está registrado.");
     }
 
+    $usuario = $result->fetch_assoc();
+    $userId = (int) $usuario['id_usuario'];
+
     // Generar código de 6 dígitos
     $codigo = mt_rand(100000, 999999);
 
@@ -47,6 +52,8 @@ try {
         throw new Exception("Error al enviar el correo de recuperación.");
     }
 
+    registrarLog($conn, $userId, 'Usuarios', 'Solicitud de código de recuperación de contraseña');
+
     $response["success"] = true;
     $response["message"] = "El código de recuperación ha sido enviado a tu correo.";
 
@@ -57,3 +64,4 @@ try {
     echo json_encode($response);
 }
 ?>
+

--- a/scripts/php/regist_google.php
+++ b/scripts/php/regist_google.php
@@ -1,36 +1,43 @@
 <?php
-// Conexión a la base de datos
+require_once __DIR__ . '/log_utils.php';
+
 $servername = "localhost";
 $db_user    = "u296155119_Admin";
 $db_pass    = "4Dmin123o";
 $database   = "u296155119_OptiStock";
 $conn = mysqli_connect($servername, $db_user, $db_pass, $database);
 
-// Verificar conexión
 if (!$conn) {
     echo json_encode(["success" => false, "message" => "Error de conexión a la base de datos."]);
     exit;
 }
 
-// Obtener los datos del formulario
 $correo = $_POST['correo'];
 $nombre = $_POST['nombre'];
 $apellido = $_POST['apellido'];
 $fecha_nacimiento = $_POST['fecha_nacimiento'];
 $telefono = $_POST['telefono'];
 
-// Validación simple
 if (!$correo || !$fecha_nacimiento || !$telefono || !$nombre) {
     die("Faltan datos");
 }
 
 $stmt = $conn->prepare("UPDATE usuario SET nombre = ?, apellido = ?, fecha_nacimiento = ?, telefono = ? WHERE correo = ?");
-$stmt->bind_param("sssss",$nombre, $apellido, $fecha_nacimiento, $telefono, $correo);
+$stmt->bind_param("sssss", $nombre, $apellido, $fecha_nacimiento, $telefono, $correo);
 
 if ($stmt->execute()) {
+    $stmtUser = $conn->prepare("SELECT id_usuario FROM usuario WHERE correo = ?");
+    $stmtUser->bind_param('s', $correo);
+    $stmtUser->execute();
+    $resUser = $stmtUser->get_result();
+    if ($resUser && $resUser->num_rows > 0) {
+        $user = $resUser->fetch_assoc();
+        registrarLog($conn, (int) $user['id_usuario'], 'Usuarios', 'Actualización de datos por registro con Google');
+    }
+
     header("Location: ../../pages/regis_login/login/login.html?msg=created");
     exit;
-} else {
-    echo "Error al guardar los datos.";
 }
-?>
+
+echo "Error al guardar los datos.";
+

--- a/scripts/php/registro_empresa.php
+++ b/scripts/php/registro_empresa.php
@@ -3,6 +3,8 @@ ini_set('display_errors', 1);
 error_reporting(E_ALL);
 header('Content-Type: application/json');
 
+require_once __DIR__ . '/log_utils.php';
+
 $servername = "localhost";
 $db_user    = "u296155119_Admin";
 $db_pass    = "4Dmin123o";
@@ -49,6 +51,7 @@ $stmt = mysqli_prepare($conn, $sql);
 mysqli_stmt_bind_param($stmt, "sssi", $nombre_empresa, $logo_empresa, $sector_empresa, $usuario_creador);
 
 if (mysqli_stmt_execute($stmt)) {
+    registrarLog($conn, (int) $usuario_creador, 'Empresas', "Registro de empresa: {$nombre_empresa}");
     echo json_encode(["success" => true, "logo_empresa" => $logo_empresa]);
 } else {
     echo json_encode(["success" => false, "message" => "Error: " . mysqli_error($conn)]);

--- a/scripts/php/resend_verificacion.php
+++ b/scripts/php/resend_verificacion.php
@@ -3,10 +3,11 @@ header('Content-Type: application/json');
 ini_set('display_errors', 1);
 error_reporting(E_ALL);
 
-$response = ["success" => false, "message" => ""]; // Respuesta inicial
+require_once __DIR__ . '/log_utils.php';
+
+$response = ["success" => false, "message" => ""];
 
 try {
-    // Leer datos del cliente
     $data = json_decode(file_get_contents("php://input"), true);
     $email = $data['email'] ?? null;
 
@@ -14,15 +15,34 @@ try {
         throw new Exception("Correo no proporcionado.");
     }
 
-    // Generar un nuevo código de verificación
+    $servername = "localhost";
+    $db_user    = "u296155119_Admin";
+    $db_pass    = "4Dmin123o";
+    $database   = "u296155119_OptiStock";
+
+    $conn = mysqli_connect($servername, $db_user, $db_pass, $database);
+    if (!$conn) {
+        throw new Exception('Error de conexión a la base de datos.');
+    }
+
+    $stmt = $conn->prepare("SELECT id_usuario FROM usuario WHERE correo = ?");
+    $stmt->bind_param('s', $email);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    if ($result->num_rows === 0) {
+        throw new Exception('El correo no está registrado.');
+    }
+    $usuario = $result->fetch_assoc();
+    $userId = (int) $usuario['id_usuario'];
+
     $codigo_verificacion = mt_rand(100000, 999999);
 
-    // Guardar el código en la sesión
-    session_start();
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
     $_SESSION['codigo_verificacion'] = $codigo_verificacion;
     $_SESSION['correo_verificacion'] = $email;
 
-    // Enviar el correo
     $mail_subject = "OPTISTOCK - Reenvío de Código de Verificación";
     $mail_message = "Hola de nuevo. tu código de verificación es: $codigo_verificacion";
     $mail_headers = "From: no-reply@optistock.site";
@@ -31,14 +51,14 @@ try {
         throw new Exception("Error al enviar el correo de verificación.");
     }
 
-    // Respuesta de éxito
+    registrarLog($conn, $userId, 'Usuarios', 'Reenvío de código de verificación de cuenta');
+
     $response["success"] = true;
     $response["message"] = "El código de verificación ha sido reenviado.";
 } catch (Exception $e) {
-    // Capturar errores y enviar respuesta
     $response["success"] = false;
     $response["message"] = $e->getMessage();
 } finally {
     echo json_encode($response);
 }
-?>
+

--- a/scripts/php/reset_pass.php
+++ b/scripts/php/reset_pass.php
@@ -1,6 +1,8 @@
 <?php
 header('Content-Type: application/json');
-// Conexión a la base de datos
+
+require_once __DIR__ . '/log_utils.php';
+
 $servername = "localhost";
 $db_user    = "u296155119_Admin";
 $db_pass    = "4Dmin123o";
@@ -21,7 +23,6 @@ if (empty($token) || empty($newPassword)) {
     exit;
 }
 
-// Verificar el token
 $query = $conn->prepare("SELECT id_usuario FROM pass_resets WHERE token = ? AND expira > NOW()");
 $query->bind_param("s", $token);
 $query->execute();
@@ -33,18 +34,19 @@ if ($result->num_rows === 0) {
 }
 
 $user = $result->fetch_assoc();
-$userId = $user['user_id'];
+$userId = (int) $user['id_usuario'];
 
-// Actualizar la contraseña
 $hashedPassword = password_hash($newPassword, PASSWORD_BCRYPT);
 $update = $conn->prepare("UPDATE usuario SET contrasena = ? WHERE id_usuario = ?");
 $update->bind_param("si", $hashedPassword, $userId);
 $update->execute();
 
-// Eliminar el token usado
 $delete = $conn->prepare("DELETE FROM pass_resets WHERE token = ?");
 $delete->bind_param("s", $token);
 $delete->execute();
 
+registrarLog($conn, $userId, 'Usuarios', 'Restablecimiento de contraseña mediante token');
+
 echo json_encode(['success' => true, 'message' => 'Contraseña restablecida con éxito.']);
-?>
+
+

--- a/scripts/php/update_configuracion.php
+++ b/scripts/php/update_configuracion.php
@@ -1,4 +1,13 @@
 <?php
+require_once __DIR__ . '/log_utils.php';
+
+$usuarioId = obtenerUsuarioIdSesion();
+if (!$usuarioId) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'message' => 'Sesión no válida']);
+    exit;
+}
+
 $servername = "localhost";
 $db_user    = "u296155119_Admin";
 $db_pass    = "4Dmin123o";
@@ -33,6 +42,7 @@ try {
     $stmt->execute();
 
     if ($stmt->affected_rows > 0) {
+        registrarLog($conn, $usuarioId, 'Configuración', "Actualización de configuración para empresa {$id_empresa}");
         echo json_encode(['success' => true, 'message' => 'Configuración actualizada']);
     } else {
         echo json_encode(['success' => false, 'message' => 'No se actualizó ningún dato']);
@@ -40,3 +50,4 @@ try {
 } catch (Exception $e) {
     echo json_encode(['success' => false, 'message' => 'Error: '.$e->getMessage()]);
 }
+

--- a/scripts/php/update_empresa.php
+++ b/scripts/php/update_empresa.php
@@ -3,6 +3,15 @@ ini_set('display_errors', 1);
 error_reporting(E_ALL);
 header('Content-Type: application/json');
 
+require_once __DIR__ . '/log_utils.php';
+
+$usuarioId = obtenerUsuarioIdSesion();
+if (!$usuarioId) {
+    http_response_code(401);
+    echo json_encode(["success" => false, "message" => "Sesión no válida"]);
+    exit;
+}
+
 $servername = "localhost";
 $db_user    = "u296155119_Admin";
 $db_pass    = "4Dmin123o";
@@ -59,8 +68,10 @@ $stmt->execute();
 if ($stmt->affected_rows > 0) {
     $resp = ["success" => true, "message" => "Empresa actualizada"];
     if ($logo_empresa !== $logo_actual) $resp["logo_empresa"] = $logo_empresa;
+    registrarLog($conn, $usuarioId, 'Empresas', "Actualización de empresa ID: {$id_empresa}");
     echo json_encode($resp);
 } else {
     echo json_encode(["success" => false, "message" => "No se actualizó ningún dato"]);
 }
 ?>
+

--- a/scripts/php/update_subscription_plan.php
+++ b/scripts/php/update_subscription_plan.php
@@ -2,6 +2,17 @@
 header('Content-Type: application/json');
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
+$method = $_SERVER['REQUEST_METHOD'];
+
+require_once __DIR__ . '/log_utils.php';
+
+$usuarioId = obtenerUsuarioIdSesion();
+if (!$usuarioId) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'message' => 'Sesión no válida']);
+    exit;
+}
+
 $servername = "localhost";
 $db_user    = "u296155119_Admin";
 $db_pass    = "4Dmin123o";
@@ -29,6 +40,7 @@ try {
     $stmt->execute();
 
     if ($stmt->affected_rows > 0) {
+        registrarLog($conn, $usuarioId, 'Suscripciones', "Actualización de plan a {$plan} para empresa {$id_empresa}");
         echo json_encode(['success' => true]);
     } else {
         echo json_encode(['success' => false, 'message' => 'No se pudo actualizar']);
@@ -36,3 +48,4 @@ try {
 } catch (Exception $e) {
     echo json_encode(['success' => false, 'message' => 'Error: ' . $e->getMessage()]);
 }
+

--- a/scripts/php/update_user.php
+++ b/scripts/php/update_user.php
@@ -14,6 +14,13 @@ if (!$conn) {
 
 require_once __DIR__ . '/log_utils.php';
 
+$usuarioAccionId = obtenerUsuarioIdSesion();
+if (!$usuarioAccionId) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'message' => 'Sesión no válida']);
+    exit;
+}
+
 $usuario_id = $_POST['id_usuario'] ?? null;
 $nombre     = $_POST['nombre'] ?? null;
 $apellido   = $_POST['apellido'] ?? null;
@@ -63,7 +70,7 @@ try {
     $row = $res3->fetch_assoc();
     $ruta_foto = $row ? $row['foto_perfil'] : null;
 
-    registrarLog($conn, $_SESSION['usuario_id'] ?? 0, 'Usuarios', "Actualización de usuario: $usuario_id");
+    registrarLog($conn, $usuarioAccionId, 'Usuarios', "Actualización de usuario: $usuario_id");
 
     echo json_encode([
         'success' => true,

--- a/scripts/php/upload_profile_picture.php
+++ b/scripts/php/upload_profile_picture.php
@@ -3,6 +3,15 @@ ini_set('display_errors', 1);
 error_reporting(E_ALL);
 header('Content-Type: application/json');
 
+require_once __DIR__ . '/log_utils.php';
+
+$usuarioIdSesion = obtenerUsuarioIdSesion();
+if (!$usuarioIdSesion) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'message' => 'Sesión no válida']);
+    exit;
+}
+
 $servername = "localhost";
 $db_user    = "u296155119_Admin";
 $db_pass    = "4Dmin123o";
@@ -25,7 +34,6 @@ if (!is_dir($destDir)) {
     mkdir($destDir, 0755, true);
 }
 
-// Validar extensión
 $allowed = ['jpg', 'jpeg', 'png', 'gif'];
 $ext = strtolower(pathinfo($_FILES['foto_perfil']['name'], PATHINFO_EXTENSION));
 if (!in_array($ext, $allowed)) {
@@ -33,7 +41,6 @@ if (!in_array($ext, $allowed)) {
     exit;
 }
 
-// Renombrar archivo
 $filename = 'perfil_' . $usuario_id . '_' . time() . '.' . $ext;
 $path = $destDir . $filename;
 
@@ -48,8 +55,9 @@ $stmt->bind_param('si', $ruta_bd, $usuario_id);
 $stmt->execute();
 
 if ($stmt->affected_rows > 0) {
+    registrarLog($conn, $usuarioIdSesion, 'Usuarios', "Actualización de foto de perfil para usuario {$usuario_id}");
     echo json_encode(['success' => true, 'foto' => $ruta_bd]);
 } else {
     echo json_encode(['success' => false, 'message' => 'No se actualizó la foto']);
 }
-?>
+

--- a/scripts/php/verificacion.php
+++ b/scripts/php/verificacion.php
@@ -1,50 +1,60 @@
 <?php
-session_start(); // Iniciar la sesión
+session_start();
+header('Content-Type: application/json');
+
+require_once __DIR__ . '/log_utils.php';
 
 $data = json_decode(file_get_contents("php://input"), true);
 
-if (isset($data['email']) && isset($data['code'])) {
-    $email = $data['email'];
-    $code = $data['code'];
-
-    // Verificar si el código ingresado es correcto y si el correo coincide con el guardado en la sesión
-    if (isset($_SESSION['codigo_verificacion']) && $_SESSION['codigo_verificacion'] == $code && $_SESSION['correo_verificacion'] == $email) {
-        // El código es correcto, procedemos a marcar la cuenta como verificada
-
-        // Conectarse a la base de datos
-        $servername = "localhost"; // Host de la BD
-        $db_user    = "u296155119_Admin";  // Usuario de la base de datos
-        $db_pass    = "4Dmin123o"; // Contraseña de la base de datos
-        $database   = "u296155119_OptiStock";   // Nombre de la base de datos
-
-        $conn = mysqli_connect($servername, $db_user, $db_pass, $database);
-        if (!$conn) {
-            die("Error de conexión: " . mysqli_connect_error());
-        }
-
-        // 1. Actualizar la verificación de la cuenta en la base de datos
-        $sql = "UPDATE usuario SET verificacion_cuenta = 1 WHERE correo = ?";
-        
-        $stmt = mysqli_prepare($conn, $sql);
-        mysqli_stmt_bind_param($stmt, "s", $email);
-
-        if (mysqli_stmt_execute($stmt)) {
-            // Si la actualización es exitosa, devolver éxito
-            echo json_encode(["success" => true, "message" => "Tu cuenta ha sido verificada exitosamente."]);
-        } else {
-            echo json_encode(["success" => false, "message" => "Error al verificar la cuenta."]);
-        }
-
-        // Limpiar la sesión para que el código no quede almacenado
-        unset($_SESSION['codigo_verificacion']);
-        unset($_SESSION['correo_verificacion']);
-
-        // Cerrar la conexión
-        mysqli_close($conn);
-    } else {
-        echo json_encode(["success" => false, "message" => "El código de verificación es incorrecto o ha expirado."]);
-    }
-} else {
+if (!isset($data['email'], $data['code'])) {
     echo json_encode(["success" => false, "message" => "Datos no válidos."]);
+    exit;
 }
-?>
+
+$email = $data['email'];
+$code  = $data['code'];
+
+if (!isset($_SESSION['codigo_verificacion'], $_SESSION['correo_verificacion']) ||
+    $_SESSION['codigo_verificacion'] != $code ||
+    $_SESSION['correo_verificacion'] !== $email) {
+    echo json_encode(["success" => false, "message" => "El código de verificación es incorrecto o ha expirado."]);
+    exit;
+}
+
+$servername = "localhost";
+$db_user    = "u296155119_Admin";
+$db_pass    = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+$conn = mysqli_connect($servername, $db_user, $db_pass, $database);
+if (!$conn) {
+    echo json_encode(["success" => false, "message" => "Error de conexión"]);
+    exit;
+}
+
+$stmtUsuario = $conn->prepare("SELECT id_usuario FROM usuario WHERE correo = ?");
+$stmtUsuario->bind_param('s', $email);
+$stmtUsuario->execute();
+$resultUsuario = $stmtUsuario->get_result();
+if ($resultUsuario->num_rows === 0) {
+    echo json_encode(["success" => false, "message" => "Usuario no encontrado."]);
+    exit;
+}
+$userRow = $resultUsuario->fetch_assoc();
+$userId = (int) $userRow['id_usuario'];
+
+$sql = "UPDATE usuario SET verificacion_cuenta = 1 WHERE correo = ?";
+$stmt = mysqli_prepare($conn, $sql);
+mysqli_stmt_bind_param($stmt, "s", $email);
+
+if (mysqli_stmt_execute($stmt)) {
+    unset($_SESSION['codigo_verificacion']);
+    unset($_SESSION['correo_verificacion']);
+
+    registrarLog($conn, $userId, 'Usuarios', 'Verificación de cuenta completada');
+
+    echo json_encode(["success" => true, "message" => "Tu cuenta ha sido verificada exitosamente."]);
+} else {
+    echo json_encode(["success" => false, "message" => "Error al verificar la cuenta."]);
+}
+

--- a/scripts/php/verificar_codigo_recuperacion.php
+++ b/scripts/php/verificar_codigo_recuperacion.php
@@ -4,6 +4,8 @@ header('Content-Type: application/json');
 ini_set('display_errors', 1);
 error_reporting(E_ALL);
 
+require_once __DIR__ . '/log_utils.php';
+
 $response = ["success" => false, "message" => ""];
 
 try {
@@ -14,12 +16,30 @@ try {
 
     $codigoIngresado = trim($input['codigo']);
 
-    if (!isset($_SESSION['codigo_recuperacion'])) {
+    if (!isset($_SESSION['codigo_recuperacion'], $_SESSION['correo_recuperacion'])) {
         throw new Exception("No hay código guardado en sesión.");
     }
 
     if ((string)$codigoIngresado !== (string)$_SESSION['codigo_recuperacion']) {
         throw new Exception("Código incorrecto.");
+    }
+
+    $servername = "localhost";
+    $db_user    = "u296155119_Admin";
+    $db_pass    = "4Dmin123o";
+    $database   = "u296155119_OptiStock";
+
+    $conn = mysqli_connect($servername, $db_user, $db_pass, $database);
+    if ($conn) {
+        $correo = $_SESSION['correo_recuperacion'];
+        $stmt = $conn->prepare("SELECT id_usuario FROM usuario WHERE correo = ?");
+        $stmt->bind_param('s', $correo);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        if ($result && $result->num_rows > 0) {
+            $row = $result->fetch_assoc();
+            registrarLog($conn, (int) $row['id_usuario'], 'Usuarios', 'Código de recuperación validado');
+        }
     }
 
     $response["success"] = true;
@@ -30,4 +50,4 @@ try {
 } finally {
     echo json_encode($response);
 }
-?>
+


### PR DESCRIPTION
## Summary
- add a session-aware logging helper with error handling to centralize inserts into `log_control`
- require authenticated sessions and log create/update/delete operations across inventory management endpoints (áreas, zonas, categorías, subcategorías, productos)
- capture audit events for configuration changes, subscription updates and the full password/verification recovery flow

## Testing
- `for f in "scripts/php/cambiar_contraseña.php" scripts/php/cancel_subscription.php scripts/php/guardar_areas.php scripts/php/guardar_categorias.php scripts/php/guardar_configuracion_empresa.php scripts/php/guardar_productos.php scripts/php/guardar_subcategorias.php scripts/php/guardar_zonas.php scripts/php/log_utils.php scripts/php/movimiento.php scripts/php/pass_recuperar.php scripts/php/regist_google.php scripts/php/registro_empresa.php scripts/php/resend_verificacion.php scripts/php/reset_pass.php scripts/php/update_configuracion.php scripts/php/update_empresa.php scripts/php/update_subscription_plan.php scripts/php/update_user.php scripts/php/upload_profile_picture.php scripts/php/verificacion.php scripts/php/verificar_codigo_recuperacion.php; do php -l "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_68c8757d9c2c832c9221b957e8fee392