### PR TITLE
Restyle inventory page to match control center UI

### DIFF
--- a/pages/gest_inve/inventario_basico.html
+++ b/pages/gest_inve/inventario_basico.html
@@ -1,177 +1,187 @@
 <!DOCTYPE html>
-<html lang="es" data-bs-theme="light">
+<html lang="es">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Inventario Básico — UI Moderna</title>
+  <title>Gestión de inventario | OptiStock</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
-<style>
-  :root{
-    --bg:#f7fafc; --card:#ffffff; --text:#0f172a; --muted:#475569;
-    --border:#e2e8f0; --primary:#2563eb; --success:#16a34a; --danger:#dc2626;
-    --radius: 1rem;
-  }
-  body { background: var(--bg); color: var(--text); }
-  .soft-card { background: var(--card); border: 1px solid var(--border); border-radius: var(--radius);
-               box-shadow: 0 10px 24px rgba(2,6,23,.06); transition: box-shadow .25s, transform .25s; }
-  .soft-card:hover{ transform: translateY(-2px); box-shadow: 0 16px 32px rgba(2,6,23,.08); }
-  .accordion-button { border-radius: .75rem !important; }
-  .accordion-body { background: #f9fafb; border-radius: .75rem; }
-  .btn-pill { border-radius: 999px; } .btn { transition: transform .15s, box-shadow .2s; }
-  .btn:active { transform: translateY(1px) scale(.99); }
-  .form-label { font-weight: 600; color: #334155; } .form-text { color: #64748b; }
-  .form-control,.form-select{ transition: box-shadow .2s,border-color .2s; }
-  .form-control:focus,.form-select:focus{ box-shadow: 0 0 0 .25rem rgba(37,99,235,.15); border-color: rgba(37,99,235,.35); }
-  .table { color: var(--text); }
-  .table thead th { color: #334155; border-bottom-color: rgba(2,6,23,.1); }
-  .table tbody td { border-top-color: rgba(2,6,23,.06); }
-  .chip{display:inline-flex;align-items:center;gap:.35rem;padding:.25rem .6rem;border-radius:999px;font-size:.75rem;
-        background: rgba(2, 6, 23, .06); border: 1px solid rgba(2, 6, 23, .08);}
-  .muted{color:var(--muted);} .subtle-sep{border-top:1px dashed rgba(2,6,23,.12);}
-  .toolbar{display:flex;gap:.5rem;flex-wrap:wrap;}
-  @media (max-width:576px){ .toolbar .btn{flex:1 1 auto;} header h1{font-size:1.125rem;} body{padding:.75rem !important;} }
-  @keyframes fadeSlideIn{from{opacity:0;transform:translateY(6px);}to{opacity:1;transform:none;}}
-  .animate-in{animation:fadeSlideIn .28s ease both;}
-  @media (prefers-reduced-motion:reduce){*{animation:none !important;transition:none !important;}}
-</style>
-
+  <link rel="stylesheet" href="../../styles/gest_inve/inventario_basico.css" />
 </head>
-<body class="p-3 p-md-4">
-  <header class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3 mb-md-4">
-    <h1 class="page-title h3 m-0">Inventario Básico</h1>
-    <div class="section-actions d-flex gap-2">
-      <button id="btnProductos" class="btn btn-sm btn-outline-primary btn-pill">Productos</button>
-      <button id="btnCategorias" class="btn btn-sm btn-outline-primary btn-pill">Categorías</button>
-      <button id="btnSubcategorias" class="btn btn-sm btn-outline-primary btn-pill">Subcategorías</button>
-      <button id="btnRecargarResumen" class="btn btn-outline-primary btn-pill">Recargar</button>
-      <button id="btnScanQR" class="btn btn-outline-success btn-pill">Escanear QR</button>
+<body>
+  <div class="inventory-page container-fluid py-4 px-3 px-md-4">
+    <section class="page-header">
+      <span class="header-eyebrow">Operaciones</span>
+      <h1 class="header-title">Gestión de inventario</h1>
+      <p class="header-description">
+        Supervisa productos, categorías y movimientos desde un panel que comparte el mismo estilo visual del centro de control de
+        OptiStock.
+      </p>
 
-    </div>
-  </header>
-
-  <!-- FORMULARIOS EN ACORDEÓN (DESPLEGABLES) -->
-  <section class="soft-card p-3 p-md-4 mb-4">
-    <div class="d-flex align-items-center justify-content-between flex-wrap gap-2 mb-3">
-      <div class="d-flex align-items-center gap-2">
-        <span class="chip"><span>⚙️</span><span>Gestión</span></span>
-        <span class="muted">Crea y edita entidades del inventario</span>
+      <div class="header-highlights">
+        <article class="highlight-card">
+          <span class="card-label">Productos activos</span>
+          <strong class="card-title" id="resumenProductos">0</strong>
+          <span class="card-subtitle">Registrados en la empresa</span>
+        </article>
+        <article class="highlight-card">
+          <span class="card-label">Categorías creadas</span>
+          <strong class="card-title" id="resumenCategorias">0</strong>
+          <span class="card-subtitle">Agrupan tu catálogo</span>
+        </article>
+        <article class="highlight-card">
+          <span class="card-label">Alertas de stock</span>
+          <strong class="card-title" id="resumenCriticos">0</strong>
+          <span class="card-subtitle">Productos por revisar</span>
+        </article>
       </div>
-    </div>
+    </section>
 
-    <div class="accordion" id="accGestion">
-      <!-- PRODUCTO -->
-      <div class="accordion-item">
-        <h2 class="accordion-header" id="hdrProducto">
-          <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#colProducto" aria-expanded="true" aria-controls="colProducto">
-            Nuevo producto
+    <section class="inventory-shell">
+      <div class="shell-header">
+        <div class="shell-header__info">
+          <span class="shell-eyebrow">Panel inteligente</span>
+          <h2 class="shell-title">Administra tus catálogos con el mismo lenguaje visual del centro de control.</h2>
+          <p class="shell-subtitle">
+            Cambia entre productos, categorías y subcategorías sin salir de la pantalla. Cada formulario conserva los campos
+            originales para mantener la compatibilidad con tus procesos.
+          </p>
+        </div>
+        <div class="shell-header__actions" role="tablist" aria-label="Secciones del inventario">
+          <button id="btnProductos" class="tab-chip active" type="button" role="tab" aria-selected="true">
+            <span class="tab-chip__title">Productos</span>
+            <span class="tab-chip__description">Catálogo general</span>
           </button>
-        </h2>
-        <div id="colProducto" class="accordion-collapse collapse show" aria-labelledby="hdrProducto" data-bs-parent="#accGestion">
-          <div class="accordion-body">
-            <form id="productoForm" class="gy-3">
-              <div class="row g-3">
-                <div class="col-lg-6">
-                  <label for="prodNombre" class="form-label">Nombre del producto</label>
-                  <input type="text" id="prodNombre" class="form-control" placeholder="Ej. Tornillo M4 x 20" required>
-                  <div class="form-text">Nombre visible en listados y reportes.</div>
-                </div>
-                <div class="col-4 col-lg-2">
-                  <label for="prodDimX" class="form-label">Dimensión X</label>
-                  <input type="number" id="prodDimX" class="form-control" placeholder="X" step="0.01" min="0">
-                </div>
-                <div class="col-4 col-lg-2">
-                  <label for="prodDimY" class="form-label">Dimensión Y</label>
-                  <input type="number" id="prodDimY" class="form-control" placeholder="Y" step="0.01" min="0">
-                </div>
-                <div class="col-4 col-lg-2">
-                  <label for="prodDimZ" class="form-label">Dimensión Z</label>
-                  <input type="number" id="prodDimZ" class="form-control" placeholder="Z" step="0.01" min="0">
-                </div>
-
-                <div class="col-md-6">
-                  <label for="prodCategoria" class="form-label">Categoría</label>
-                  <select id="prodCategoria" class="form-select">
-                    <option value="">Seleccione categoría</option>
-                  </select>
-                </div>
-                <div class="col-md-6">
-                  <label for="prodSubcategoria" class="form-label">Subcategoría</label>
-                  <select id="prodSubcategoria" class="form-select">
-                    <option value="">Seleccione subcategoría</option>
-                  </select>
-                </div>
-
-                <div class="col-md-6">
-                  <label for="prodZona" class="form-label">Zona de almacén</label>
-                  <select id="prodZona" class="form-select">
-                    <option value="">Seleccione zona</option>
-                  </select>
-                </div>
-
-                <div class="col-md-6">
-                  <label for="prodStock" class="form-label">Stock inicial</label>
-                  <input type="number" id="prodStock" class="form-control" placeholder="0" min="0">
-                </div>
-                <div class="col-md-6">
-                  <label for="prodPrecio" class="form-label">Precio de compra</label>
-                  <input type="number" id="prodPrecio" class="form-control" placeholder="0.00" min="0" step="0.01">
-                </div>
-
-                <div class="col-12">
-                  <label for="prodDescripcion" class="form-label">Descripción</label>
-                  <textarea id="prodDescripcion" class="form-control" rows="2" placeholder="Notas, materiales, especificaciones..."></textarea>
-                </div>
-                <div class="col-12">
-                  <label for="prodImagen" class="form-label">Imagen</label>
-                  <input type="file" id="prodImagen" class="form-control">
-                </div>
-              </div>
-              <div class="d-flex gap-2 mt-3">
-                <button type="submit" class="btn btn-success">Guardar producto</button>
-                <button type="reset" class="btn btn-outline-light">Limpiar</button>
-              </div>
-            </form>
-          </div>
+          <button id="btnCategorias" class="tab-chip" type="button" role="tab" aria-selected="false">
+            <span class="tab-chip__title">Categorías</span>
+            <span class="tab-chip__description">Organiza tu inventario</span>
+          </button>
+          <button id="btnSubcategorias" class="tab-chip" type="button" role="tab" aria-selected="false">
+            <span class="tab-chip__title">Subcategorías</span>
+            <span class="tab-chip__description">Detalla cada grupo</span>
+          </button>
         </div>
       </div>
 
-      <!-- CATEGORÍA -->
-      <div class="accordion-item mt-3">
-        <h2 class="accordion-header" id="hdrCategoria">
-          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#colCategoria" aria-expanded="false" aria-controls="colCategoria">
-            Nueva categoría
-          </button>
-        </h2>
-        <div id="colCategoria" class="accordion-collapse collapse" aria-labelledby="hdrCategoria" data-bs-parent="#accGestion">
-          <div class="accordion-body">
-            <form id="categoriaForm" class="row g-3">
+      <div class="inventory-card">
+        <section id="productoFormContainer" class="panel-card" aria-labelledby="btnProductos">
+          <header class="panel-header">
+            <span class="panel-eyebrow">Productos</span>
+            <h2 class="panel-title">Registrar nuevo producto</h2>
+            <p class="panel-description">
+              Define la información esencial de cada artículo, incluyendo medidas, categoría y zona de almacenamiento para
+              mantener tu inventario sincronizado.
+            </p>
+          </header>
+
+          <form id="productoForm" class="compact-form" novalidate>
+            <div class="row g-3">
+              <div class="col-lg-6">
+                <label for="prodNombre" class="form-label">Nombre del producto</label>
+                <input type="text" id="prodNombre" class="form-control" placeholder="Ej. Tornillo M4 x 20" required />
+                <div class="form-text">Nombre visible en listados y reportes.</div>
+              </div>
+              <div class="col-4 col-lg-2">
+                <label for="prodDimX" class="form-label">Dimensión X</label>
+                <input type="number" id="prodDimX" class="form-control" placeholder="X" step="0.01" min="0" />
+              </div>
+              <div class="col-4 col-lg-2">
+                <label for="prodDimY" class="form-label">Dimensión Y</label>
+                <input type="number" id="prodDimY" class="form-control" placeholder="Y" step="0.01" min="0" />
+              </div>
+              <div class="col-4 col-lg-2">
+                <label for="prodDimZ" class="form-label">Dimensión Z</label>
+                <input type="number" id="prodDimZ" class="form-control" placeholder="Z" step="0.01" min="0" />
+              </div>
+
+              <div class="col-md-6">
+                <label for="prodCategoria" class="form-label">Categoría</label>
+                <select id="prodCategoria" class="form-select">
+                  <option value="">Seleccione categoría</option>
+                </select>
+              </div>
+              <div class="col-md-6">
+                <label for="prodSubcategoria" class="form-label">Subcategoría</label>
+                <select id="prodSubcategoria" class="form-select">
+                  <option value="">Seleccione subcategoría</option>
+                </select>
+              </div>
+
+              <div class="col-md-6">
+                <label for="prodZona" class="form-label">Zona de almacén</label>
+                <select id="prodZona" class="form-select">
+                  <option value="">Seleccione zona</option>
+                </select>
+              </div>
+              <div class="col-md-6">
+                <label for="prodStock" class="form-label">Stock inicial</label>
+                <input type="number" id="prodStock" class="form-control" placeholder="0" min="0" />
+              </div>
+              <div class="col-md-6">
+                <label for="prodPrecio" class="form-label">Precio de compra</label>
+                <input type="number" id="prodPrecio" class="form-control" placeholder="0.00" min="0" step="0.01" />
+              </div>
+
+              <div class="col-12">
+                <label for="prodDescripcion" class="form-label">Descripción</label>
+                <textarea id="prodDescripcion" class="form-control" rows="2" placeholder="Notas, materiales, especificaciones..."></textarea>
+              </div>
+              <div class="col-12">
+                <label for="prodImagen" class="form-label">Imagen</label>
+                <input type="file" id="prodImagen" class="form-control" />
+              </div>
+            </div>
+
+            <div class="form-actions">
+              <button type="reset" class="btn btn-secondary">Cancelar</button>
+              <button type="submit" class="btn btn-primary">Guardar producto</button>
+            </div>
+          </form>
+        </section>
+
+        <section id="categoriaFormContainer" class="panel-card d-none" aria-labelledby="btnCategorias">
+          <header class="panel-header">
+            <span class="panel-eyebrow">Categorías</span>
+            <h2 class="panel-title">Crear nueva categoría</h2>
+            <p class="panel-description">
+              Organiza tus productos en grupos principales para mejorar la navegación y los reportes de inventario.
+            </p>
+          </header>
+
+          <form id="categoriaForm" class="compact-form" novalidate>
+            <div class="row g-3">
               <div class="col-md-6">
                 <label for="catNombre" class="form-label">Nombre</label>
-                <input type="text" id="catNombre" class="form-control" placeholder="Ej. Ferretería" required>
+                <input type="text" id="catNombre" class="form-control" placeholder="Ej. Ferretería" required />
               </div>
               <div class="col-12">
                 <label for="catDescripcion" class="form-label">Descripción</label>
                 <textarea id="catDescripcion" class="form-control" rows="2" placeholder="Uso, alcance..."></textarea>
               </div>
-              <div class="col-12 d-flex gap-2">
-                <button type="submit" class="btn btn-success">Guardar categoría</button>
-                <button type="reset" class="btn btn-outline-light">Limpiar</button>
-              </div>
-            </form>
-          </div>
-        </div>
-      </div>
+            </div>
+            <div class="form-actions">
+              <button type="reset" class="btn btn-secondary">Cancelar</button>
+              <button type="submit" class="btn btn-primary">Guardar categoría</button>
+            </div>
+          </form>
+        </section>
 
-      <!-- SUBCATEGORÍA -->
-      <div class="accordion-item mt-3">
-        <h2 class="accordion-header" id="hdrSubcategoria">
-          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#colSubcategoria" aria-expanded="false" aria-controls="colSubcategoria">
-            Nueva subcategoría
-          </button>
-        </h2>
-        <div id="colSubcategoria" class="accordion-collapse collapse" aria-labelledby="hdrSubcategoria" data-bs-parent="#accGestion">
-          <div class="accordion-body">
-            <form id="subcategoriaForm" class="row g-3">
+        <section id="subcategoriaFormContainer" class="panel-card d-none" aria-labelledby="btnSubcategorias">
+          <header class="panel-header">
+            <span class="panel-eyebrow">Subcategorías</span>
+            <h2 class="panel-title">Registrar nueva subcategoría</h2>
+            <p class="panel-description">
+              Añade capas adicionales de clasificación para encontrar productos específicos con mayor rapidez.
+            </p>
+          </header>
+
+          <form id="subcategoriaForm" class="compact-form" novalidate>
+            <div class="row g-3">
               <div class="col-md-6">
                 <label for="subcatCategoria" class="form-label">Categoría</label>
                 <select id="subcatCategoria" class="form-select" required>
@@ -180,53 +190,94 @@
               </div>
               <div class="col-md-6">
                 <label for="subcatNombre" class="form-label">Nombre</label>
-                <input type="text" id="subcatNombre" class="form-control" placeholder="Ej. Tornillería" required>
+                <input type="text" id="subcatNombre" class="form-control" placeholder="Ej. Tornillería" required />
               </div>
               <div class="col-12">
                 <label for="subcatDescripcion" class="form-label">Descripción</label>
                 <textarea id="subcatDescripcion" class="form-control" rows="2" placeholder="Detalles opcionales..."></textarea>
               </div>
-              <div class="col-12 d-flex gap-2">
-                <button type="submit" class="btn btn-success">Guardar subcategoría</button>
-                <button type="reset" class="btn btn-outline-light">Limpiar</button>
-              </div>
-            </form>
-          </div>
+            </div>
+            <div class="form-actions">
+              <button type="reset" class="btn btn-secondary">Cancelar</button>
+              <button type="submit" class="btn btn-primary">Guardar subcategoría</button>
+            </div>
+          </form>
+        </section>
+      </div>
+    </section>
+
+    <section class="table-card">
+      <div class="table-heading">
+        <div>
+          <h2 class="table-title">Resumen del inventario</h2>
+          <span class="table-subtitle" id="tablaResumenDescripcion">Selecciona una vista para consultar los registros disponibles.</span>
+        </div>
+        <div class="summary-actions">
+          <button id="btnIngreso" class="btn-icon btn-icon--success" type="button" title="Registrar ingreso">
+            <span class="btn-icon__circle" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                <polyline points="23 4 23 10 17 10"></polyline>
+                <polyline points="1 20 1 14 7 14"></polyline>
+                <path d="M3.51 9a9 9 0 0 1 14.13-3.36L23 10"></path>
+                <path d="M20.49 15A9 9 0 0 1 6.36 18L1 14"></path>
+              </svg>
+            </span>
+            <span class="btn-icon__label">Ingreso</span>
+          </button>
+          <button id="btnEgreso" class="btn-icon btn-icon--danger" type="button" title="Registrar egreso">
+            <span class="btn-icon__circle" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                <path d="M9 14l-4-4 4-4"></path>
+                <path d="M5 10h14"></path>
+                <path d="M15 6l4 4-4 4"></path>
+              </svg>
+            </span>
+            <span class="btn-icon__label">Egreso</span>
+          </button>
+          <button id="btnRecargarResumen" class="btn-icon" type="button" title="Recargar datos">
+            <span class="btn-icon__circle" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                <polyline points="23 4 23 10 17 10"></polyline>
+                <polyline points="1 20 1 14 7 14"></polyline>
+                <path d="M3.51 9a9 9 0 0 1 14.13-3.36L23 10"></path>
+                <path d="M20.49 15A9 9 0 0 1 6.36 18L1 14"></path>
+              </svg>
+            </span>
+            <span class="btn-icon__label">Recargar</span>
+          </button>
+          <button id="btnScanQR" class="btn-icon btn-icon--accent" type="button" title="Escanear QR">
+            <span class="btn-icon__circle" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                <rect x="3" y="3" width="7" height="7"></rect>
+                <rect x="14" y="3" width="7" height="7"></rect>
+                <rect x="3" y="14" width="7" height="7"></rect>
+                <path d="M14 14h3v3h-3z"></path>
+                <path d="M17 17h4"></path>
+                <path d="M17 13v-3"></path>
+              </svg>
+            </span>
+            <span class="btn-icon__label">Escanear</span>
+          </button>
         </div>
       </div>
-    </div>
-  </section>
 
-  <!-- RESUMEN INVENTARIO -->
-  <section class="soft-card p-3 p-md-4">
-    <div class="d-flex align-items-center justify-content-between flex-wrap gap-2 mb-3">
-      <h2 class="h5 m-0">Resumen del inventario</h2>
-      <div class="d-flex gap-2">
-        <button id="btnIngreso" class="btn btn-success btn-pill">Registrar ingreso</button>
-        <button id="btnEgreso" class="btn btn-danger btn-pill">Registrar egreso</button>
-        <button id="btnRecargarResumen" class="btn btn-outline-light btn-pill">Recargar</button>
+      <div class="inventory-table-wrapper">
+        <table id="tablaResumen" class="inventory-table">
+          <thead id="tablaHead"></thead>
+          <tbody></tbody>
+        </table>
       </div>
-    </div>
+    </section>
+  </div>
 
-    <div class="table-responsive">
-      <table class="table align-middle mb-0" id="tablaResumen">
-        <thead id="tablaHead"></thead>
-        <tbody></tbody>
-      </table>
-    </div>
-    <div class="subtle-sep my-3"></div>
-    <p class="muted small mb-0">Usa los botones para registrar movimientos rápidos. La tabla se actualiza con <em>Recargar</em>.</p>
-  </section>
-
-  <!-- ESCÁNER QR SIN MODAL -->
-  <div id="qrReader" class="d-none my-3" style="width:100%"></div>
-
-  <!-- MODAL MOVIMIENTO -->
   <div class="modal fade" id="movimientoModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog">
-      <div class="modal-content soft-card">
-        <div class="modal-header">
-          <h5 class="modal-title" id="movimientoTitle">Movimiento</h5>
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content shadow-lg">
+        <div class="modal-header border-0">
+          <div>
+            <span class="modal-eyebrow">Movimiento</span>
+            <h5 class="modal-title fw-bold" id="movimientoTitle">Registrar movimiento</h5>
+          </div>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
         </div>
         <div class="modal-body">
@@ -236,70 +287,66 @@
           </div>
           <div class="mb-3">
             <label class="form-label">Cantidad</label>
-            <input type="number" id="movCantidad" class="form-control" min="1">
+            <input type="number" id="movCantidad" class="form-control" min="1" />
           </div>
         </div>
-        <div class="modal-footer">
-          <button id="movGuardar" class="btn btn-primary">Guardar</button>
-          <button class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <div class="modal-footer border-0 d-flex flex-column flex-sm-row gap-2">
+          <button id="movGuardar" class="btn btn-primary flex-fill" type="button">Guardar movimiento</button>
+          <button class="btn btn-outline-secondary flex-fill" type="button" data-bs-dismiss="modal">Cancelar</button>
         </div>
       </div>
     </div>
   </div>
 
-  <!-- SCRIPTS -->
+  <div class="modal fade" id="scanModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+      <div class="modal-content qr-modal shadow-lg">
+        <div class="modal-header border-0">
+          <div>
+            <span class="modal-eyebrow">Escáner</span>
+            <h5 class="modal-title fw-bold">Escanear código QR</h5>
+          </div>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+        </div>
+        <div class="modal-body">
+          <div id="qrReader" class="qr-reader d-none" role="img" aria-label="Visor para lectura de códigos QR"></div>
+          <p class="qr-helper">Coloca el código frente a la cámara para registrar el movimiento automáticamente.</p>
+        </div>
+        <div class="modal-footer border-0">
+          <button class="btn btn-outline-secondary" type="button" data-bs-dismiss="modal">Cerrar escáner</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="toast-container position-fixed top-0 end-0 p-3" id="toastStack" aria-live="polite" aria-atomic="true"></div>
+
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script src="https://unpkg.com/html5-qrcode@2.3.8/minified/html5-qrcode.min.js"></script>
-  <!-- Tu lógica original -->
   <script src="../../scripts/gest_inve/inventario_basico.js"></script>
-
-  <!-- JS de ayuda para navegar entre secciones conservando IDs/funciones existentes -->
   <script>
-    (function() {
-      const mapping = {
-        btnProductos: 'colProducto',
-        btnCategorias: 'colCategoria',
-        btnSubcategorias: 'colSubcategoria'
-      };
+    function makeToast(message, cls = 'text-bg-success', delay = 2600) {
+      const container = document.getElementById('toastStack');
+      if (!container) return;
+      const toast = document.createElement('div');
+      toast.className = `toast align-items-center ${cls} border-0 shadow`;
+      toast.setAttribute('role', 'status');
+      toast.setAttribute('aria-live', 'polite');
+      toast.innerHTML = `
+        <div class="d-flex">
+          <div class="toast-body">${message}</div>
+          <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Cerrar"></button>
+        </div>
+      `;
+      container.appendChild(toast);
+      const instance = new bootstrap.Toast(toast, { delay });
+      instance.show();
+      toast.addEventListener('hidden.bs.toast', () => toast.remove());
+    }
 
-      for (const [btnId, colId] of Object.entries(mapping)) {
-        const btn = document.getElementById(btnId);
-        const col = document.getElementById(colId);
-        if (!btn || !col) continue;
-        btn.addEventListener('click', () => {
-          // Cierra todos
-          document.querySelectorAll('.accordion-collapse').forEach(el => {
-            const c = bootstrap.Collapse.getOrCreateInstance(el, { toggle: false });
-            c.hide();
-          });
-          // Abre el destino
-          const target = bootstrap.Collapse.getOrCreateInstance(col, { toggle: false });
-          target.show();
-          col.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        });
-      }
-    })();
+    window.toastOk = (m = 'Acción realizada correctamente ✅') => makeToast(m, 'text-bg-success', 2600);
+    window.toastError = (m = 'Ocurrió un error ❌') => makeToast(m, 'text-bg-danger', 3200);
+    window.toastInfo = (m = 'Información ℹ️') => makeToast(m, 'text-bg-primary', 2800);
   </script>
-<div class="position-fixed top-0 end-0 p-3" style="z-index:1080">
-  <div id="toastStack" class="toast-container"></div>
-</div>
-<script>
-  function makeToast(message, cls='text-bg-success', delay=2600){
-    const c = document.getElementById('toastStack');
-    const el = document.createElement('div');
-    el.className = `toast align-items-center ${cls} border-0`;
-    el.setAttribute('role','status'); el.setAttribute('aria-live','polite');
-    el.innerHTML = `<div class="d-flex">
-        <div class="toast-body">${message}</div>
-        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Cerrar"></button>
-      </div>`;
-    c.appendChild(el);
-    const t = new bootstrap.Toast(el, { delay }); t.show();
-    el.addEventListener('hidden.bs.toast', () => el.remove());
-  }
-  window.toastOk    = (m='Acción realizada correctamente ✅') => makeToast(m,'text-bg-success',2600);
-  window.toastError = (m='Ocurrió un error ❌')                => makeToast(m,'text-bg-danger',3200);
-  window.toastInfo  = (m='Información ℹ️')                     => makeToast(m,'text-bg-primary',2800);
-</script>
 </body>
 </html>

--- a/styles/gest_inve/inventario_basico.css
+++ b/styles/gest_inve/inventario_basico.css
@@ -1,19 +1,626 @@
-body {
-  font-family: Arial, sans-serif;
+:root {
+  --page-bg: #f5f6fb;
+  --card-bg: #ffffff;
+  --border-color: #e7e9f5;
+  --text-color: #1f2937;
+  --muted-color: #6b7280;
+  --primary-color: #7056ff;
+  --primary-soft: rgba(112, 86, 255, 0.08);
+  --accent-color: #00c4cc;
+  --success-color: #16a34a;
+  --danger-color: #ff6b6b;
+  --shadow-soft: 0 18px 40px -28px rgba(14, 20, 56, 0.55);
+  --radius-md: 16px;
+  --radius-lg: 22px;
+  --radius-pill: 999px;
+  --font-main: 'Poppins', sans-serif;
 }
 
-table th, table td {
-  border: 1px solid #ccc;
-  padding: 4px;
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--page-bg);
+  color: var(--text-color);
+  font-family: var(--font-main);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.inventory-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.page-header {
+  position: relative;
+  background: linear-gradient(135deg, rgba(112, 86, 255, 0.08), rgba(0, 196, 204, 0.08));
+  border-radius: var(--radius-lg);
+  padding: 2rem clamp(1.5rem, 3vw, 2.5rem);
+  overflow: hidden;
+  border: 1px solid rgba(112, 86, 255, 0.12);
+  box-shadow: var(--shadow-soft);
+}
+
+.page-header::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 15% 15%, rgba(112, 86, 255, 0.24), transparent 60%);
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.header-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--primary-color);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  position: relative;
+  z-index: 1;
+}
+
+.header-title {
+  margin: 1rem 0 0.5rem;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  font-weight: 700;
+  color: #171f34;
+  position: relative;
+  z-index: 1;
+}
+
+.header-description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted-color);
+  max-width: 640px;
+  position: relative;
+  z-index: 1;
+}
+
+.header-highlights {
+  position: relative;
+  z-index: 1;
+  margin-top: 2rem;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.highlight-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(112, 86, 255, 0.18);
+  padding: 1.25rem 1.5rem;
+  backdrop-filter: blur(12px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  box-shadow: 0 12px 32px -28px rgba(112, 86, 255, 0.9);
+}
+
+.card-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-color);
+  font-weight: 600;
+}
+
+.card-title {
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #171f34;
+}
+
+.card-subtitle {
+  font-size: 0.85rem;
+  color: var(--muted-color);
+}
+
+.inventory-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.shell-header {
+  background: var(--card-bg);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 12px 40px -30px rgba(18, 26, 69, 0.55);
+  padding: clamp(1.5rem, 3vw, 2rem);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.shell-header__info {
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.shell-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: var(--radius-pill);
+  background: rgba(112, 86, 255, 0.1);
+  color: var(--primary-color);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.shell-title {
+  margin: 0;
+  font-size: clamp(1.2rem, 3vw, 1.7rem);
+  color: #1f2538;
+  font-weight: 600;
+}
+
+.shell-subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted-color);
+  max-width: 520px;
+}
+
+.shell-header__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.tab-chip {
+  border: 1px solid transparent;
+  background: rgba(112, 86, 255, 0.1);
+  border-radius: var(--radius-md);
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.2rem;
+  font-weight: 600;
+  color: var(--muted-color);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  min-width: 180px;
+}
+
+.tab-chip__title {
+  font-size: 0.95rem;
+}
+
+.tab-chip__description {
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: rgba(31, 41, 55, 0.6);
+}
+
+.tab-chip.active {
+  background: #ffffff;
+  color: var(--primary-color);
+  border-color: rgba(112, 86, 255, 0.18);
+  box-shadow: 0 18px 32px -30px rgba(112, 86, 255, 0.95);
+}
+
+.tab-chip:hover {
+  color: var(--text-color);
+  border-color: rgba(112, 86, 255, 0.18);
+}
+
+.inventory-card {
+  background: var(--card-bg);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 18px 45px -32px rgba(18, 26, 69, 0.55);
+  padding: clamp(1.5rem, 3vw, 2rem);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.panel-card {
+  background: linear-gradient(180deg, rgba(112, 86, 255, 0.06), rgba(255, 255, 255, 0.95));
+  border: 1px solid rgba(112, 86, 255, 0.14);
+  border-radius: var(--radius-md);
+  padding: clamp(1.25rem, 2.5vw, 1.75rem);
+  box-shadow: 0 18px 40px -32px rgba(14, 20, 56, 0.4);
+}
+
+.panel-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.2rem;
+}
+
+.panel-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: var(--radius-pill);
+  background: rgba(112, 86, 255, 0.12);
+  color: var(--primary-color);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.panel-title {
+  margin: 0;
+  font-size: clamp(1.1rem, 3vw, 1.45rem);
+  color: #1f2538;
+  font-weight: 600;
+}
+
+.panel-description {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted-color);
+  max-width: 540px;
+}
+
+.compact-form {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: clamp(1.25rem, 2.5vw, 1.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 16px 40px -36px rgba(15, 23, 42, 0.35);
+}
+
+.compact-form .form-label {
+  font-weight: 600;
+  color: var(--text-color);
+  font-size: 0.85rem;
+}
+
+.compact-form .form-control,
+.compact-form .form-select,
+.compact-form textarea {
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  padding: 0.65rem 0.85rem;
+  font-size: 0.9rem;
+  background: rgba(245, 246, 251, 0.8);
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.compact-form .form-control:focus,
+.compact-form .form-select:focus,
+.compact-form textarea:focus {
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(112, 86, 255, 0.18);
+}
+
+.compact-form textarea {
+  min-height: 100px;
+  resize: vertical;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.btn.btn-primary {
+  background: linear-gradient(135deg, var(--primary-color), #8c75ff);
+  border: none;
+  padding: 0.65rem 1.4rem;
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  box-shadow: 0 14px 32px -26px rgba(112, 86, 255, 0.85);
+}
+
+.btn.btn-primary:hover {
+  background: linear-gradient(135deg, #8c75ff, var(--primary-color));
+}
+
+.btn.btn-secondary {
+  background: rgba(112, 86, 255, 0.08);
+  color: var(--primary-color);
+  border: none;
+  padding: 0.65rem 1.4rem;
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+}
+
+.btn.btn-outline-secondary {
+  border-radius: var(--radius-pill);
+}
+
+.table-card {
+  background: var(--card-bg);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 18px 45px -32px rgba(18, 26, 69, 0.55);
+  padding: clamp(1.5rem, 3vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.table-heading {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.table-title {
+  margin: 0;
+  font-size: clamp(1.2rem, 3vw, 1.6rem);
+  font-weight: 600;
+  color: #1f2538;
+}
+
+.table-subtitle {
+  display: block;
+  font-size: 0.9rem;
+  color: var(--muted-color);
+  margin-top: 0.35rem;
+}
+
+.summary-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.btn-icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  border: none;
+  background: rgba(112, 86, 255, 0.12);
+  color: var(--primary-color);
+  padding: 0.65rem 1rem;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.85rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn-icon:hover {
+  background: rgba(112, 86, 255, 0.18);
+  box-shadow: 0 12px 30px -22px rgba(112, 86, 255, 0.9);
+  transform: translateY(-2px);
+}
+
+.btn-icon__circle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.9);
+  color: currentColor;
+}
+
+.btn-icon__label {
+  letter-spacing: 0.02em;
+}
+
+.btn-icon--success {
+  background: rgba(22, 163, 74, 0.12);
+  color: var(--success-color);
+}
+
+.btn-icon--success:hover {
+  background: rgba(22, 163, 74, 0.18);
+  box-shadow: 0 12px 30px -22px rgba(22, 163, 74, 0.4);
+}
+
+.btn-icon--danger {
+  background: rgba(255, 107, 107, 0.12);
+  color: var(--danger-color);
+}
+
+.btn-icon--danger:hover {
+  background: rgba(255, 107, 107, 0.18);
+  box-shadow: 0 12px 30px -22px rgba(255, 107, 107, 0.4);
+}
+
+.btn-icon--accent {
+  background: rgba(0, 196, 204, 0.12);
+  color: var(--accent-color);
+}
+
+.btn-icon--accent:hover {
+  background: rgba(0, 196, 204, 0.18);
+  box-shadow: 0 12px 30px -22px rgba(0, 196, 204, 0.4);
+}
+
+.inventory-table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+}
+
+.inventory-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+  font-size: 0.88rem;
+}
+
+.inventory-table thead th {
+  background: rgba(112, 86, 255, 0.08);
+  color: #1f2538;
+  text-align: left;
+  padding: 0.85rem 1rem;
+  font-weight: 600;
+  border-bottom: 1px solid rgba(112, 86, 255, 0.18);
+}
+
+.inventory-table tbody td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+  color: var(--muted-color);
+}
+
+.inventory-table tbody tr:hover {
+  background: rgba(112, 86, 255, 0.05);
+}
+
+.inventory-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.modal-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: var(--radius-pill);
+  background: rgba(112, 86, 255, 0.12);
+  color: var(--primary-color);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+}
+
+.qr-modal {
+  background: var(--card-bg);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color);
+}
+
+.qr-reader {
+  width: 100%;
+  min-height: 320px;
+  border-radius: var(--radius-md);
+  background: repeating-linear-gradient(
+      135deg,
+      rgba(112, 86, 255, 0.08),
+      rgba(112, 86, 255, 0.08) 12px,
+      rgba(0, 196, 204, 0.08) 12px,
+      rgba(0, 196, 204, 0.08) 24px
+    ),
+    #fff;
+  border: 1px dashed rgba(112, 86, 255, 0.35);
+  display: grid;
+  place-items: center;
+}
+
+.qr-helper {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  color: var(--muted-color);
+  text-align: center;
 }
 
 .toast-message {
   position: fixed;
-  bottom: 1rem;
-  right: 1rem;
-  background: #333;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  background: var(--primary-color);
   color: #fff;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  opacity: 0.9;
+  padding: 0.65rem 1.1rem;
+  border-radius: 14px;
+  box-shadow: 0 18px 40px -30px rgba(17, 24, 67, 0.65);
+  font-size: 0.85rem;
+  z-index: 1080;
+  opacity: 0.95;
+}
+
+.toast-message.toast-success {
+  background: var(--success-color);
+}
+
+.toast-message.toast-error {
+  background: var(--danger-color);
+}
+
+.toast-message.toast-info {
+  background: var(--accent-color);
+}
+
+@media (max-width: 992px) {
+  .shell-header {
+    align-items: flex-start;
+  }
+
+  .shell-header__actions {
+    justify-content: flex-start;
+  }
+
+  .inventory-table {
+    min-width: 520px;
+  }
+}
+
+@media (max-width: 768px) {
+  .header-highlights {
+    grid-template-columns: 1fr;
+  }
+
+  .form-actions {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .form-actions .btn {
+    width: 100%;
+  }
+
+  .summary-actions {
+    justify-content: stretch;
+  }
+
+  .tab-chip {
+    min-width: 160px;
+  }
+}
+
+@media (max-width: 576px) {
+  .inventory-table {
+    min-width: 480px;
+  }
+
+  .shell-header__actions,
+  .summary-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .btn-icon,
+  .tab-chip {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## Summary
- rediseñé `inventario_basico.html` para ofrecer cabecera con indicadores, pestañas y acciones en línea con el resto del centro de control
- añadí un nuevo tema en `inventario_basico.css` que aplica la misma paleta, tarjetas y tablas utilizadas en las pantallas de cuenta y log
- actualicé `inventario_basico.js` para controlar las pestañas, refrescar los contadores, mejorar los toasts y activar el nuevo modal de escaneo QR

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca0c440354832c8f6232cf4a223e18