### PR TITLE
style: modernizar pagina de menu principal

### DIFF
--- a/pages/main_menu/main_menu.html
+++ b/pages/main_menu/main_menu.html
@@ -5,7 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>OPTISTOCK - Sistema de Gestión de Almacenes</title>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="../../styles/main_menu/main_menu.css">
 </head>
@@ -63,56 +65,79 @@
             <div class="alert-settings" id="alertSettingsBtn">
                 <i class="fas fa-cog"></i>
             </div>
-            <!-- Usuario en la topbar -->
-<div class="user-profile">
-    <img src="" alt="Usuario">
-    <div class="user-info">
-        <span class="user-name">Usuario</span>
-        <span class="user-role">Rol</span>
-    </div>
-    <!-- Submenú desplegable -->
-    <div class="dropdown">
-        <button class="dropdown-toggle" id="dropdownMenuButton">
-            <i class="fas fa-caret-down"></i>
-        </button>
-        <div class="dropdown-menu" id="userMenu">
-            <a href="#" class="dropdown-item" id="logoutBtn">Cerrar sesión</a>
-        </div>
-    </div>
-</div>
-        </div>
-    </div>
-    
-    <!-- Main Content -->
-    <div class="content" id="mainContent">
-        <!-- Welcome Card -->
-        <div class="welcome-card">
-            <h1 class="welcome-title" id="empresaTitulo">Bienvenido a OPTISTOCK</h1>
-            <p class="welcome-text">Sistema de Gestión y Administración de Almacenes. Desde aquí puedes controlar todas las operaciones de tu almacén, gestionar inventarios, áreas de almacenamiento y generar reportes detallados.</p>
-            
-            <!-- Quick Actions -->
-            <div class="quick-actions">
-                <button class="btn btn-success" id="ingresoFlashBtn">
-                    <i class="fas fa-bolt"></i> Ingreso Flash
-                </button>
-                <button class="btn btn-danger" id="egresoFlashBtn">
-                    <i class="fas fa-bolt"></i> Egreso Flash
-                </button>
-                <button class="btn btn-primary">
-                    <i class="fas fa-sign-in-alt"></i> Registrar Entrada
-                </button>
-                <button class="btn btn-primary">
-                    <i class="fas fa-sign-out-alt"></i> Registrar Salida
-                </button>
+            <div class="user-profile">
+                <img src="" alt="Usuario">
+                <div class="user-info">
+                    <span class="user-name">Usuario</span>
+                    <span class="user-role">Rol</span>
+                </div>
+                <div class="dropdown">
+                    <button class="dropdown-toggle" id="dropdownMenuButton">
+                        <i class="fas fa-caret-down"></i>
+                    </button>
+                    <div class="dropdown-menu" id="userMenu">
+                        <a href="#" class="dropdown-item" id="logoutBtn">Cerrar sesión</a>
+                    </div>
+                </div>
             </div>
         </div>
-        
-        <!-- Dashboard Grid -->
-        <div class="dashboard-grid">
+    </div>
+
+    <!-- Main Content -->
+    <div class="content" id="mainContent">
+        <div class="dashboard-page">
+            <section class="page-header">
+                <span class="header-eyebrow">Panel principal</span>
+                <h1 class="header-title" id="empresaTitulo">Bienvenido a OPTISTOCK</h1>
+                <p class="header-description">Sistema de Gestión y Administración de Almacenes. Desde aquí puedes controlar todas las operaciones de tu almacén, gestionar inventarios, áreas de almacenamiento y generar reportes detallados.</p>
+
+                <div class="header-bottom">
+                    <div class="header-stats">
+                        <article class="stat-card">
+                            <span class="stat-label">Alertas activas</span>
+                            <span class="stat-value">4</span>
+                            <span class="stat-trend negative"><i class="fas fa-arrow-up"></i> +12%</span>
+                        </article>
+                        <article class="stat-card">
+                            <span class="stat-label">Movimientos hoy</span>
+                            <span class="stat-value">128</span>
+                            <span class="stat-trend positive"><i class="fas fa-arrow-up"></i> +8%</span>
+                        </article>
+                        <article class="stat-card">
+                            <span class="stat-label">Zonas críticas</span>
+                            <span class="stat-value">2</span>
+                            <span class="stat-trend neutral"><i class="fas fa-minus"></i> Sin cambios</span>
+                        </article>
+                    </div>
+
+                    <div class="header-actions">
+                        <span class="actions-title">Acciones rápidas</span>
+                        <div class="quick-actions">
+                            <button class="btn btn-success" id="ingresoFlashBtn">
+                                <i class="fas fa-bolt"></i> Ingreso Flash
+                            </button>
+                            <button class="btn btn-danger" id="egresoFlashBtn">
+                                <i class="fas fa-bolt"></i> Egreso Flash
+                            </button>
+                            <button class="btn btn-primary">
+                                <i class="fas fa-sign-in-alt"></i> Registrar Entrada
+                            </button>
+                            <button class="btn btn-primary">
+                                <i class="fas fa-sign-out-alt"></i> Registrar Salida
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <div class="dashboard-grid">
             <!-- Stock Alerts Card -->
             <div class="dashboard-card" id="stockAlertsCard">
                 <div class="card-header">
-                    <h3 class="card-title"><i class="fas fa-exclamation-triangle"></i> Productos con Stock Bajo</h3>
+                    <div class="card-heading">
+                        <span class="card-eyebrow">Alertas</span>
+                        <h3 class="card-title"><i class="fas fa-exclamation-triangle"></i> Productos con Stock Bajo</h3>
+                    </div>
                     <div class="card-actions">
                         <button class="card-action-btn"><i class="fas fa-sync-alt"></i></button>
                         <button class="card-action-btn"><i class="fas fa-ellipsis-v"></i></button>
@@ -173,7 +198,10 @@
             <!-- Recent Activity Card -->
             <div class="dashboard-card" id="recentActivityCard">
                 <div class="card-header">
-                    <h3 class="card-title"><i class="fas fa-history"></i> Movimientos Recientes</h3>
+                    <div class="card-heading">
+                        <span class="card-eyebrow">Actividad</span>
+                        <h3 class="card-title"><i class="fas fa-history"></i> Movimientos Recientes</h3>
+                    </div>
                     <div class="card-actions">
                         <button class="card-action-btn"><i class="fas fa-sync-alt"></i></button>
                     </div>
@@ -230,7 +258,10 @@
             <!-- Space Optimization Card -->
             <div class="dashboard-card" id="spaceOptimizationCard">
                 <div class="card-header">
-                    <h3 class="card-title"><i class="fas fa-warehouse"></i> Optimización de Espacio</h3>
+                    <div class="card-heading">
+                        <span class="card-eyebrow">Espacio</span>
+                        <h3 class="card-title"><i class="fas fa-warehouse"></i> Optimización de Espacio</h3>
+                    </div>
                     <div class="card-actions">
                         <button class="card-action-btn"><i class="fas fa-sync-alt"></i></button>
                     </div>
@@ -244,7 +275,10 @@
             <!-- High Rotation Card -->
             <div class="dashboard-card" id="highRotationCard">
                 <div class="card-header">
-                    <h3 class="card-title"><i class="fas fa-sync-alt"></i> Mayor Rotación 24h</h3>
+                    <div class="card-heading">
+                        <span class="card-eyebrow">Inventario</span>
+                        <h3 class="card-title"><i class="fas fa-sync-alt"></i> Mayor Rotación 24h</h3>
+                    </div>
                     <div class="card-actions">
                         <button class="card-action-btn"><i class="fas fa-sync-alt"></i></button>
                     </div>
@@ -257,7 +291,10 @@
             <!-- Zone Capacity Card -->
             <div class="dashboard-card" id="zoneCapacityCard">
                 <div class="card-header">
-                    <h3 class="card-title"><i class="fas fa-exclamation-circle"></i> Zonas con Capacidad Reducida</h3>
+                    <div class="card-heading">
+                        <span class="card-eyebrow">Capacidad</span>
+                        <h3 class="card-title"><i class="fas fa-exclamation-circle"></i> Zonas con Capacidad Reducida</h3>
+                    </div>
                     <div class="card-actions">
                         <button class="card-action-btn"><i class="fas fa-sync-alt"></i></button>
                     </div>
@@ -270,7 +307,10 @@
             <!-- Employee Access Card -->
             <div class="dashboard-card" id="employeeAccessCard">
                 <div class="card-header">
-                    <h3 class="card-title"><i class="fas fa-user-clock"></i> Accesos Recientes</h3>
+                    <div class="card-heading">
+                        <span class="card-eyebrow">Usuarios</span>
+                        <h3 class="card-title"><i class="fas fa-user-clock"></i> Accesos Recientes</h3>
+                    </div>
                     <div class="card-actions">
                         <button class="card-action-btn"><i class="fas fa-sync-alt"></i></button>
                     </div>
@@ -278,6 +318,7 @@
                 <ul class="activity-list" id="accessLogsList">
                     <!-- Filled dynamically -->
                 </ul>
+            </div>
             </div>
         </div>
     </div>

--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -1,4 +1,5 @@
 // Toggle sidebar collapse/expand
+const body = document.body;
 const menuToggle = document.getElementById('menuToggle');
 const sidebar = document.querySelector('.sidebar');
 const accessLogsList = document.getElementById('accessLogsList');
@@ -308,30 +309,32 @@ function loadAccessLogs() {
 
 
 // Toggle sidebar on button click
-menuToggle.addEventListener('click', function() {
-    // On mobile, just show/hide the sidebar
-    if (window.innerWidth <= 992) {
-        sidebar.classList.toggle('active');
-    } 
-    // On desktop, toggle collapsed state
-    else {
-        sidebar.classList.toggle('collapsed');
-    }
-});
+if (menuToggle && sidebar) {
+    menuToggle.addEventListener('click', function() {
+        if (window.innerWidth <= 992) {
+            const isActive = sidebar.classList.toggle('active');
+            body.classList.toggle('sidebar-open', isActive);
+        }
+    });
+}
 
 // Close sidebar when clicking outside on mobile
 document.addEventListener('click', function(e) {
-    if (window.innerWidth <= 992 && 
-        !sidebar.contains(e.target) && 
+    if (!sidebar || !menuToggle) return;
+    if (window.innerWidth <= 992 &&
+        !sidebar.contains(e.target) &&
         !menuToggle.contains(e.target)) {
         sidebar.classList.remove('active');
+        body.classList.remove('sidebar-open');
     }
 });
 
 // Handle window resize
 window.addEventListener('resize', function() {
+    if (!sidebar) return;
     if (window.innerWidth > 992) {
         sidebar.classList.remove('active');
+        body.classList.remove('sidebar-open');
     }
 });
 

--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -1,18 +1,26 @@
 :root {
-    --primary-color: #2c3e50;
-    --secondary-color: #3498db;
-    --accent-color: #e74c3c;
-    --light-color: #ecf0f1;
-    --dark-color: #2c3e50;
-    --success-color: #27ae60;
-    --warning-color: #f39c12;
-    --info-color: #2980b9;
-    --sidebar-color: #20252a;
-    --topbar-color: #454b52; /* Color predeterminado del topbar */
+    --page-bg: #f5f6fb;
+    --card-bg: #ffffff;
+    --border-color: #e7e9f5;
+    --text-color: #1f2937;
+    --muted-color: #6b7280;
+    --primary-color: #7056ff;
+    --primary-soft: rgba(112, 86, 255, 0.08);
+    --accent-color: #00c4cc;
+    --danger-color: #ff6b6b;
+    --warning-color: #f7b500;
+    --success-color: #16a34a;
+    --shadow-soft: 0 18px 40px -28px rgba(14, 20, 56, 0.55);
+    --radius-md: 16px;
+    --radius-lg: 22px;
+    --radius-pill: 999px;
+    --font-main: "Poppins", sans-serif;
+    --sidebar-color: #171f34;
+    --topbar-color: #ffffff;
     --sidebar-text-color: #ffffff;
-    --topbar-text-color: #ffffff;
+    --topbar-text-color: #1f2538;
     --sidebar-width: 280px;
-    --topbar-height: 70px;
+    --topbar-height: 74px;
     --transition-speed: 0.3s;
 }
 
@@ -23,51 +31,50 @@
 }
 
 body {
-    font-family: 'Roboto', sans-serif;
-    background-color: #f5f7fa;
-    color: #333;
+    font-family: var(--font-main);
+    background: var(--page-bg);
+    color: var(--text-color);
     line-height: 1.6;
 }
 
-/* Sidebar Styles */
+img {
+    max-width: 100%;
+    display: block;
+}
+
+/* Sidebar */
 .sidebar {
-    background-color: var(--sidebar-color);
+    background: var(--sidebar-color);
     color: var(--sidebar-text-color);
     width: var(--sidebar-width);
     height: 100vh;
     position: fixed;
     top: 0;
     left: 0;
-    padding: 20px 0;
-    box-shadow: 2px 0 10px rgba(0, 0, 0, 0.1);
+    padding: 22px 0 18px;
+    box-shadow: 12px 0 40px -32px rgba(17, 17, 17, 0.6);
     z-index: 100;
-    transition: all var(--transition-speed) ease;
     display: flex;
     flex-direction: column;
+    transition: width var(--transition-speed) ease, transform var(--transition-speed) ease;
+    transform: translateX(0);
 }
 
 .sidebar-header {
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 0 20px 20px;
+    padding: 0 24px 24px;
     border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 }
 
-.sidebar-header h2 {
-    font-weight: 500;
-    font-size: 1.5rem;
-    display: flex;
-    align-items: center;
-}
-
-.sidebar-header i {
-    margin-right: 10px;
-    color: var(--sidebar-text-color);
+.sidebar-logo {
+    width: 160px;
+    object-fit: contain;
 }
 
 .sidebar-menu {
-    padding: 20px 0;
+    padding: 22px 0;
     flex: 1;
     overflow-y: auto;
 }
@@ -75,44 +82,36 @@ body {
 .sidebar-menu a {
     display: flex;
     align-items: center;
+    gap: 14px;
     color: var(--sidebar-text-color);
     text-decoration: none;
-    padding: 12px 25px;
-    margin: 5px 0;
+    padding: 12px 28px;
+    margin: 4px 0;
     border-left: 4px solid transparent;
-    transition: all var(--transition-speed) ease;
-    font-weight: 400;
-}
-
-.sidebar-menu a:hover {
-    background-color: rgba(255, 255, 255, 0.1);
-    border-left: 4px solid var(--secondary-color);
-    color: var(--sidebar-text-color);
-}
-
-.sidebar-menu a i {
-    margin-right: 12px;
-    width: 20px;
-    text-align: center;
-    font-size: 1.1rem;
-}
-
-.sidebar-menu a.active {
-    background-color: rgba(255, 255, 255, 0.1);
-    border-left: 4px solid var(--secondary-color);
+    transition: background var(--transition-speed) ease, border-color var(--transition-speed) ease;
     font-weight: 500;
 }
 
-.sidebar-footer {
-    padding: 15px;
-    border-top: 1px solid rgba(255, 255, 255, 0.1);
+.sidebar-menu a i {
+    width: 22px;
+    font-size: 1.05rem;
     text-align: center;
-    margin-top: auto; /* evita que el botón desaparezca */
 }
 
-/* Topbar Styles */
+.sidebar-menu a:hover,
+.sidebar-menu a.active {
+    background: rgba(255, 255, 255, 0.12);
+    border-color: rgba(255, 255, 255, 0.65);
+}
+
+.sidebar-footer {
+    padding: 18px 24px 0;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+/* Topbar */
 .topbar {
-    background-color: var(--topbar-color);
+    background: var(--topbar-color);
     height: var(--topbar-height);
     position: fixed;
     top: 0;
@@ -121,417 +120,584 @@ body {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0 30px;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+    padding: 0 32px;
+    border-bottom: 1px solid var(--border-color);
+    box-shadow: 0 12px 32px -28px rgba(17, 24, 39, 0.65);
     z-index: 90;
 }
 
+.menu-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+    border: 1px solid var(--border-color);
+    background: rgba(255, 255, 255, 0.65);
+    color: var(--topbar-text-color);
+    font-size: 1.1rem;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.menu-toggle:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 32px -24px rgba(112, 86, 255, 0.45);
+}
+
+@media (min-width: 993px) {
+    .menu-toggle {
+        display: none;
+    }
+}
+
 .topbar-title {
-    font-size: 1.3rem;
-    font-weight: 500;
+    font-size: 1.2rem;
+    font-weight: 600;
     color: var(--topbar-text-color);
 }
 
 .topbar-actions {
     display: flex;
     align-items: center;
-    gap: 20px;
+    gap: 18px;
 }
 
 .search-bar {
     position: relative;
-    width: 300px;
+    width: 280px;
 }
 
 .search-bar input {
     width: 100%;
-    padding: 10px 15px 10px 40px;
-    border: 1px solid #ddd;
-    border-radius: 30px;
-    font-size: 0.9rem;
-    transition: all var(--transition-speed) ease;
+    padding: 12px 18px 12px 46px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-pill);
+    font-size: 0.95rem;
+    background: rgba(255, 255, 255, 0.85);
+    color: var(--text-color);
+    transition: border-color var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
 }
 
 .search-bar input:focus {
     outline: none;
-    border-color: var(--secondary-color);
-    box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.2);
+    border-color: rgba(112, 86, 255, 0.55);
+    box-shadow: 0 0 0 4px rgba(112, 86, 255, 0.12);
 }
 
 .search-bar i {
     position: absolute;
-    left: 15px;
+    left: 18px;
     top: 50%;
     transform: translateY(-50%);
-    color: #95a5a6;
+    color: var(--muted-color);
+    font-size: 0.95rem;
 }
 
-.notification-bell {
+.notification-bell,
+.alert-settings {
     position: relative;
     cursor: pointer;
     color: var(--topbar-text-color);
-    font-size: 1.2rem;
+    font-size: 1.1rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: 14px;
+    border: 1px solid var(--border-color);
+    background: rgba(255, 255, 255, 0.6);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.alert-settings {
-    cursor: pointer;
-    color: var(--topbar-text-color);
-    font-size: 1.2rem;
-    margin-left: 15px;
+.notification-bell:hover,
+.alert-settings:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 32px -24px rgba(112, 86, 255, 0.4);
 }
 
 .notification-badge {
     position: absolute;
-    top: -5px;
-    right: -5px;
-    background-color: var(--accent-color);
-    color: white;
-    border-radius: 50%;
-    width: 18px;
-    height: 18px;
-    font-size: 0.7rem;
+    top: 6px;
+    right: 6px;
+    background: var(--danger-color);
+    color: #fff;
+    border-radius: 999px;
+    width: 20px;
+    height: 20px;
     display: flex;
     align-items: center;
     justify-content: center;
+    font-size: 0.7rem;
+    font-weight: 600;
 }
 
 .user-profile {
     display: flex;
     align-items: center;
+    gap: 10px;
     cursor: pointer;
     position: relative;
 }
 
 .user-profile img {
-    width: 40px;
-    height: 40px;
+    width: 42px;
+    height: 42px;
     border-radius: 50%;
-    margin-right: 10px;
     object-fit: cover;
+    background: rgba(112, 86, 255, 0.12);
+    border: 2px solid rgba(255, 255, 255, 0.6);
 }
 
 .user-info {
     display: flex;
     flex-direction: column;
-    margin-right: 10px;
+    gap: 2px;
 }
 
 .user-name {
-    font-weight: 500;
-    font-size: 0.9rem;
+    font-weight: 600;
+    font-size: 0.95rem;
     color: var(--topbar-text-color);
 }
 
 .user-role {
     font-size: 0.8rem;
     color: var(--topbar-text-color);
-}
-
-.user-profile .dropdown {
-    position: relative;
-}
-
-#userMenu {
-    display: none;
-    position: absolute;
-    top: 100%;
-    right: 0;
-    background-color: #fff;
-    border: 1px solid #ddd;
-    border-radius: 5px;
-    box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
-    width: 150px;
-    z-index: 9999;
-    padding: 10px 0; /* Añadir espacio dentro del submenú */
-}
-
-.dropdown-toggle:active + #userMenu,
-#userMenu:hover {
-    display: block;
-}
-
-#userMenu .dropdown-item {
-    padding: 10px;
-    text-decoration: none;
-    color: #333;
-    font-size: 0.9rem;
-    display: block;
-}
-
-#userMenu .dropdown-item:hover {
-    background-color: #f1f1f1;
+    opacity: 0.65;
 }
 
 .dropdown-toggle {
     background: none;
     border: none;
     cursor: pointer;
-    font-size: 1.2rem;
+    font-size: 1rem;
     color: var(--topbar-text-color);
 }
 
-.dropdown-toggle:hover {
-    color: var(--topbar-text-color);
+.dropdown-menu {
+    display: none;
+    position: absolute;
+    top: calc(100% + 10px);
+    right: 0;
+    background: #fff;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-soft);
+    width: 180px;
+    padding: 10px 0;
+    z-index: 999;
 }
-/* Main Content Styles */
+
+.dropdown-item {
+    display: block;
+    padding: 10px 18px;
+    text-decoration: none;
+    color: var(--text-color);
+    font-size: 0.9rem;
+    transition: background var(--transition-speed) ease;
+}
+
+.dropdown-item:hover {
+    background: rgba(112, 86, 255, 0.08);
+}
+
+.user-profile .dropdown:hover .dropdown-menu,
+.dropdown-toggle:focus + .dropdown-menu,
+.dropdown-menu:hover {
+    display: block;
+}
+
+/* Layout */
 .content {
     margin-left: var(--sidebar-width);
     margin-top: var(--topbar-height);
-    padding: 30px;
+    padding: 32px;
     min-height: calc(100vh - var(--topbar-height));
 }
 
-/* Welcome Card */
-.welcome-card {
-    background: white;
-    border-radius: 10px;
-    padding: 30px;
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.05);
-    margin-bottom: 30px;
+.dashboard-page {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+}
+
+.page-header {
     position: relative;
+    background: linear-gradient(135deg, var(--primary-soft), rgba(0, 196, 204, 0.12));
+    border-radius: var(--radius-lg);
+    padding: clamp(1.8rem, 3vw, 2.5rem);
+    border: 1px solid rgba(112, 86, 255, 0.18);
+    box-shadow: var(--shadow-soft);
     overflow: hidden;
 }
 
-.welcome-title {
-    font-size: 1.8rem;
-    color: var(--dark-color);
-    margin-bottom: 10px;
-    font-weight: 500;
+.page-header::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 20% 20%, rgba(112, 86, 255, 0.3), transparent 60%);
+    opacity: 0.8;
+    pointer-events: none;
 }
 
-.welcome-text {
-    color: #7f8c8d;
-    margin-bottom: 20px;
-    max-width: 700px;
+.header-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.4rem 0.85rem;
+    background: rgba(255, 255, 255, 0.92);
+    color: var(--primary-color);
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    border-radius: var(--radius-pill);
+    font-weight: 600;
+    position: relative;
+    z-index: 1;
 }
 
-/* Quick Actions */
+.header-title {
+    margin: 1.2rem 0 0.5rem;
+    font-size: clamp(1.9rem, 4vw, 2.6rem);
+    font-weight: 700;
+    color: #171f34;
+    position: relative;
+    z-index: 1;
+}
+
+.header-description {
+    margin: 0;
+    max-width: 640px;
+    color: var(--muted-color);
+    font-size: 0.95rem;
+    position: relative;
+    z-index: 1;
+}
+
+.header-bottom {
+    position: relative;
+    z-index: 1;
+    margin-top: 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.header-stats {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.stat-card {
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(112, 86, 255, 0.14);
+    padding: 1.1rem 1.3rem;
+    backdrop-filter: blur(10px);
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.stat-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted-color);
+    font-weight: 600;
+}
+
+.stat-value {
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: #171f34;
+}
+
+.stat-trend {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.stat-trend i {
+    font-size: 0.75rem;
+}
+
+.stat-trend.positive {
+    color: var(--success-color);
+}
+
+.stat-trend.negative {
+    color: var(--danger-color);
+}
+
+.stat-trend.neutral {
+    color: var(--muted-color);
+}
+
+.header-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    width: 100%;
+    align-items: flex-start;
+}
+
+.actions-title {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted-color);
+    font-weight: 600;
+    text-align: left;
+}
+
 .quick-actions {
     display: flex;
-    gap: 15px;
-    margin-bottom: 30px;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    width: 100%;
 }
 
 .btn {
-    padding: 12px 25px;
+    padding: 12px 24px;
     border: none;
-    border-radius: 6px;
-    font-weight: 500;
+    border-radius: var(--radius-pill);
+    font-weight: 600;
     cursor: pointer;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    transition: all var(--transition-speed) ease;
+    gap: 0.5rem;
     font-size: 0.95rem;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .btn i {
-    margin-right: 8px;
+    font-size: 1rem;
 }
 
 .btn-primary {
-    background-color: var(--secondary-color);
-    color: white;
-}
-
-.btn-primary:hover {
-    background-color: #2980b9;
-    transform: translateY(-2px);
-    box-shadow: 0 4px 8px rgba(41, 128, 185, 0.3);
+    background: linear-gradient(135deg, var(--primary-color), #8a75ff);
+    color: #fff;
 }
 
 .btn-success {
-    background-color: var(--success-color);
-    color: white;
-}
-
-.btn-success:hover {
-    background-color: #219653;
-    transform: translateY(-2px);
-    box-shadow: 0 4px 8px rgba(33, 150, 83, 0.3);
+    background: linear-gradient(135deg, var(--success-color), #22c55e);
+    color: #fff;
 }
 
 .btn-danger {
-    background-color: var(--accent-color);
-    color: white;
-}
-
-.btn-danger:hover {
-    background-color: #c0392b;
-    transform: translateY(-2px);
-    box-shadow: 0 4px 8px rgba(231, 76, 60, 0.3);
+    background: linear-gradient(135deg, var(--danger-color), #f87171);
+    color: #fff;
 }
 
 .btn-warning {
-    background-color: var(--warning-color);
-    color: white;
+    background: linear-gradient(135deg, var(--warning-color), #ff8f00);
+    color: #fff;
 }
 
-.btn-warning:hover {
-    background-color: #e67e22;
+.btn:hover {
     transform: translateY(-2px);
-    box-shadow: 0 4px 8px rgba(230, 126, 34, 0.3);
+    box-shadow: 0 16px 40px -30px rgba(112, 86, 255, 0.65);
 }
 
-/* Dashboard Grid */
+/* Dashboard */
 .dashboard-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    gap: 20px;
-    margin-bottom: 30px;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1.75rem;
 }
 
-/* Dashboard Cards */
 .dashboard-card {
-    background: white;
-    border-radius: 10px;
-    padding: 20px;
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.05);
+    background: var(--card-bg);
+    border-radius: var(--radius-lg);
+    padding: 1.65rem;
+    border: 1px solid var(--border-color);
+    box-shadow: var(--shadow-soft);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    position: relative;
+    overflow: hidden;
 }
 
 .card-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 15px;
-    padding-bottom: 10px;
-    border-bottom: 1px solid #eee;
+    gap: 1rem;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 1rem;
+}
+
+.card-heading {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.card-eyebrow {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted-color);
+    font-weight: 600;
 }
 
 .card-title {
     font-size: 1.1rem;
-    font-weight: 500;
-    color: var(--dark-color);
+    font-weight: 600;
+    color: #1f2538;
     display: flex;
     align-items: center;
+    gap: 0.55rem;
 }
 
 .card-title i {
-    margin-right: 10px;
-    color: var(--secondary-color);
+    color: var(--primary-color);
+    font-size: 1.1rem;
 }
 
 .card-actions {
     display: flex;
-    gap: 10px;
+    gap: 0.5rem;
 }
 
 .card-action-btn {
-    background: none;
+    background: rgba(112, 86, 255, 0.08);
     border: none;
-    color: #95a5a6;
+    color: var(--primary-color);
+    width: 38px;
+    height: 38px;
+    border-radius: 12px;
     cursor: pointer;
-    font-size: 1rem;
-    transition: color var(--transition-speed) ease;
+    transition: transform 0.2s ease, background 0.2s ease;
 }
 
 .card-action-btn:hover {
-    color: var(--secondary-color);
+    transform: translateY(-2px);
+    background: rgba(112, 86, 255, 0.16);
 }
 
-/* Stock Alert List */
-.stock-alert-list {
+/* Lists */
+.stock-alert-list,
+.activity-list {
     list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
 }
 
-.stock-alert-item {
+.stock-alert-item,
+.activity-item {
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    padding: 10px 0;
-    border-bottom: 1px solid #f5f5f5;
+    justify-content: space-between;
+    gap: 1rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.stock-alert-item:last-child,
+.activity-item:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
 }
 
 .stock-alert-info {
     display: flex;
     align-items: center;
+    gap: 0.85rem;
 }
 
 .stock-alert-icon {
-    width: 40px;
-    height: 40px;
-    background-color: rgba(231, 76, 60, 0.1);
-    border-radius: 50%;
+    width: 44px;
+    height: 44px;
+    border-radius: 16px;
+    background: rgba(255, 107, 107, 0.12);
+    color: var(--danger-color);
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-right: 10px;
-    color: var(--accent-color);
+    font-size: 1rem;
 }
 
 .stock-alert-name {
-    font-weight: 500;
+    font-weight: 600;
+    color: var(--text-color);
 }
 
 .stock-alert-detail {
-    font-size: 0.8rem;
-    color: #7f8c8d;
+    font-size: 0.85rem;
+    color: var(--muted-color);
 }
 
 .stock-alert-stock {
-    font-weight: 500;
-    color: var(--accent-color);
-}
-
-/* Recent Activity List */
-.activity-list {
-    list-style: none;
-}
-
-.activity-item {
-    padding: 10px 0;
-    border-bottom: 1px solid #f5f5f5;
-    display: flex;
-    align-items: center;
+    font-weight: 600;
+    color: var(--danger-color);
 }
 
 .activity-icon {
-    width: 30px;
-    height: 30px;
-    background-color: rgba(52, 152, 219, 0.1);
+    width: 44px;
+    height: 44px;
     border-radius: 50%;
+    background: rgba(112, 86, 255, 0.12);
+    color: var(--primary-color);
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-right: 10px;
-    color: var(--secondary-color);
-    font-size: 0.9rem;
+    font-size: 1rem;
+    overflow: hidden;
 }
-  .activity-avatar {
-      width: 100%;
-      height: 100%;
-      border-radius: 50%;
-      object-fit: cover;
-  }
 
+.activity-icon img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%;
+    border: 2px solid #ffffff;
+    box-shadow: 0 4px 12px -6px rgba(17, 24, 39, 0.4);
+}
 
 .activity-details {
     flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
 }
 
 .activity-description {
-    font-size: 0.9rem;
+    font-size: 0.95rem;
+    font-weight: 500;
 }
 
 .activity-time {
     font-size: 0.8rem;
-    color: #7f8c8d;
+    color: var(--muted-color);
 }
 
-/* Empty State */
 .empty-state {
     text-align: center;
-    padding: 30px;
-    color: #95a5a6;
+    padding: 32px 12px;
+    color: var(--muted-color);
 }
 
 .empty-state i {
     font-size: 2rem;
-    margin-bottom: 10px;
-    color: #bdc3c7;
+    color: rgba(112, 86, 255, 0.35);
+    margin-bottom: 12px;
 }
 
-/* Tutorial Styles */
+/* Tutorial */
 .tutorial-spotlight {
     position: relative;
     z-index: 1002;
@@ -539,35 +705,35 @@ body {
 }
 
 @keyframes pulse {
-    0% { box-shadow: 0 0 0 0 rgba(52, 152, 219, 0.7); }
-    70% { box-shadow: 0 0 0 15px rgba(52, 152, 219, 0); }
-    100% { box-shadow: 0 0 0 0 rgba(52, 152, 219, 0); }
+    0% {
+        box-shadow: 0 0 0 0 rgba(112, 86, 255, 0.45);
+    }
+    70% {
+        box-shadow: 0 0 0 18px rgba(112, 86, 255, 0);
+    }
+    100% {
+        box-shadow: 0 0 0 0 rgba(112, 86, 255, 0);
+    }
 }
 
 .tutorial-overlay-bg {
     position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.7);
+    inset: 0;
+    background: rgba(15, 23, 42, 0.65);
     z-index: 1000;
 }
 
 .tutorial-hole {
     position: absolute;
-    border-radius: 8px;
-    box-shadow: 0 0 0 9999px rgba(0,0,0,0.7);
+    border-radius: 18px;
+    box-shadow: 0 0 0 9999px rgba(15, 23, 42, 0.7);
     pointer-events: none;
     transition: all 0.3s ease;
 }
 
 .tutorial-card-container {
     position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    inset: 0;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -576,308 +742,196 @@ body {
 }
 
 .tutorial-card {
-    background-color: white;
-    border-radius: 10px;
-    padding: 30px;
-    max-width: 500px;
-    position: relative;
-    animation: fadeIn 0.3s ease;
+    background: #fff;
+    border-radius: var(--radius-lg);
+    padding: 32px;
+    max-width: 480px;
+    box-shadow: var(--shadow-soft);
     pointer-events: auto;
-    box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+    animation: fadeIn 0.3s ease;
 }
 
 @keyframes fadeIn {
-    from { opacity: 0; transform: translateY(20px); }
-    to { opacity: 1; transform: translateY(0); }
+    from {
+        opacity: 0;
+        transform: translateY(18px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 .tutorial-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 20px;
+    margin-bottom: 18px;
 }
 
 .tutorial-title {
-    font-size: 1.3rem;
-    color: var(--dark-color);
-    font-weight: 500;
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: var(--text-color);
 }
 
 .tutorial-close {
     background: none;
     border: none;
     font-size: 1.5rem;
-    color: #95a5a6;
     cursor: pointer;
+    color: var(--muted-color);
 }
 
 .tutorial-content {
-    margin-bottom: 20px;
-    line-height: 1.6;
+    color: var(--muted-color);
+    font-size: 0.95rem;
+    margin-bottom: 18px;
 }
 
 .tutorial-indicator {
-    text-align: center;
-    color: #95a5a6;
-    margin-top: 20px;
+    font-size: 0.85rem;
+    color: var(--muted-color);
+    margin-bottom: 18px;
 }
 
 .tutorial-actions {
     display: flex;
-    justify-content: space-between;
-    margin-top: 20px;
+    justify-content: flex-end;
+    gap: 0.75rem;
 }
 
 .tutorial-btn {
-    padding: 8px 20px;
-    border-radius: 5px;
+    padding: 10px 18px;
+    border-radius: var(--radius-pill);
+    border: none;
     cursor: pointer;
-    transition: all 0.2s ease;
+    font-weight: 600;
+    font-size: 0.85rem;
 }
 
 .tutorial-skip {
-    background: none;
-    border: 1px solid #ddd;
-    color: #7f8c8d;
-}
-
-.tutorial-skip:hover {
-    background: #f5f5f5;
+    background: rgba(112, 86, 255, 0.1);
+    color: var(--primary-color);
 }
 
 .tutorial-next {
-    background-color: var(--secondary-color);
-    color: white;
-    border: none;
+    background: var(--primary-color);
+    color: #fff;
 }
 
-.tutorial-next:hover {
-    background-color: #2980b9;
-}
-
-/* Menu Toggle Button */
-.menu-toggle {
-    background: none;
-    border: none;
-    color: var(--topbar-text-color);
-    font-size: 1.3rem;
-    cursor: pointer;
-    margin-right: 15px;
+/* Modal */
+.modal-overlay,
+.color-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.6);
     display: none;
-}
-
-/* Sidebar Collapsed State */
-.sidebar.collapsed {
-    width: 70px;
-    overflow: hidden;
-}
-
-.sidebar-logo {
-  display: block;
-  width: 80%;
-  margin: 0 auto;
-  padding: 15px 0;
-}
-
-.sidebar.collapsed .sidebar-header h2,
-.sidebar.collapsed .sidebar-menu a span,
-.sidebar.collapsed .sidebar-footer button span {
-    display: none;
-}
-
-.sidebar.collapsed .sidebar-header h2 i,
-.sidebar.collapsed .sidebar-menu a i,
-.sidebar.collapsed .sidebar-footer button i {
-    margin-right: 0;
-    font-size: 1.3rem;
-}
-
-.sidebar.collapsed .sidebar-menu a {
+    align-items: center;
     justify-content: center;
-    padding: 12px 0;
-    border-left: none;
-    border-right: 4px solid transparent;
+    z-index: 1000;
 }
 
-.sidebar.collapsed .sidebar-menu a:hover {
-    border-left: none;
-    border-right: 4px solid var(--secondary-color);
+.modal-content,
+.color-options {
+    background: #fff;
+    border-radius: var(--radius-lg);
+    padding: 32px;
+    max-width: 420px;
+    width: 90%;
+    box-shadow: var(--shadow-soft);
 }
 
-.sidebar.collapsed .sidebar-menu a.active {
-    border-left: none;
-    border-right: 4px solid var(--secondary-color);
+.color-options h3 {
+    margin-top: 0;
+    margin-bottom: 18px;
+    font-size: 1.1rem;
+    color: var(--text-color);
 }
 
-/* Adjust content when sidebar is collapsed */
-.sidebar.collapsed + .topbar {
-    left: 70px;
+.color-palette {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(34px, 1fr));
+    gap: 0.75rem;
+    margin-bottom: 1.25rem;
 }
 
-.sidebar.collapsed ~ .content {
-    margin-left: 70px;
+.color-palette button {
+    width: 34px;
+    height: 34px;
+    border-radius: 12px;
+    border: 2px solid #fff;
+    cursor: pointer;
+    box-shadow: 0 10px 24px -18px rgba(17, 24, 39, 0.65);
 }
 
-/* Responsive Design */
-@media (max-width: 992px) {
-    .menu-toggle {
-        display: block;
+/* Responsive */
+@media (max-width: 1200px) {
+    .content {
+        padding: 28px 24px;
     }
-    
+
+    .dashboard-grid {
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+}
+
+@media (max-width: 992px) {
     .sidebar {
+        width: 240px;
         transform: translateX(-100%);
     }
-    
+
     .sidebar.active {
         transform: translateX(0);
     }
-    
-    .sidebar.collapsed {
-        transform: translateX(-100%);
-    }
-    
-    .sidebar.collapsed.active {
-        transform: translateX(0);
-    }
-    
+
     .topbar {
         left: 0;
+        padding: 0 24px;
     }
-    
+
     .content {
         margin-left: 0;
     }
-    
+
     .search-bar {
-        width: 200px;
+        width: 220px;
     }
-    
+
+    body.sidebar-open {
+        overflow: hidden;
+    }
+}
+
+@media (max-width: 768px) {
+    .topbar {
+        padding: 0 20px;
+    }
+
+    .content {
+        padding: 24px 20px;
+    }
+
+    .search-bar {
+        display: none;
+    }
+
     .dashboard-grid {
         grid-template-columns: 1fr;
     }
-    
+}
+
+@media (max-width: 576px) {
+    .page-header {
+        padding: 1.75rem;
+    }
+
     .quick-actions {
-        flex-wrap: wrap;
+        flex-direction: column;
     }
-    
-    .tutorial-card {
-        max-width: 90%;
-        margin: 0 auto;
+
+    .btn {
+        width: 100%;
     }
-}
-
-.modal-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0,0,0,0.7);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 2000;
-}
-
-.modal-content {
-    background: #fff;
-    color: #333;
-    padding: 40px;
-    border-radius: 12px;
-    text-align: center;
-    max-width: 400px;
-    box-shadow: 0 0 20px rgba(0,0,0,0.4);
-}
-
-.modal-content h2 {
-    margin-bottom: 15px;
-    font-size: 1.6rem;
-}
-
-.modal-content button {
-    background: #e67e22;
-    color: #fff;
-    border: none;
-    padding: 12px 24px;
-    border-radius: 8px;
-    font-size: 1rem;
-    cursor: pointer;
-    margin-top: 20px;
-    transition: background 0.3s ease;
-}
-
-.modal-content button:hover {
-    background: #d35400;
-}
-
-.modal-overlay {
-    position: fixed;
-    z-index: 9999;
-    top: 0; left: 0;
-    width: 100%; height: 100%;
-    background: rgba(0,0,0,0.6);
-    display: flex; justify-content: center; align-items: center;
-  }
-
-  .color-modal {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0,0,0,0.6);
-    display: none;
-    align-items: center;
-    justify-content: center;
-    z-index: 9999;
-}
-
-.color-options {
-    background: white;
-    padding: 30px;
-    border-radius: 12px;
-    text-align: center;
-}
-
-  .modal-content {
-    background: white;
-    padding: 30px;
-    border-radius: 12px;
-    text-align: center;
-  }
-  .color-options button {
-    width: 40px;
-    height: 40px;
-    margin: 5px;
-    border: 2px solid #ccc;
-    cursor: pointer;
-    border-radius: 5px;
-  }
-
-  .color-palette button {
-  width: 24px;
-  height: 24px;
-  border: none;
-  border-radius: 4px;
-  margin: 4px;
-  cursor: pointer;
-}
-
-@media (max-width: 600px) {
-  :root {
-    --sidebar-width: 220px;
-  }
-  .search-bar {
-    width: 150px;
-  }
-  .topbar-title {
-    font-size: 1rem;
-  }
-
-  .tutorial-card {
-    width: 95%;
-    max-width: none;
-    padding: 20px;
-  }
 }


### PR DESCRIPTION
## Summary
- rediseñar la vista de `main_menu.html` para incluir cabecera, métricas y acciones rápidas en línea con el resto del panel
- reemplazar la hoja de estilos del menú principal con el sistema de diseño usado en administración, inventario y cuenta
- ajustar componentes del tablero (tarjetas, listas y botones) para respetar la nueva paleta y tipografía
- reorganizar las métricas y acciones rápidas para mantener las tarjetas en una fila y colocar los botones debajo con el mismo estilo visual
- corregir el comportamiento del botón de menú en móviles, ocultarlo en escritorio y redondear los avatares de usuario en todo el panel

## Testing
- no se ejecutaron pruebas automatizadas (cambios visuales)


------
https://chatgpt.com/codex/tasks/task_e_68ca1b88b30c832cbcc930cd5550e623