### PR TITLE
Habilitar modal para crear y editar productos

### DIFF
--- a/pages/gest_inve/inventario.html
+++ b/pages/gest_inve/inventario.html
@@ -111,62 +111,6 @@
                 <button type="button" class="btn-add">+ Nuevo producto</button>
               </div>
 
-              <form id="productoForm" class="compact-form">
-                <input type="hidden" id="productoId" />
-                <div class="row g-3">
-                  <div class="col-md-6">
-                    <label for="productoNombre" class="form-label">Nombre</label>
-                    <input type="text" id="productoNombre" class="form-control" placeholder="Nombre del producto" required />
-                  </div>
-                  <div class="col-md-6">
-                    <label for="productoCategoria" class="form-label">Categoría</label>
-                    <select id="productoCategoria" class="form-select" required>
-                      <option value="">Categoría</option>
-                    </select>
-                  </div>
-                </div>
-                <div class="row g-3">
-                  <div class="col-md-6">
-                    <label for="productoSubcategoria" class="form-label">Subcategoría</label>
-                    <select id="productoSubcategoria" class="form-select" required>
-                      <option value="">Subcategoría</option>
-                    </select>
-                  </div>
-                  <div class="col-md-6">
-                    <label for="productoStock" class="form-label">Stock inicial</label>
-                    <input type="number" id="productoStock" class="form-control" placeholder="Cantidad" min="0" />
-                  </div>
-                </div>
-                <div class="row g-3">
-                  <div class="col-md-4">
-                    <label for="productoDimX" class="form-label">Dimensión X (m)</label>
-                    <input type="number" id="productoDimX" class="form-control" placeholder="Ancho" min="0" step="0.01" />
-                  </div>
-                  <div class="col-md-4">
-                    <label for="productoDimY" class="form-label">Dimensión Y (m)</label>
-                    <input type="number" id="productoDimY" class="form-control" placeholder="Alto" min="0" step="0.01" />
-                  </div>
-                  <div class="col-md-4">
-                    <label for="productoDimZ" class="form-label">Dimensión Z (m)</label>
-                    <input type="number" id="productoDimZ" class="form-control" placeholder="Largo" min="0" step="0.01" />
-                  </div>
-                </div>
-                <div class="row g-3">
-                  <div class="col-md-6">
-                    <label for="productoPrecio" class="form-label">Precio de compra</label>
-                    <input type="number" id="productoPrecio" class="form-control" placeholder="0.00" min="0" step="0.01" />
-                  </div>
-                  <div class="col-md-6">
-                    <label for="productoDesc" class="form-label">Descripción</label>
-                    <textarea id="productoDesc" class="form-control" placeholder="Características y notas"></textarea>
-                  </div>
-                </div>
-                <div class="form-actions">
-                  <button type="reset" class="btn btn-secondary">Cancelar</button>
-                  <button type="submit" class="btn btn-primary">Guardar</button>
-                </div>
-              </form>
-
               <div id="alertasStock" class="panel-alert" role="status"></div>
 
               <div class="items-grid">
@@ -251,6 +195,74 @@
         </div>
       </div>
     </section>
+  </div>
+
+  <div class="modal fade" id="productoModal" tabindex="-1" aria-labelledby="productoModalTitulo" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="productoModalTitulo">Nuevo producto</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+        </div>
+        <div class="modal-body">
+          <form id="productoForm" class="compact-form">
+            <input type="hidden" id="productoId" />
+            <div class="row g-3">
+              <div class="col-md-6">
+                <label for="productoNombre" class="form-label">Nombre</label>
+                <input type="text" id="productoNombre" class="form-control" placeholder="Nombre del producto" required />
+              </div>
+              <div class="col-md-6">
+                <label for="productoCategoria" class="form-label">Categoría</label>
+                <select id="productoCategoria" class="form-select" required>
+                  <option value="">Categoría</option>
+                </select>
+              </div>
+            </div>
+            <div class="row g-3">
+              <div class="col-md-6">
+                <label for="productoSubcategoria" class="form-label">Subcategoría</label>
+                <select id="productoSubcategoria" class="form-select" required>
+                  <option value="">Subcategoría</option>
+                </select>
+              </div>
+              <div class="col-md-6">
+                <label for="productoStock" class="form-label">Stock inicial</label>
+                <input type="number" id="productoStock" class="form-control" placeholder="Cantidad" min="0" />
+              </div>
+            </div>
+            <div class="row g-3">
+              <div class="col-md-4">
+                <label for="productoDimX" class="form-label">Dimensión X (m)</label>
+                <input type="number" id="productoDimX" class="form-control" placeholder="Ancho" min="0" step="0.01" />
+              </div>
+              <div class="col-md-4">
+                <label for="productoDimY" class="form-label">Dimensión Y (m)</label>
+                <input type="number" id="productoDimY" class="form-control" placeholder="Alto" min="0" step="0.01" />
+              </div>
+              <div class="col-md-4">
+                <label for="productoDimZ" class="form-label">Dimensión Z (m)</label>
+                <input type="number" id="productoDimZ" class="form-control" placeholder="Largo" min="0" step="0.01" />
+              </div>
+            </div>
+            <div class="row g-3">
+              <div class="col-md-6">
+                <label for="productoPrecio" class="form-label">Precio de compra</label>
+                <input type="number" id="productoPrecio" class="form-control" placeholder="0.00" min="0" step="0.01" />
+              </div>
+              <div class="col-md-6">
+                <label for="productoDesc" class="form-label">Descripción</label>
+                <textarea id="productoDesc" class="form-control" placeholder="Características y notas"></textarea>
+              </div>
+            </div>
+            <div class="form-actions">
+              <button type="reset" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+              <button type="submit" class="btn btn-primary">Guardar</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>


### PR DESCRIPTION
## Summary
- reemplazé el formulario inline de productos por un modal Bootstrap reutilizable en la página de inventario
- prelleno y abro el modal al editar un producto, cerrándolo automáticamente tras guardar
- añadí un controlador de modal y actualicé los botones de "Nuevo" para que utilicen el modal de productos

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca30ba00c0832c98e865bfa97f95bc