### PR TITLE
Fix responsive offsets when sidebar hidden

### DIFF
--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -900,6 +900,11 @@ img {
     .topbar {
         left: 0;
         padding: 0 24px;
+    }
+
+    .content {
+        margin-left: 0;
+    }
 }
 
 /* Modal */
@@ -963,11 +968,15 @@ img {
         width: 240px;
     }
 
-    .topbar {
+    .content {
+        margin-left: 0;
+    }
+
+    body.sidebar-open .topbar {
         left: 240px;
     }
 
-    .content {
+    body.sidebar-open .content {
         margin-left: 240px;
     }
 


### PR DESCRIPTION
## Summary
- reset the topbar and content offsets to zero when the sidebar is hidden on medium screens
- reapply the 240px offsets only when the sidebar is opened so content shifts correctly

## Testing
- Manual verification at ~992px viewport toggling the sidebar

------
https://chatgpt.com/codex/tasks/task_e_68ca3999cde4832c86ec0d7bd18b12d2