### PR TITLE
Rediseñar la página de cuenta con estilo moderno

### DIFF
--- a/pages/account_suscrip/account_suscrip.html
+++ b/pages/account_suscrip/account_suscrip.html
@@ -1,195 +1,393 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8" />
   <title>Configuración de cuenta | OPTISTOCK</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  
-  <!-- Estilos -->
-  <link rel="stylesheet" href="../../styles/account_suscrip/account_suscrip.css">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  
-  <!-- Scripts Bootstrap -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+  />
+  <link rel="stylesheet" href="../../styles/account_suscrip/account_suscrip.css" />
 </head>
-
 <body>
-  <div class="container py-4">
-    <h2 class="mb-3">Configuración de cuenta</h2>
-    <div class="account-wrapper">
+  <div class="account-page container-fluid py-4 px-3 px-md-4">
+    <section class="page-header">
+      <span class="header-eyebrow">Centro de control</span>
+      <h1 class="header-title">Configuración de cuenta</h1>
+      <p class="header-description">
+        Administra los datos de tu perfil, la información empresarial y la suscripción
+        activa de OptiStock desde un panel con el mismo lenguaje visual de administración.
+      </p>
+
+      <div class="header-highlights">
+        <article class="highlight-card profile-card">
+          <div class="profile-card__meta">
+            <div class="profile-card__avatar">
+              <img
+                data-field-image="fotoPerfil"
+                src="/images/profile.jpg"
+                alt="Foto de perfil"
+                width="80"
+                height="80"
+              />
+            </div>
+            <div class="profile-card__info">
+              <span class="card-label">Usuario principal</span>
+              <strong class="card-title" data-field="nombreCompleto">—</strong>
+              <span class="card-subtitle" data-field="correoUsuario">—</span>
+              <span class="card-subtitle" data-field="telefonoUsuario">—</span>
+            </div>
+          </div>
+        </article>
+
+        <article class="highlight-card company-card">
+          <div class="company-card__meta">
+            <div class="company-card__logo">
+              <img
+                data-field-image="logoEmpresa"
+                src="/images/optistockLogo.png"
+                alt="Logo de la empresa"
+                width="56"
+                height="56"
+              />
+            </div>
+            <div class="company-card__info">
+              <span class="card-label">Empresa</span>
+              <strong class="card-title" data-field="nombreEmpresa">—</strong>
+              <span class="card-subtitle" data-field="sectorEmpresa">—</span>
+            </div>
+          </div>
+        </article>
+
+        <article class="highlight-card plan-card">
+          <span class="card-label">Suscripción</span>
+          <strong class="card-title" data-field="planActual">Gratuito</strong>
+          <ul class="plan-card__details">
+            <li>
+              <span>Renovación</span>
+              <strong data-field="fechaRenovacion">—</strong>
+            </li>
+            <li>
+              <span>Método de pago</span>
+              <strong data-field="metodoPago">—</strong>
+            </li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section class="account-panel">
       <nav class="account-menu">
+        <span class="menu-eyebrow">Secciones</span>
         <ul>
-          <li class="active" data-target="secUser">Perfil</li>
-          <li data-target="secEmpresa">Empresa</li>
-          <!-- <li data-target="secVisual">Diseño</li> -->
-          <li data-target="secSuscripcion">Suscripción</li>
+          <li class="active" data-target="secUser">
+            <span class="menu-icon" aria-hidden="true">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6">
+                <circle cx="12" cy="8" r="4"></circle>
+                <path d="M4 20c0-4 4-6 8-6s8 2 8 6"></path>
+              </svg>
+            </span>
+            <div class="menu-texts">
+              <span class="menu-title">Perfil</span>
+              <span class="menu-description">Datos personales y contacto</span>
+            </div>
+          </li>
+          <li data-target="secEmpresa">
+            <span class="menu-icon" aria-hidden="true">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6">
+                <path d="M4 21V5a1 1 0 0 1 1-1h5v17"></path>
+                <path d="M14 21V9h5a1 1 0 0 1 1 1v11"></path>
+                <path d="M4 10h6"></path>
+                <path d="M14 13h6"></path>
+              </svg>
+            </span>
+            <div class="menu-texts">
+              <span class="menu-title">Empresa</span>
+              <span class="menu-description">Datos fiscales y marca</span>
+            </div>
+          </li>
+          <li data-target="secSuscripcion">
+            <span class="menu-icon" aria-hidden="true">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6">
+                <path d="M4 7h16"></path>
+                <path d="M10 11h4"></path>
+                <rect x="3" y="5" width="18" height="14" rx="2"></rect>
+              </svg>
+            </span>
+            <div class="menu-texts">
+              <span class="menu-title">Suscripción</span>
+              <span class="menu-description">Plan y facturación</span>
+            </div>
+          </li>
+          <li data-target="secPlanes">
+            <span class="menu-icon" aria-hidden="true">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6">
+                <path d="M9 3h6l1 7H8l1-7z"></path>
+                <path d="M4 21h16l-1-11H5l-1 11z"></path>
+              </svg>
+            </span>
+            <div class="menu-texts">
+              <span class="menu-title">Beneficios</span>
+              <span class="menu-description">Comparativa de planes</span>
+            </div>
+          </li>
         </ul>
       </nav>
 
       <div class="account-content">
-        <!-- Sección Usuario -->
         <section id="secUser" class="account-section active">
-          <div class="d-flex justify-content-between align-items-center mb-3">
-            <span class="fw-bold">Información personal</span>
-            <button class="btn btn-outline-primary btn-sm" id="btnEditarUsuario">Editar</button>
+          <header class="section-header">
+            <span class="section-eyebrow">Perfil</span>
+            <h2 class="section-title">Información personal</h2>
+            <p class="section-description">
+              Mantén tus datos de contacto actualizados para personalizar la experiencia y facilitar la comunicación.
+            </p>
+          </header>
+
+          <div class="info-grid">
+            <article class="info-card">
+              <span class="info-label">Nombre completo</span>
+              <strong class="info-value" data-field="nombreCompleto">—</strong>
+            </article>
+            <article class="info-card">
+              <span class="info-label">Correo electrónico</span>
+              <strong class="info-value" data-field="correoUsuario">—</strong>
+            </article>
+            <article class="info-card">
+              <span class="info-label">Teléfono</span>
+              <strong class="info-value" data-field="telefonoUsuario">—</strong>
+            </article>
           </div>
-          <div class="row">
-            <div class="col-md-3 text-center">
-              <img id="fotoPerfil" class="img-thumbnail rounded-circle mb-2" width="120" height="120" src="/images/profile.jpg">
-            </div>
-            <div class="col-md-9">
-              <p><strong>Nombre:</strong> <span id="nombreCompleto"></span></p>
-              <p><strong>Correo:</strong> <span id="correoUsuario"></span></p>
-              <p><strong>Teléfono:</strong> <span id="telefonoUsuario"></span></p>
-            </div>
+
+          <div class="section-actions">
+            <button class="cta-pill" id="btnEditarUsuario">
+              <span class="cta-pill__icon" aria-hidden="true">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                  <path d="M13.5 5.5l5 5"></path>
+                  <path d="M4 21l2-7 9.5-9.5a2 2 0 0 1 2.8 0l1.2 1.2a2 2 0 0 1 0 2.8L9.9 18"></path>
+                </svg>
+              </span>
+              <span class="cta-pill__label">Editar información personal</span>
+            </button>
           </div>
         </section>
 
-        <!-- Sección Empresa -->
         <section id="secEmpresa" class="account-section">
-          <div class="d-flex justify-content-between align-items-center mb-3">
-            <span class="fw-bold">Información empresarial</span>
-            <button class="btn btn-outline-primary btn-sm" id="btnEditarEmpresa">Editar</button>
+          <header class="section-header">
+            <span class="section-eyebrow">Empresa</span>
+            <h2 class="section-title">Identidad corporativa</h2>
+            <p class="section-description">
+              Asegura que la información de tu empresa coincida con los datos fiscales y de comunicación utilizados en los reportes.
+            </p>
+          </header>
+
+          <div class="company-summary">
+            <div class="company-summary__logo">
+              <img
+                data-field-image="logoEmpresa"
+                src="/images/optistockLogo.png"
+                alt="Logo de la empresa"
+                width="72"
+                height="72"
+              />
+            </div>
+            <div class="company-summary__info">
+              <span class="info-label">Nombre comercial</span>
+              <strong class="info-value" data-field="nombreEmpresa">—</strong>
+              <span class="info-label">Sector</span>
+              <strong class="info-value" data-field="sectorEmpresa">—</strong>
+            </div>
           </div>
-          <p><strong>Nombre de empresa:</strong> <span id="nombreEmpresa"></span></p>
-          <p><strong>Sector:</strong> <span id="sectorEmpresa"></span></p>
-          <p><strong>Logo:</strong><br> <img id="logoEmpresa" height="60"></p>
+
+          <div class="section-actions">
+            <button class="cta-pill" id="btnEditarEmpresa">
+              <span class="cta-pill__icon" aria-hidden="true">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                  <path d="M12 20h9"></path>
+                  <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4 12.5-12.5z"></path>
+                </svg>
+              </span>
+              <span class="cta-pill__label">Actualizar datos empresariales</span>
+            </button>
+          </div>
         </section>
 
-        <!-- Sección Visual -->
-        <section id="secVisual" class="account-section">
-          <span class="fw-bold d-block mb-2">Personalización visual</span>
-          <label>Color Sidebar: <input type="color" id="colorSidebar" disabled></label>
-          <label class="ms-3">Color Topbar: <input type="color" id="colorTopbar" disabled></label>
-          <button class="btn btn-sm btn-primary ms-3" id="btnGuardarColores">Guardar</button>
-        </section>
-
-        <!-- Sección Suscripción -->
         <section id="secSuscripcion" class="account-section">
-          <span class="fw-bold d-block mb-2">Suscripción actual</span>
-          <p><strong>Plan:</strong> <span id="planActual">Gratuito</span></p>
-          <p><strong>Renovación:</strong> <span id="fechaRenovacion">-</span></p>
-          <p><strong>Método de pago:</strong> <span id="metodoPago">-</span></p>
-          <button class="btn btn-outline-success btn-sm" id="btnActualizarPlan">Actualizar plan</button>
-          <button class="btn btn-outline-danger btn-sm" id="btnCancelarSuscripcion">Cancelar suscripción</button>
+          <header class="section-header">
+            <span class="section-eyebrow">Suscripción</span>
+            <h2 class="section-title">Plan y facturación</h2>
+            <p class="section-description">
+              Revisa los detalles del plan activo, la fecha de renovación automática y el método de pago asociado a tu cuenta.
+            </p>
+          </header>
+
+          <div class="plan-overview">
+            <div>
+              <span class="info-label">Plan actual</span>
+              <strong class="info-value" data-field="planActual">Gratuito</strong>
+            </div>
+            <div>
+              <span class="info-label">Renovación</span>
+              <strong class="info-value" data-field="fechaRenovacion">—</strong>
+            </div>
+            <div>
+              <span class="info-label">Método de pago</span>
+              <strong class="info-value" data-field="metodoPago">—</strong>
+            </div>
+          </div>
+
+          <div class="section-actions section-actions--stack">
+            <button class="btn-chip" id="btnActualizarPlan">
+              <span class="btn-chip__icon" aria-hidden="true">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                  <path d="M4 4h16v4H4z"></path>
+                  <path d="M4 12h10v8H4z"></path>
+                  <path d="M18 12h2v8h-2z"></path>
+                </svg>
+              </span>
+              <span class="btn-chip__label">Actualizar plan</span>
+            </button>
+            <button class="btn-chip btn-chip--danger" id="btnCancelarSuscripcion">
+              <span class="btn-chip__icon" aria-hidden="true">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                  <path d="M18 6 6 18"></path>
+                  <path d="M6 6l12 12"></path>
+                </svg>
+              </span>
+              <span class="btn-chip__label">Cancelar suscripción</span>
+            </button>
+          </div>
         </section>
 
-        <!-- Sección Planes -->
         <section id="secPlanes" class="account-section">
-          <span class="fw-bold d-block mb-2">Beneficios por plan</span>
-          <table class="table table-bordered" id="tablaPlanes">
-            <thead>
-              <tr>
-                <th>Característica</th>
-                <th>Gratis</th>
-                <th>Pro</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>Usuarios incluidos</td>
-                <td>1</td>
-                <td>10</td>
-              </tr>
-              <tr>
-                <td>Soporte</td>
-                <td>Correo</td>
-                <td>Prioritario</td>
-              </tr>
-              <tr>
-                <td>Reportes</td>
-                <td>Básicos</td>
-                <td>Avanzados</td>
-              </tr>
-            </tbody>
-          </table>
+          <header class="section-header">
+            <span class="section-eyebrow">Comparativa</span>
+            <h2 class="section-title">Beneficios por plan</h2>
+            <p class="section-description">
+              Evalúa qué incluye cada modalidad para proyectar el crecimiento de tu operación sin perder el control de costos.
+            </p>
+          </header>
+
+          <div class="table-wrapper">
+            <table class="comparison-table" id="tablaPlanes">
+              <thead>
+                <tr>
+                  <th>Característica</th>
+                  <th>Gratis</th>
+                  <th>Pro</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Usuarios incluidos</td>
+                  <td>1</td>
+                  <td>10</td>
+                </tr>
+                <tr>
+                  <td>Soporte</td>
+                  <td>Correo</td>
+                  <td>Prioritario</td>
+                </tr>
+                <tr>
+                  <td>Reportes</td>
+                  <td>Básicos</td>
+                  <td>Avanzados</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
-    </div>
+    </section>
+  </div>
 
-    <!-- Comparativa adicional de planes -->
-    <div class="card mb-4">
-      <div class="card-header">Beneficios por plan</div>
-      <div class="card-body">
-        <table class="table table-bordered">
-          <thead>
-            <tr>
-              <th>Característica</th>
-              <th>Gratis</th>
-              <th>Pro</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>Usuarios incluidos</td>
-              <td>1</td>
-              <td>10</td>
-            </tr>
-            <tr>
-              <td>Soporte</td>
-              <td>Correo</td>
-              <td>Prioritario</td>
-            </tr>
-            <tr>
-              <td>Reportes</td>
-              <td>Básicos</td>
-              <td>Avanzados</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-
-    <!-- Modal Editar Usuario -->
-    <div class="modal fade" id="modalEditarUsuario" tabindex="-1">
-      <div class="modal-dialog">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title">Editar Información Personal</h5>
-            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-          </div>
-          <div class="modal-body">
-            <form id="formEditarUsuario" enctype="multipart/form-data">
-              <input type="hidden" id="usuarioId">
-              <div class="mb-2"><label>Nombre:</label><input type="text" class="form-control" id="inputNombre"></div>
-              <div class="mb-2"><label>Apellido:</label><input type="text" class="form-control" id="inputApellido"></div>
-              <div class="mb-2"><label>Correo:</label><input type="email" class="form-control" id="inputCorreo" readonly></div>
-              <div class="mb-2"><label>Teléfono:</label><input type="text" class="form-control" id="inputTelefono"></div>
-              <div class="mb-2"><label>Foto de perfil:</label><input type="file" class="form-control" id="inputFoto"></div>
-              <div class="mb-2"><label>Nueva Contraseña (opcional):</label><input type="password" class="form-control" id="inputContrasena"></div>
-            </form>
-          </div>
-          <div class="modal-footer">
-            <button class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-            <button class="btn btn-primary" id="btnGuardarCambiosUsuario">Guardar cambios</button>
-          </div>
+  <div class="modal fade" id="modalEditarUsuario" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Editar Información Personal</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
         </div>
-      </div>
-    </div>
-
-    <!-- Modal Editar Empresa -->
-    <div class="modal fade" id="modalEditarEmpresa" tabindex="-1">
-      <div class="modal-dialog">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title">Editar Información de Empresa</h5>
-            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-          </div>
-          <div class="modal-body">
-            <form id="formEditarEmpresa">
-              <div class="mb-2"><label>Nombre empresa:</label><input type="text" class="form-control" id="inputNombreEmpresa"></div>
-              <div class="mb-2"><label>Sector:</label><input type="text" class="form-control" id="inputSectorEmpresa"></div>
-              <div class="mb-2"><label>Logo de empresa:</label><input type="file" class="form-control" id="inputLogoEmpresaFile" accept="image/*"></div>            </form>
-          </div>
-          <div class="modal-footer">
-            <button class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-            <button class="btn btn-primary" id="btnGuardarCambiosEmpresa">Guardar cambios</button>
-          </div>
+        <div class="modal-body">
+          <form id="formEditarUsuario" enctype="multipart/form-data">
+            <input type="hidden" id="usuarioId" />
+            <div class="mb-2">
+              <label for="inputNombre" class="form-label">Nombre</label>
+              <input type="text" class="form-control" id="inputNombre" />
+            </div>
+            <div class="mb-2">
+              <label for="inputApellido" class="form-label">Apellido</label>
+              <input type="text" class="form-control" id="inputApellido" />
+            </div>
+            <div class="mb-2">
+              <label for="inputCorreo" class="form-label">Correo</label>
+              <input type="email" class="form-control" id="inputCorreo" readonly />
+            </div>
+            <div class="mb-2">
+              <label for="inputTelefono" class="form-label">Teléfono</label>
+              <input type="text" class="form-control" id="inputTelefono" />
+            </div>
+            <div class="mb-2">
+              <label for="inputFoto" class="form-label">Foto de perfil</label>
+              <input type="file" class="form-control" id="inputFoto" />
+            </div>
+            <div class="mb-2">
+              <label for="inputContrasena" class="form-label">Nueva contraseña (opcional)</label>
+              <input type="password" class="form-control" id="inputContrasena" />
+            </div>
+          </form>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button class="btn btn-primary" id="btnGuardarCambiosUsuario">Guardar cambios</button>
         </div>
       </div>
     </div>
   </div>
 
+  <div class="modal fade" id="modalEditarEmpresa" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Editar Información de Empresa</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+        </div>
+        <div class="modal-body">
+          <form id="formEditarEmpresa">
+            <div class="mb-2">
+              <label for="inputNombreEmpresa" class="form-label">Nombre de la empresa</label>
+              <input type="text" class="form-control" id="inputNombreEmpresa" />
+            </div>
+            <div class="mb-2">
+              <label for="inputSectorEmpresa" class="form-label">Sector</label>
+              <input type="text" class="form-control" id="inputSectorEmpresa" />
+            </div>
+            <div class="mb-2">
+              <label for="inputLogoEmpresaFile" class="form-label">Logo de empresa</label>
+              <input type="file" class="form-control" id="inputLogoEmpresaFile" accept="image/*" />
+            </div>
+          </form>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button class="btn btn-primary" id="btnGuardarCambiosEmpresa">Guardar cambios</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="../../scripts/account_suscrip/account_suscrip.js"></script>
 </body>
 </html>

--- a/scripts/account_suscrip/account_suscrip.js
+++ b/scripts/account_suscrip/account_suscrip.js
@@ -1,4 +1,7 @@
-// Gestion de cuenta y suscripción
+// Gestión de cuenta y suscripción
+
+const DEFAULT_PROFILE_IMG = '/images/profile.jpg';
+const DEFAULT_COMPANY_LOGO = '/images/optistockLogo.png';
 
 function getContrastingColor(hexColor) {
   const r = parseInt(hexColor.slice(1, 3), 16);
@@ -10,8 +13,33 @@ function getContrastingColor(hexColor) {
 
 async function obtenerDatosCuenta(id_usuario) {
   const res = await fetch(`/scripts/php/get_account_data.php?usuario_id=${id_usuario}`);
-  const data = await res.json();
-  return data;
+  return res.json();
+}
+
+function sanitizePath(path) {
+  if (!path) return '';
+  const normalized = path.replace(/\\/g, '/').trim();
+  if (normalized.startsWith('http')) return normalized;
+  return `/${normalized.replace(/^\/+/, '')}`;
+}
+
+function setTextContent(field, value, fallback = '—') {
+  const finalValue = value && `${value}`.trim() !== '' ? value : fallback;
+  document.querySelectorAll(`[data-field="${field}"]`).forEach((el) => {
+    el.textContent = finalValue;
+  });
+}
+
+function setImageContent(field, value, fallback) {
+  const src = value && `${value}`.trim() !== '' ? sanitizePath(value) : fallback;
+  if (!src) return;
+  document.querySelectorAll(`[data-field-image="${field}"]`).forEach((img) => {
+    img.src = src;
+  });
+}
+
+function firstAvailable(...values) {
+  return values.find((value) => value && `${value}`.trim() !== '');
 }
 
 function mainAccountSuscrip() {
@@ -25,20 +53,14 @@ function mainAccountSuscrip() {
     return;
   }
 
-  const nombreEl = document.getElementById('nombreCompleto');
-  const correoEl = document.getElementById('correoUsuario');
-  const telEl    = document.getElementById('telefonoUsuario');
-  const fotoEl   = document.getElementById('fotoPerfil');
-  const empNomEl = document.getElementById('nombreEmpresa');
-  const empSecEl = document.getElementById('sectorEmpresa');
-  const empLogo  = document.getElementById('logoEmpresa');
   const btnCancel = document.getElementById('btnCancelarSuscripcion');
 
-  async function cargar(){
+  async function cargar() {
     const data = await obtenerDatosCuenta(usuarioId);
-    console.log("Respuesta get_account_data:", data);
+    console.log('Respuesta get_account_data:', data);
 
-    if(data.success){
+    if (!data.success) return;
+
     const config = data.configuracion;
     if (config && config.color_topbar) {
       document.documentElement.style.setProperty('--topbar-color', config.color_topbar);
@@ -46,28 +68,52 @@ function mainAccountSuscrip() {
       document.documentElement.style.setProperty('--topbar-text-color', textColor);
     }
 
-    const u = data.usuario;
-    nombreEl.textContent = `${u.nombre} ${u.apellido}`;
-    correoEl.textContent = u.correo;
-    telEl.textContent = u.telefono || '';
-    fotoEl.src = u.foto_perfil ? `/${u.foto_perfil}` : '/images/profile.jpg';
+    const usuario = data.usuario || {};
+    const nombreCompleto = [usuario.nombre, usuario.apellido].filter(Boolean).join(' ').trim();
+    setTextContent('nombreCompleto', nombreCompleto, '—');
+    setTextContent('correoUsuario', usuario.correo, '—');
+    setTextContent('telefonoUsuario', usuario.telefono, '—');
+    const fotoPath = usuario.foto_perfil ? sanitizePath(usuario.foto_perfil) : DEFAULT_PROFILE_IMG;
+    setImageContent('fotoPerfil', fotoPath, DEFAULT_PROFILE_IMG);
 
-    // Actualiza localStorage con los datos más recientes
-    localStorage.setItem('usuario_nombre', `${u.nombre} ${u.apellido}`);
-    localStorage.setItem('usuario_email', u.correo);
-    localStorage.setItem('usuario_telefono', u.telefono || '');
-    localStorage.setItem('foto_perfil', u.foto_perfil || '');
+    localStorage.setItem('usuario_nombre', nombreCompleto || '');
+    localStorage.setItem('usuario_email', usuario.correo || '');
+    localStorage.setItem('usuario_telefono', usuario.telefono || '');
+    localStorage.setItem('foto_perfil', usuario.foto_perfil || '');
 
-    const e = data.empresa || {};
-    empNomEl.textContent = e.nombre_empresa || '';
-    empSecEl.textContent = e.sector_empresa || '';
-    if(e.logo_empresa){ empLogo.src = '/' + e.logo_empresa.replace(/^\/+/,''); }
+    const empresa = data.empresa || {};
+    setTextContent('nombreEmpresa', empresa.nombre_empresa, '—');
+    setTextContent('sectorEmpresa', empresa.sector_empresa, '—');
+    const logoPath = empresa.logo_empresa ? sanitizePath(empresa.logo_empresa) : DEFAULT_COMPANY_LOGO;
+    setImageContent('logoEmpresa', logoPath, DEFAULT_COMPANY_LOGO);
 
-    localStorage.setItem('empresa_nombre', e.nombre_empresa || '');
-    localStorage.setItem('empresa_sector', e.sector_empresa || '');
-    localStorage.setItem('logo_empresa', e.logo_empresa ? '/' + e.logo_empresa.replace(/^\/+/,'') : '');
+    localStorage.setItem('empresa_nombre', empresa.nombre_empresa || '');
+    localStorage.setItem('empresa_sector', empresa.sector_empresa || '');
+    localStorage.setItem('logo_empresa', empresa.logo_empresa ? sanitizePath(empresa.logo_empresa) : '');
+
+    const suscripcion = data.suscripcion || data.subscription || data.plan || {};
+    const planName = firstAvailable(
+      suscripcion.plan,
+      suscripcion.nombre_plan,
+      suscripcion.plan_actual,
+      suscripcion.nombre
+    );
+    const fechaRenovacion = firstAvailable(
+      suscripcion.renovacion,
+      suscripcion.fecha_renovacion,
+      suscripcion.fechaRenovacion,
+      suscripcion.renovacion_plan
+    );
+    const metodoPago = firstAvailable(
+      suscripcion.metodo_pago,
+      suscripcion.metodoPago,
+      suscripcion.metodo
+    );
+
+    setTextContent('planActual', planName, 'Gratuito');
+    setTextContent('fechaRenovacion', fechaRenovacion, '—');
+    setTextContent('metodoPago', metodoPago, '—');
   }
-}
 
   cargar();
 
@@ -75,7 +121,7 @@ function mainAccountSuscrip() {
   const modalUsuario = new bootstrap.Modal(document.getElementById('modalEditarUsuario'));
   document.getElementById('btnEditarUsuario').addEventListener('click', async () => {
     const d = await obtenerDatosCuenta(usuarioId);
-    if(d.success){
+    if (d.success) {
       const u = d.usuario;
       document.getElementById('inputNombre').value = u.nombre;
       document.getElementById('inputApellido').value = u.apellido;
@@ -87,148 +133,130 @@ function mainAccountSuscrip() {
   });
 
   document.getElementById('btnGuardarCambiosUsuario').addEventListener('click', async () => {
-  const formData = new FormData();
-  formData.append('id_usuario', usuarioId);
-  formData.append('nombre', document.getElementById('inputNombre').value);
-  formData.append('apellido', document.getElementById('inputApellido').value);
-  formData.append('telefono', document.getElementById('inputTelefono').value);
-  formData.append('correo', document.getElementById('inputCorreo').value);
-  formData.append('contrasena', document.getElementById('inputContrasena').value);
-  const file = document.getElementById('inputFoto').files[0];
-  if (file) formData.append('foto_perfil', file);
+    const formData = new FormData();
+    formData.append('id_usuario', usuarioId);
+    formData.append('nombre', document.getElementById('inputNombre').value);
+    formData.append('apellido', document.getElementById('inputApellido').value);
+    formData.append('telefono', document.getElementById('inputTelefono').value);
+    formData.append('correo', document.getElementById('inputCorreo').value);
+    formData.append('contrasena', document.getElementById('inputContrasena').value);
+    const file = document.getElementById('inputFoto').files[0];
+    if (file) formData.append('foto_perfil', file);
 
-  const resp = await fetch('/scripts/php/update_user.php', {
-    method: 'POST',
-    body: formData
-  }).then(r => r.json());
+    const resp = await fetch('/scripts/php/update_user.php', {
+      method: 'POST',
+      body: formData,
+    }).then((r) => r.json());
 
-  if(resp.success){
-  localStorage.setItem('usuario_nombre', formData.get('nombre') + ' ' + formData.get('apellido'));
-  localStorage.setItem('usuario_email', formData.get('correo'));
-  localStorage.setItem('usuario_telefono', formData.get('telefono'));
-  if(resp.foto_perfil){
-    localStorage.setItem('foto_perfil', resp.foto_perfil);
-  }
-  modalUsuario.hide();
-  location.reload();
-}else{
-    alert(resp.message || 'Error al actualizar usuario');
-  }
-});
+    if (resp.success) {
+      localStorage.setItem('usuario_nombre', `${formData.get('nombre')} ${formData.get('apellido')}`.trim());
+      localStorage.setItem('usuario_email', formData.get('correo'));
+      localStorage.setItem('usuario_telefono', formData.get('telefono'));
+      if (resp.foto_perfil) {
+        localStorage.setItem('foto_perfil', resp.foto_perfil);
+      }
+      modalUsuario.hide();
+      location.reload();
+    } else {
+      alert(resp.message || 'Error al actualizar usuario');
+    }
+  });
 
   // --- Editar empresa ---
   const modalEmpresa = new bootstrap.Modal(document.getElementById('modalEditarEmpresa'));
   document.getElementById('btnEditarEmpresa').addEventListener('click', async () => {
-  const d = await obtenerDatosCuenta(usuarioId);
-  if(d.success && d.empresa){
-    const e = d.empresa;
-    document.getElementById('inputNombreEmpresa').value = e.nombre_empresa || '';
-    document.getElementById('inputSectorEmpresa').value = e.sector_empresa || '';
-    // Solo limpiar el input file, no puedes asignar value
-    document.getElementById('inputLogoEmpresaFile').value = '';
-    modalEmpresa.show();
-  }
-});
-
-document.getElementById('btnGuardarCambiosEmpresa').addEventListener('click', async () => {
-  const formData = new FormData();
-  formData.append('id_empresa', idEmpresa);
-  formData.append('nombre_empresa', document.getElementById('inputNombreEmpresa').value);
-  formData.append('sector_empresa', document.getElementById('inputSectorEmpresa').value);
-  const file = document.getElementById('inputLogoEmpresaFile').files[0];
-  if (file) formData.append('logo_empresa', file);
-
-  const resp = await fetch('/scripts/php/update_empresa.php', {
-    method: 'POST',
-    body: formData
-  }).then(r=>r.json());
-
-  if(resp.success){
-    localStorage.setItem('empresa_nombre', formData.get('nombre_empresa'));
-    localStorage.setItem('empresa_sector', formData.get('sector_empresa'));
-    if (resp.logo_empresa) {
-      const logoPath = '/' + resp.logo_empresa.replace(/^\/+/,'');
-      localStorage.setItem('logo_empresa', logoPath);
-      empLogo.src = logoPath;
+    const d = await obtenerDatosCuenta(usuarioId);
+    if (d.success && d.empresa) {
+      const e = d.empresa;
+      document.getElementById('inputNombreEmpresa').value = e.nombre_empresa || '';
+      document.getElementById('inputSectorEmpresa').value = e.sector_empresa || '';
+      document.getElementById('inputLogoEmpresaFile').value = '';
+      modalEmpresa.show();
     }
-    modalEmpresa.hide();
-    location.reload();
-  }else{
-    alert(resp.message || 'Error al actualizar empresa');
-  }
-});
+  });
+
+  document.getElementById('btnGuardarCambiosEmpresa').addEventListener('click', async () => {
+    const formData = new FormData();
+    formData.append('id_empresa', idEmpresa);
+    formData.append('nombre_empresa', document.getElementById('inputNombreEmpresa').value);
+    formData.append('sector_empresa', document.getElementById('inputSectorEmpresa').value);
+    const file = document.getElementById('inputLogoEmpresaFile').files[0];
+    if (file) formData.append('logo_empresa', file);
+
+    const resp = await fetch('/scripts/php/update_empresa.php', {
+      method: 'POST',
+      body: formData,
+    }).then((r) => r.json());
+
+    if (resp.success) {
+      localStorage.setItem('empresa_nombre', formData.get('nombre_empresa'));
+      localStorage.setItem('empresa_sector', formData.get('sector_empresa'));
+      if (resp.logo_empresa) {
+        const logoPath = sanitizePath(resp.logo_empresa);
+        localStorage.setItem('logo_empresa', logoPath);
+        setImageContent('logoEmpresa', logoPath, DEFAULT_COMPANY_LOGO);
+      }
+      modalEmpresa.hide();
+      location.reload();
+    } else {
+      alert(resp.message || 'Error al actualizar empresa');
+    }
+  });
 
   // Actualizar plan
   const btnPlan = document.getElementById('btnActualizarPlan');
   btnPlan?.addEventListener('click', () => {
     const plan = prompt('Ingresa el nuevo plan (Pro, etc)');
-    if(plan){
+    if (plan) {
       const form = new URLSearchParams();
       form.append('id_empresa', idEmpresa);
       form.append('plan', plan);
-      fetch('/scripts/php/update_subscription_plan.php', { method:'POST', body: form })
-        .then(r=>r.json()).then(d=>{ if(d.success){ alert('Plan actualizado'); cargar(); } else { alert(d.message||'Error'); } });
+      fetch('/scripts/php/update_subscription_plan.php', { method: 'POST', body: form })
+        .then((r) => r.json())
+        .then((d) => {
+          if (d.success) {
+            alert('Plan actualizado');
+            cargar();
+          } else {
+            alert(d.message || 'Error');
+          }
+        });
     }
   });
 
   // Navegación lateral
   const menuItems = document.querySelectorAll('.account-menu li');
   const sections = document.querySelectorAll('.account-section');
-  menuItems.forEach(item => {
+  menuItems.forEach((item) => {
     item.addEventListener('click', () => {
-      menuItems.forEach(i => i.classList.remove('active'));
+      menuItems.forEach((i) => i.classList.remove('active'));
       item.classList.add('active');
       const target = item.getAttribute('data-target');
-      sections.forEach(sec => sec.classList.toggle('active', sec.id === target));
+      sections.forEach((sec) => sec.classList.toggle('active', sec.id === target));
     });
   });
 
   // Cancelar suscripción con doble confirmación
   if (btnCancel) {
     btnCancel.addEventListener('click', () => {
-      if (confirm('¿Seguro que deseas cancelar la suscripción?') &&
-          confirm('Confirma nuevamente para cancelar')) {
-        const idEmpresa = localStorage.getItem('id_empresa');
+      if (
+        confirm('¿Seguro que deseas cancelar la suscripción?') &&
+        confirm('Confirma nuevamente para cancelar')
+      ) {
+        const empresaId = localStorage.getItem('id_empresa');
         const form = new URLSearchParams();
-        form.append('id_empresa', idEmpresa);
+        form.append('id_empresa', empresaId);
         fetch('/scripts/php/cancel_subscription.php', {
           method: 'POST',
-          body: form
+          body: form,
         })
-          .then(res => res.json())
-          .then(data => {
-            if (data.success) {
+          .then((res) => res.json())
+          .then((response) => {
+            if (response.success) {
               alert('Suscripción cancelada');
               location.reload();
             } else {
-              alert(data.message || 'Error al cancelar');
-            }
-          });
-      }
-    });
-  }
-
-  // Actualizar plan de suscripción
-  const btnUpgrade = document.getElementById('btnActualizarPlan');
-  if (btnUpgrade) {
-    btnUpgrade.addEventListener('click', () => {
-      const nuevoPlan = prompt('Ingresa el nuevo plan (por ejemplo: Pro)');
-      if (nuevoPlan) {
-        const idEmpresa = localStorage.getItem('id_empresa');
-        const form = new URLSearchParams();
-        form.append('id_empresa', idEmpresa);
-        form.append('plan', nuevoPlan);
-        fetch('/scripts/php/update_subscription_plan.php', {
-          method: 'POST',
-          body: form
-        })
-          .then(res => res.json())
-          .then(data => {
-            if (data.success) {
-              alert('Plan actualizado');
-              location.reload();
-            } else {
-              alert(data.message || 'Error al actualizar plan');
+              alert(response.message || 'Error al cancelar');
             }
           });
       }
@@ -236,7 +264,6 @@ document.getElementById('btnGuardarCambiosEmpresa').addEventListener('click', as
   }
 }
 
-// Ejecutar el código principal según el estado del DOM
 if (document.readyState !== 'loading') {
   mainAccountSuscrip();
 } else {

--- a/styles/account_suscrip/account_suscrip.css
+++ b/styles/account_suscrip/account_suscrip.css
@@ -1,113 +1,571 @@
-body {
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background-color: #eef1f7;
-  color: #333;
+:root {
+  --page-bg: #f5f6fb;
+  --card-bg: #ffffff;
+  --border-color: #e7e9f5;
+  --text-color: #1f2937;
+  --muted-color: #6b7280;
+  --primary-color: #7056ff;
+  --primary-soft: rgba(112, 86, 255, 0.08);
+  --accent-color: #00c4cc;
+  --danger-color: #ff6b6b;
+  --shadow-soft: 0 18px 40px -28px rgba(14, 20, 56, 0.55);
+  --radius-md: 16px;
+  --radius-lg: 22px;
+  --font-main: 'Poppins', sans-serif;
+  --font-mono: 'JetBrains Mono', monospace;
 }
 
-.account-wrapper {
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--page-bg);
+  color: var(--text-color);
+  font-family: var(--font-main);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.account-page {
+  max-width: 1200px;
+  margin: 0 auto;
   display: flex;
-  gap: 20px;
-  margin-top: 20px;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.page-header {
+  position: relative;
+  background: linear-gradient(135deg, rgba(112, 86, 255, 0.08), rgba(0, 196, 204, 0.08));
+  border-radius: var(--radius-lg);
+  padding: 2rem clamp(1.5rem, 3vw, 2.5rem);
+  overflow: hidden;
+  border: 1px solid rgba(112, 86, 255, 0.12);
+  box-shadow: var(--shadow-soft);
+}
+
+.page-header::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 15% 15%, rgba(112, 86, 255, 0.24), transparent 60%);
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.header-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--primary-color);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  position: relative;
+  z-index: 1;
+}
+
+.header-title {
+  margin: 1rem 0 0.5rem;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  font-weight: 700;
+  color: #171f34;
+  position: relative;
+  z-index: 1;
+}
+
+.header-description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted-color);
+  max-width: 640px;
+  position: relative;
+  z-index: 1;
+}
+
+.header-highlights {
+  position: relative;
+  z-index: 1;
+  margin-top: 2rem;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.highlight-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(112, 86, 255, 0.18);
+  padding: 1.25rem 1.5rem;
+  backdrop-filter: blur(12px);
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+  box-shadow: 0 12px 32px -28px rgba(112, 86, 255, 0.9);
+}
+
+.profile-card__meta,
+.company-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.profile-card__avatar,
+.company-card__logo {
+  width: 68px;
+  height: 68px;
+  border-radius: 50%;
+  border: 3px solid rgba(112, 86, 255, 0.2);
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  background: rgba(112, 86, 255, 0.08);
+}
+
+.profile-card__avatar img,
+.company-card__logo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.card-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(112, 86, 255, 0.1);
+  color: var(--primary-color);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.card-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #1f2538;
+}
+
+.card-subtitle {
+  font-size: 0.85rem;
+  color: var(--muted-color);
+}
+
+.plan-card {
+  gap: 0.75rem;
+}
+
+.plan-card__details {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.plan-card__details li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(112, 86, 255, 0.08);
+  border-radius: 12px;
+  padding: 0.65rem 0.85rem;
+  font-size: 0.85rem;
+  color: var(--muted-color);
+}
+
+.plan-card__details strong {
+  font-size: 0.95rem;
+  color: #1f2538;
+}
+
+.account-panel {
+  display: grid;
+  grid-template-columns: minmax(220px, 260px) 1fr;
+  gap: 1.5rem;
+  align-items: start;
 }
 
 .account-menu {
-  width: 200px;
-  background: var(--topbar-color, linear-gradient(45deg, #6a11cb, #2575fc));
-  border-radius: 8px;
-  padding: 20px;
-  color: var(--topbar-text-color, #fff);
+  background: var(--card-bg);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color);
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  box-shadow: 0 12px 40px -30px rgba(18, 26, 69, 0.55);
+}
 
+.menu-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(112, 86, 255, 0.1);
+  color: var(--primary-color);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .account-menu ul {
   list-style: none;
+  margin: 1.2rem 0 0;
   padding: 0;
-  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 .account-menu li {
-  padding: 10px 15px;
-  margin-bottom: 5px;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+  padding: 0.9rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  color: var(--muted-color);
   cursor: pointer;
-  border-radius: 4px;
+  transition: background 0.2s ease, color 0.2s ease, border 0.2s ease, box-shadow 0.2s ease;
 }
 
-.account-menu li.active,
-.account-menu li:hover {
-  background: rgba(255, 255, 255, 0.2);
+.account-menu li:hover,
+.account-menu li.active {
+  background: var(--primary-soft);
+  color: var(--text-color);
+  border-color: rgba(112, 86, 255, 0.25);
+  box-shadow: 0 12px 30px -24px rgba(112, 86, 255, 0.7);
+}
+
+.account-menu li:hover .menu-icon,
+.account-menu li.active .menu-icon {
+  background: rgba(112, 86, 255, 0.15);
+  color: var(--primary-color);
+}
+
+.menu-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: rgba(112, 86, 255, 0.08);
+  color: var(--muted-color);
+  flex-shrink: 0;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.menu-title {
+  font-weight: 600;
+  color: #1f2538;
+  display: block;
+}
+
+.menu-description {
+  font-size: 0.8rem;
+  color: var(--muted-color);
 }
 
 .account-content {
-  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
 .account-section {
-  background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
-  padding: 20px;
-  margin-bottom: 20px;
+  background: var(--card-bg);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color);
+  padding: clamp(1.5rem, 3vw, 2rem);
+  box-shadow: 0 12px 40px -30px rgba(18, 26, 69, 0.55);
   display: none;
 }
 
 .account-section.active {
   display: block;
-
 }
 
-.account-menu ul {
-  list-style: none;
-  padding: 0;
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  margin-bottom: 1.5rem;
+}
+
+.section-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(112, 86, 255, 0.1);
+  color: var(--primary-color);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.section-title {
   margin: 0;
+  font-size: clamp(1.35rem, 3vw, 1.7rem);
+  font-weight: 600;
+  color: #1f2538;
 }
 
-.account-menu li {
-  padding: 10px 15px;
-  margin-bottom: 5px;
+.section-description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted-color);
+  max-width: 640px;
+}
+
+.info-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.info-card {
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+  background: var(--card-bg);
+  box-shadow: 0 16px 28px -26px rgba(17, 24, 67, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.info-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-color);
+  font-weight: 600;
+}
+
+.info-value {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #1f2538;
+  word-break: break-word;
+}
+
+.section-actions {
+  margin-top: 1.5rem;
+  display: flex;
+  justify-content: flex-start;
+}
+
+.section-actions--stack {
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.cta-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  border: none;
+  background: linear-gradient(135deg, var(--primary-color), #8a75ff);
+  color: #fff;
+  padding: 0.75rem 1.35rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
   cursor: pointer;
-  border-radius: 4px;
+  box-shadow: 0 18px 32px -26px rgba(112, 86, 255, 0.9);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.account-menu li.active,
-.account-menu li:hover {
-  background: rgba(255, 255, 255, 0.2);
+.cta-pill:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 42px -28px rgba(112, 86, 255, 0.9);
+  color: #fff;
 }
 
-.account-content {
-  flex-grow: 1;
+.cta-pill__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.18);
 }
 
-.account-section {
-  background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
-  padding: 20px;
-  margin-bottom: 20px;
-  display: none;
+.btn-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(112, 86, 255, 0.12);
+  color: var(--primary-color);
+  border: 1px solid rgba(112, 86, 255, 0.25);
+  border-radius: 999px;
+  padding: 0.65rem 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.account-section.active {
-  display: block;
+.btn-chip:hover {
+  background: rgba(112, 86, 255, 0.18);
+  box-shadow: 0 14px 28px -24px rgba(112, 86, 255, 0.8);
 }
 
-#tablaPlanes th,
-#tablaPlanes td {
+.btn-chip--danger {
+  background: rgba(255, 107, 107, 0.12);
+  border-color: rgba(255, 107, 107, 0.3);
+  color: #dc4c64;
+}
+
+.btn-chip--danger:hover {
+  background: rgba(255, 107, 107, 0.18);
+  box-shadow: 0 14px 28px -24px rgba(220, 76, 100, 0.8);
+}
+
+.btn-chip__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.plan-overview {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.company-summary {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.company-summary__logo {
+  width: 84px;
+  height: 84px;
+  border-radius: 22px;
+  background: rgba(112, 86, 255, 0.1);
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(112, 86, 255, 0.2);
+  overflow: hidden;
+}
+
+.company-summary__logo img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.company-summary__info {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 220px;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+}
+
+.comparison-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 420px;
+}
+
+.comparison-table thead {
+  background: rgba(112, 86, 255, 0.12);
+}
+
+.comparison-table th,
+.comparison-table td {
+  padding: 0.85rem 1rem;
   text-align: center;
-
+  border-bottom: 1px solid var(--border-color);
+  font-size: 0.95rem;
 }
 
-#tablaPlanes th,
-#tablaPlanes td {
-  text-align: center;
+.comparison-table th:first-child,
+.comparison-table td:first-child {
+  text-align: left;
 }
 
-@media (max-width: 768px) {
-  .account-wrapper {
-    flex-direction: column;
+.comparison-table tbody tr:nth-child(even) {
+  background: rgba(112, 86, 255, 0.04);
+}
+
+.modal-content {
+  border-radius: 18px;
+}
+
+.modal-header {
+  border-bottom: none;
+}
+
+.modal-footer {
+  border-top: none;
+}
+
+@media (max-width: 992px) {
+  .account-panel {
+    grid-template-columns: 1fr;
   }
 
   .account-menu {
+    position: sticky;
+    top: 1rem;
+    z-index: 10;
+  }
+}
+
+@media (max-width: 768px) {
+  .header-highlights {
+    grid-template-columns: 1fr;
+  }
+
+  .section-actions {
+    justify-content: stretch;
+  }
+
+  .cta-pill,
+  .btn-chip {
     width: 100%;
-    margin-bottom: 20px;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 576px) {
+  .account-page {
+    padding: 0 1rem 2rem;
+  }
+
+  .plan-card__details li {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.35rem;
   }
 }


### PR DESCRIPTION
## Resumen
- Rediseñé `account_suscrip.html` con cabecera hero, tarjetas de resumen y navegación lateral al estilo de los paneles de log y administración.
- Reemplacé por completo los estilos en `account_suscrip.css` para incorporar la nueva paleta, tarjetas y comportamiento responsivo.
- Actualicé `account_suscrip.js` para poblar varios elementos dinámicos mediante data attributes y para reutilizar imágenes y datos en el nuevo layout.

## Pruebas
- No se realizaron pruebas automatizadas (no se proporcionaron comandos).

------
https://chatgpt.com/codex/tasks/task_e_68c8b956abc8832c96661179d5c03726