### PR TITLE
Usar la zona horaria del navegador en los listados

### DIFF
--- a/pages/control_log/log.html
+++ b/pages/control_log/log.html
@@ -122,7 +122,7 @@
           <thead>
             <tr>
               <th scope="col">Fecha</th>
-              <th scope="col">Hora</th>
+              <th scope="col" id="timeHeader">Hora</th>
               <th scope="col">Usuario</th>
               <th scope="col">Rol</th>
               <th scope="col">Módulo</th>


### PR DESCRIPTION
## Summary
- detectar la zona horaria del navegador y generar una etiqueta corta con su desfase GMT como respaldo
- formatear las fechas y horas del log de control empleando la zona horaria detectada y actualizar los textos informativos
- ajustar el tablero principal para mostrar los accesos recientes en la zona horaria local del usuario y mantener tooltips coherentes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8c5f3b4b8832c8a9c94c3b8871cc1