### PR TITLE
Revamp main menu hero styling

### DIFF
--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -16,9 +16,9 @@
     --radius-pill: 999px;
     --font-main: "Poppins", sans-serif;
     --sidebar-color: #171f34;
-    --topbar-color: #ffffff;
+    --topbar-color: linear-gradient(90deg, #0fb4d4 0%, #ff6f91 45%, #ff9671 100%);
     --sidebar-text-color: #ffffff;
-    --topbar-text-color: #1f2538;
+    --topbar-text-color: #ffffff;
     --sidebar-width: 280px;
     --topbar-height: 74px;
     --transition-speed: 0.3s;
@@ -122,9 +122,10 @@ img {
     align-items: center;
     justify-content: space-between;
     padding: 0 32px;
-    border-bottom: 1px solid var(--border-color);
-    box-shadow: 0 12px 32px -28px rgba(17, 24, 39, 0.65);
+    border-bottom: none;
+    box-shadow: 0 22px 45px -28px rgba(255, 111, 145, 0.55);
     z-index: 90;
+    color: var(--topbar-text-color);
 }
 
 .menu-toggle {
@@ -134,8 +135,8 @@ img {
     width: 44px;
     height: 44px;
     border-radius: 14px;
-    border: 1px solid var(--border-color);
-    background: rgba(255, 255, 255, 0.65);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: rgba(255, 255, 255, 0.15);
     color: var(--topbar-text-color);
     font-size: 1.1rem;
     cursor: pointer;
@@ -144,7 +145,7 @@ img {
 
 .menu-toggle:hover {
     transform: translateY(-2px);
-    box-shadow: 0 12px 32px -24px rgba(112, 86, 255, 0.45);
+    box-shadow: 0 12px 32px -20px rgba(255, 255, 255, 0.55);
 }
 
 @media (min-width: 993px) {
@@ -157,6 +158,7 @@ img {
     font-size: 1.2rem;
     font-weight: 600;
     color: var(--topbar-text-color);
+    text-shadow: 0 4px 12px rgba(15, 50, 87, 0.25);
 }
 
 .topbar-actions {
@@ -173,18 +175,18 @@ img {
 .search-bar input {
     width: 100%;
     padding: 12px 18px 12px 46px;
-    border: 1px solid var(--border-color);
+    border: 1px solid rgba(255, 255, 255, 0.45);
     border-radius: var(--radius-pill);
     font-size: 0.95rem;
-    background: rgba(255, 255, 255, 0.85);
-    color: var(--text-color);
+    background: rgba(255, 255, 255, 0.9);
+    color: #274060;
     transition: border-color var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
 }
 
 .search-bar input:focus {
     outline: none;
-    border-color: rgba(112, 86, 255, 0.55);
-    box-shadow: 0 0 0 4px rgba(112, 86, 255, 0.12);
+    border-color: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.3);
 }
 
 .search-bar i {
@@ -192,7 +194,7 @@ img {
     left: 18px;
     top: 50%;
     transform: translateY(-50%);
-    color: var(--muted-color);
+    color: rgba(39, 64, 96, 0.55);
     font-size: 0.95rem;
 }
 
@@ -208,15 +210,16 @@ img {
     width: 42px;
     height: 42px;
     border-radius: 14px;
-    border: 1px solid var(--border-color);
-    background: rgba(255, 255, 255, 0.6);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: rgba(255, 255, 255, 0.2);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .notification-bell:hover,
 .alert-settings:hover {
     transform: translateY(-2px);
-    box-shadow: 0 12px 32px -24px rgba(112, 86, 255, 0.4);
+    background: rgba(255, 255, 255, 0.3);
+    box-shadow: 0 12px 32px -20px rgba(15, 50, 87, 0.35);
 }
 
 .notification-badge {
@@ -246,13 +249,10 @@ img {
 .user-profile img {
     width: 42px;
     height: 42px;
-    border-radius: 50%;
-    object-fit: cover;
-    background: rgba(112, 86, 255, 0.12);
-    border: 2px solid rgba(255, 255, 255, 0.6);
     border-radius: 14px;
     object-fit: cover;
-    background: rgba(112, 86, 255, 0.12);
+    background: rgba(255, 255, 255, 0.25);
+    border: 2px solid rgba(255, 255, 255, 0.5);
 }
 
 .user-info {
@@ -269,8 +269,7 @@ img {
 
 .user-role {
     font-size: 0.8rem;
-    color: var(--topbar-text-color);
-    opacity: 0.65;
+    color: rgba(255, 255, 255, 0.75);
 }
 
 .dropdown-toggle {
@@ -287,7 +286,7 @@ img {
     top: calc(100% + 10px);
     right: 0;
     background: #fff;
-    border: 1px solid var(--border-color);
+    border: 1px solid rgba(15, 50, 87, 0.08);
     border-radius: var(--radius-md);
     box-shadow: var(--shadow-soft);
     width: 180px;
@@ -299,7 +298,7 @@ img {
     display: block;
     padding: 10px 18px;
     text-decoration: none;
-    color: var(--text-color);
+    color: #1f2538;
     font-size: 0.9rem;
     transition: background var(--transition-speed) ease;
 }
@@ -332,21 +331,38 @@ img {
 
 .page-header {
     position: relative;
-    background: linear-gradient(135deg, var(--primary-soft), rgba(0, 196, 204, 0.12));
+    background: linear-gradient(135deg, #dff3ff 0%, #f1e5ff 50%, #ffe3f1 100%);
     border-radius: var(--radius-lg);
-    padding: clamp(1.8rem, 3vw, 2.5rem);
-    border: 1px solid rgba(112, 86, 255, 0.18);
-    box-shadow: var(--shadow-soft);
+    padding: clamp(1.8rem, 3vw, 2.6rem);
+    border: none;
+    box-shadow: 0 35px 65px -45px rgba(15, 40, 65, 0.45);
     overflow: hidden;
 }
 
+.page-header::before,
 .page-header::after {
     content: "";
     position: absolute;
-    inset: 0;
-    background: radial-gradient(circle at 20% 20%, rgba(112, 86, 255, 0.3), transparent 60%);
-    opacity: 0.8;
+    border-radius: 40%;
+    filter: blur(0.4px);
+    opacity: 0.45;
     pointer-events: none;
+}
+
+.page-header::before {
+    width: 260px;
+    height: 260px;
+    background: radial-gradient(circle, rgba(255, 111, 145, 0.35) 0%, transparent 65%);
+    top: -110px;
+    right: -80px;
+}
+
+.page-header::after {
+    width: 320px;
+    height: 320px;
+    background: radial-gradient(circle, rgba(15, 180, 212, 0.38) 0%, transparent 70%);
+    bottom: -140px;
+    left: -120px;
 }
 
 .header-eyebrow {
@@ -355,7 +371,7 @@ img {
     gap: 0.4rem;
     padding: 0.4rem 0.85rem;
     background: rgba(255, 255, 255, 0.92);
-    color: var(--primary-color);
+    color: #ff6f91;
     font-size: 0.75rem;
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -369,7 +385,7 @@ img {
     margin: 1.2rem 0 0.5rem;
     font-size: clamp(1.9rem, 4vw, 2.6rem);
     font-weight: 700;
-    color: #171f34;
+    color: #1f2538;
     position: relative;
     z-index: 1;
 }
@@ -377,7 +393,7 @@ img {
 .header-description {
     margin: 0;
     max-width: 640px;
-    color: var(--muted-color);
+    color: rgba(31, 37, 56, 0.7);
     font-size: 0.95rem;
     position: relative;
     z-index: 1;
@@ -389,9 +405,8 @@ img {
     margin-top: 2rem;
     display: flex;
     flex-direction: column;
-    gap: 1.5rem;
-    flex-wrap: wrap;
     gap: 1.75rem;
+    flex-wrap: wrap;
     justify-content: space-between;
     align-items: flex-start;
 }
@@ -403,28 +418,29 @@ img {
 }
 
 .stat-card {
-    background: rgba(255, 255, 255, 0.92);
+    background: rgba(255, 255, 255, 0.95);
     border-radius: var(--radius-md);
-    border: 1px solid rgba(112, 86, 255, 0.14);
+    border: none;
     padding: 1.1rem 1.3rem;
     backdrop-filter: blur(10px);
     display: flex;
     flex-direction: column;
     gap: 0.3rem;
+    box-shadow: 0 22px 45px -38px rgba(31, 37, 56, 0.55);
 }
 
 .stat-label {
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: var(--muted-color);
+    color: rgba(31, 37, 56, 0.55);
     font-weight: 600;
 }
 
 .stat-value {
     font-size: 1.6rem;
     font-weight: 700;
-    color: #171f34;
+    color: #1f2538;
 }
 
 .stat-trend {
@@ -454,7 +470,7 @@ img {
 .header-actions {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.85rem;
     width: 100%;
     align-items: flex-start;
     min-width: 260px;
@@ -464,7 +480,7 @@ img {
     font-size: 0.85rem;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: var(--muted-color);
+    color: rgba(31, 37, 56, 0.55);
     font-weight: 600;
     text-align: left;
 }
@@ -488,6 +504,7 @@ img {
     gap: 0.5rem;
     font-size: 0.95rem;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 20px 35px -25px rgba(255, 111, 145, 0.65);
 }
 
 .btn i {
@@ -516,7 +533,7 @@ img {
 
 .btn:hover {
     transform: translateY(-2px);
-    box-shadow: 0 16px 40px -30px rgba(112, 86, 255, 0.65);
+    box-shadow: 0 22px 45px -25px rgba(15, 40, 65, 0.35);
 }
 
 /* Dashboard */


### PR DESCRIPTION
## Summary
- actualizar la barra superior con un degradado coral-menta y controles translúcidos para replicar el diseño de referencia
- renovar el encabezado del panel principal con fondos degradados, acentos radiales y tarjetas de estadísticas más limpias
- ajustar botones y textos para mantener el contraste y las sombras suaves del mockup

## Testing
- No tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca3912b704832c9f38c3396058ba7f