### PR TITLE
Refactor área y zonas UI to match modern dashboard

### DIFF
--- a/pages/area_almac_v2/gestion_areas_zonas.html
+++ b/pages/area_almac_v2/gestion_areas_zonas.html
@@ -1,161 +1,203 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Gestión de Áreas y Zonas</title>
-  <!-- Bootstrap CSS -->
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="../../styles/Area_almac_v2/gestion_areas_zonas.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="../../styles/Area_almac_v2/gestion_areas_zonas.css" />
   <script defer src="../../scripts/area_almac_v2/gestion_areas_zonas.js"></script>
 </head>
-<body class="p-4">
-  <div class="container">
-    <h1 class="mb-4">Gestión de Áreas y Zonas</h1>
+<body>
+  <div class="warehouse-page">
+    <section class="page-header">
+      <span class="header-eyebrow">Infraestructura</span>
+      <h1 class="header-title">Gestión de áreas y zonas</h1>
+      <p class="header-description">
+        Organiza tu almacén con la misma experiencia visual de los módulos de inventario y bitácora. Registra áreas, agrega zonas
+        y mantén actualizado el mapa logístico de tu operación.
+      </p>
 
-    <!-- Botones de selección -->
-    <div class="mb-4">
-      <button id="nuevaArea" class="btn btn-primary me-2">Registrar nueva Área</button>
-      <button id="nuevaZona" class="btn btn-secondary">Registrar nueva Zona</button>
-    </div>
+      <div class="header-highlights">
+        <article class="highlight-card">
+          <span class="card-label">Áreas activas</span>
+          <strong class="card-title" id="totalAreas">0</strong>
+          <span class="card-subtitle">Espacios principales definidos</span>
+        </article>
+        <article class="highlight-card">
+          <span class="card-label">Zonas creadas</span>
+          <strong class="card-title" id="totalZonas">0</strong>
+          <span class="card-subtitle">Segmentos operativos</span>
+        </article>
+        <article class="highlight-card">
+          <span class="card-label">Zonas sin área</span>
+          <strong class="card-title" id="zonasSinArea">0</strong>
+          <span class="card-subtitle">Pendientes de asignar</span>
+        </article>
+      </div>
+    </section>
 
-    <!-- Formularios a ancho completo -->
-    <div id="formularios">
-      <!-- Formulario Áreas -->
-      <form id="formArea" class="mb-4">
-        <h2 class="h5 mb-3">Nueva Área</h2>
-        <div class="mb-2">
-          <label for="areaNombre" class="form-label">Nombre</label>
-          <input type="text" id="areaNombre" class="form-control" required>
+    <section class="warehouse-shell">
+      <div class="shell-header">
+        <div class="shell-header__info">
+          <span class="shell-eyebrow">Mapa logístico</span>
+          <h2 class="shell-title">Controla ubicaciones y espacios del almacén</h2>
+          <p class="shell-subtitle">
+            Alterna entre formularios y consulta los resúmenes generales desde una vista limpia y moderna coherente con el resto del sistema.
+          </p>
         </div>
-        <div class="mb-2">
-          <label for="areaDescripcion" class="form-label">Descripción</label>
-          <textarea id="areaDescripcion" class="form-control" rows="3" required></textarea>
+        <div class="shell-header__actions">
+          <button id="nuevaArea" class="shell-action shell-action--primary">Registrar nueva área</button>
+          <button id="nuevaZona" class="shell-action">Registrar nueva zona</button>
         </div>
-        <div class="mb-2">
-          <label class="form-label">Dimensiones (m)</label>
-          <div class="d-flex gap-2">
-            <input type="number" id="areaLargo" class="form-control" placeholder="Largo" min="0" step="0.01" required>
-            <input type="number" id="areaAncho" class="form-control" placeholder="Ancho" min="0" step="0.01" required>
-            <input type="number" id="areaAlto" class="form-control" placeholder="Alto" min="0" step="0.01" required>
+      </div>
+
+      <div class="shell-grid">
+        <div class="summary-stack">
+          <section id="resumenAreas" class="data-card" aria-labelledby="tituloAreas">
+            <header class="data-card__header">
+              <span class="summary-eyebrow">Vista general</span>
+              <h3 id="tituloAreas" class="data-card__title">Áreas registradas</h3>
+              <p class="data-card__description">Detalle de dimensiones, volumen calculado y zonas asociadas.</p>
+            </header>
+            <div class="table-wrapper">
+              <table id="tablaAreas" class="data-table">
+                <thead>
+                  <tr>
+                    <th>Área</th>
+                    <th>Descripción</th>
+                    <th>Dimensiones (m)</th>
+                    <th>Volumen (m³)</th>
+                    <th># Zonas</th>
+                    <th>Acciones</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </section>
+
+          <section id="resumenZonas" class="data-card" aria-labelledby="tituloZonas">
+            <header class="data-card__header">
+              <span class="summary-eyebrow">Zonas asignadas</span>
+              <h3 id="tituloZonas" class="data-card__title">Resumen de zonas</h3>
+              <p class="data-card__description">Zonas vinculadas a un área específica y su tipo de almacenamiento.</p>
+            </header>
+            <div class="table-wrapper">
+              <table id="tablaZonas" class="data-table">
+                <thead>
+                  <tr>
+                    <th>Zona</th>
+                    <th>Área</th>
+                    <th>Dimensiones (m)</th>
+                    <th>Volumen (m³)</th>
+                    <th>Tipo</th>
+                    <th>Acciones</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </section>
+
+          <section id="resumenZonasSinArea" class="data-card" aria-labelledby="tituloZonasSinArea">
+            <header class="data-card__header">
+              <span class="summary-eyebrow">Pendientes</span>
+              <h3 id="tituloZonasSinArea" class="data-card__title">Zonas sin asignar</h3>
+              <p class="data-card__description">Revisa qué zonas necesitan asociarse a un área para mantener el control.</p>
+            </header>
+            <div class="table-wrapper">
+              <table id="tablaZonasSinArea" class="data-table">
+                <thead>
+                  <tr>
+                    <th>Zona</th>
+                    <th>Dimensiones (m)</th>
+                    <th>Volumen (m³)</th>
+                    <th>Tipo</th>
+                    <th>Acciones</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </section>
+        </div>
+
+        <section class="forms-card">
+          <div class="form-toggle">
+            <span class="form-toggle__label">Completa la información para registrar nuevos espacios.</span>
           </div>
-        </div>
-        <div class="mb-3">
-          <p>Volumen: <span id="areaVolumen">0</span> m³</p>
-        </div>
-        <button type="submit" class="btn btn-success w-100">Guardar Área</button>
-      </form>
-      
-      <!-- Formulario Zonas -->
-      <form id="formZona" class="mb-4 d-none">
-        <h2 class="h5 mb-3">Nueva Zona</h2>
-        <div class="mb-2">
-          <label for="zonaNombre" class="form-label">Nombre</label>
-          <input type="text" id="zonaNombre" class="form-control" required>
-        </div>
-        <div class="mb-2">
-          <label for="zonaArea" class="form-label">Área</label>
-          <select id="zonaArea" class="form-select" required></select>
-        </div>
-        <div class="mb-2">
-          <label for="zonaDescripcion" class="form-label">Descripción</label>
-          <textarea id="zonaDescripcion" class="form-control" rows="3" required></textarea>
-        </div>
-        <div class="mb-2">
-          <label class="form-label">Dimensiones (m)</label>
-          <div class="d-flex gap-2">
-            <input type="number" id="zonaLargo" class="form-control" placeholder="Largo" min="0" step="0.01" required>
-            <input type="number" id="zonaAncho" class="form-control" placeholder="Ancho" min="0" step="0.01" required>
-            <input type="number" id="zonaAlto" class="form-control" placeholder="Alto" min="0" step="0.01" required>
-          </div>
-        </div>
-        <div class="mb-3">
-          <p>Volumen: <span id="zonaVolumen">0</span> m³</p>
-        </div>
-        <div class="mb-2">
-          <label for="zonaTipo" class="form-label">Tipo de Zona</label>
-          <select id="zonaTipo" class="form-select" required></select>
-        </div>
-        <div class="mb-2">
-          <label for="zonaSubniveles" class="form-label">Subniveles</label>
-          <input type="number" id="zonaSubniveles" class="form-control" min="0" value="0">
-        </div>
-        <div class="mb-3">
-          <label for="zonaDistancia" class="form-label">Distancia entre subniveles (cm)</label>
-          <input type="number" id="zonaDistancia" class="form-control" min="0" step="0.1" value="0">
-        </div>
-        <button type="submit" class="btn btn-success w-100">Guardar Zona</button>
-      </form>
-    </div>
 
-    <!-- Sección resumen Áreas con sus Zonas -->
-    <section id="resumenAreas" class="mb-5">
-  <h2 class="h5 mb-3">Resumen de Áreas</h2>
-  <div class="table-responsive">
-    <table id="tablaAreas" class="table table-striped align-middle">
-      <thead>
-        <tr>
-          <th>Área</th>
-          <th>Descripción</th>
-          <th>Dimensiones (m)</th>
-          <th>Volumen (m³)</th>
-          <th># Zonas</th>
-          <th>Acciones</th>
-        </tr>
-      </thead>
-      <tbody>
-        <!-- filas generadas por JS -->
-      </tbody>
-    </table>
+          <form id="formArea" class="formulario" autocomplete="off">
+            <h4>Registrar área de almacén</h4>
+            <div class="form-group">
+              <label for="areaNombre">Nombre del área</label>
+              <input type="text" id="areaNombre" placeholder="Nombre del área" required />
+            </div>
+            <div class="form-group">
+              <label for="areaDescripcion">Descripción</label>
+              <textarea id="areaDescripcion" rows="3" placeholder="Uso o características del área" required></textarea>
+            </div>
+            <div class="form-group">
+              <label>Dimensiones físicas (m)</label>
+              <div class="dimension-row">
+                <input type="number" id="areaAncho" placeholder="Ancho" min="0.01" step="0.01" required />
+                <input type="number" id="areaLargo" placeholder="Largo" min="0.01" step="0.01" required />
+                <input type="number" id="areaAlto" placeholder="Alto" min="0.01" step="0.01" required />
+              </div>
+            </div>
+            <p class="form-helper">Volumen estimado: <span id="areaVolumen">0</span> m³</p>
+            <div class="form-actions">
+              <button type="submit" class="shell-action shell-action--primary">Guardar área</button>
+            </div>
+          </form>
+
+          <form id="formZona" class="formulario d-none" autocomplete="off">
+            <h4>Registrar zona de almacenamiento</h4>
+            <div class="form-group">
+              <label for="zonaNombre">Nombre de la zona</label>
+              <input type="text" id="zonaNombre" placeholder="Nombre de la zona" required />
+            </div>
+            <div class="form-group">
+              <label for="zonaArea">Área asociada</label>
+              <select id="zonaArea" required>
+                <option value="">Seleccione un área</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label for="zonaDescripcion">Descripción</label>
+              <textarea id="zonaDescripcion" rows="3" placeholder="Uso específico o notas" required></textarea>
+            </div>
+            <div class="form-group">
+              <label>Dimensiones físicas (m)</label>
+              <div class="dimension-row">
+                <input type="number" id="zonaAncho" placeholder="Ancho" min="0.01" step="0.01" required />
+                <input type="number" id="zonaLargo" placeholder="Largo" min="0.01" step="0.01" required />
+                <input type="number" id="zonaAlto" placeholder="Alto" min="0.01" step="0.01" required />
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="zonaTipo">Tipo de almacenamiento</label>
+              <select id="zonaTipo" required></select>
+            </div>
+            <div class="form-group">
+              <label for="zonaSubniveles">Cantidad de subniveles</label>
+              <input type="number" id="zonaSubniveles" min="0" step="1" value="0" />
+            </div>
+            <div class="form-group">
+              <label for="zonaDistancia">Distancia entre subniveles (cm)</label>
+              <input type="number" id="zonaDistancia" min="0" step="0.1" value="0" />
+            </div>
+            <p class="form-helper">Volumen estimado: <span id="zonaVolumen">0</span> m³</p>
+            <div class="form-actions">
+              <button type="submit" class="shell-action shell-action--primary">Guardar zona</button>
+            </div>
+          </form>
+        </section>
+      </div>
+    </section>
   </div>
-</section>
-
-    <!-- Sección resumen Zonas -->
-    <section id="resumenZonas" class="mb-5">
-  <h2 class="h5 mb-3">Resumen de Zonas</h2>
-  <div class="table-responsive">
-    <table id="tablaZonas" class="table table-striped align-middle">
-      <thead>
-        <tr>
-          <th>Zona</th>
-          <th>Área</th>
-          <th>Dimensiones (m)</th>
-          <th>Volumen (m³)</th>
-          <th>Tipo</th>
-          <th>Acciones</th>
-        </tr>
-      </thead>
-      <tbody>
-        <!-- filas generadas por JS -->
-      </tbody>
-    </table>
-  </div>
-</section>
-
-<!-- Sección Zonas sin asignar -->
-<section id="resumenZonasSinArea" class="mb-5">
-  <h2 class="h5 mb-3">Zonas sin asignar a un área</h2>
-  <div class="table-responsive">
-    <table id="tablaZonasSinArea" class="table table-striped align-middle">
-      <thead>
-        <tr>
-          <th>Zona</th>
-          <th>Dimensiones (m)</th>
-          <th>Volumen (m³)</th>
-          <th>Tipo</th>
-          <th>Acciones</th>
-        </tr>
-      </thead>
-      <tbody>
-        <!-- filas JS -->
-      </tbody>
-    </table>
-  </div>
-</section>
-
-
-  </div>
-  <!-- Bootstrap JS para componentes -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/styles/Area_almac_v2/gestion_areas_zonas.css
+++ b/styles/Area_almac_v2/gestion_areas_zonas.css
@@ -1,94 +1,480 @@
-/* Gestión Áreas y Zonas — Estilos coherentes con Módulo Inventario */
-
-body {
-  font-family: Arial, sans-serif;
-  margin: 1rem;
-  background-color: #f8f9fa;
+:root {
+  --page-bg: #f5f6fb;
+  --card-bg: #ffffff;
+  --border-color: #e7e9f5;
+  --text-color: #1f2937;
+  --muted-color: #6b7280;
+  --primary-color: #7056ff;
+  --primary-soft: rgba(112, 86, 255, 0.08);
+  --accent-color: #00c4cc;
+  --danger-color: #ff6b6b;
+  --shadow-soft: 0 18px 40px -28px rgba(14, 20, 56, 0.55);
+  --radius-md: 16px;
+  --radius-lg: 22px;
+  --radius-pill: 999px;
+  --font-main: 'Poppins', sans-serif;
 }
 
-/* Tablas de resumen (si las usas) */
-table th,
-table td {
-  border: 1px solid #ccc;
-  padding: 4px;
-}
-
-/* Botones de acción */
-.actions button,
-button[type="submit"] {
-  background-color: #28a745;
-  color: #fff;
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  font-size: 1rem;
-  cursor: pointer;
-  margin-right: 0.5rem;
-}
-.actions button.btn-secondary {
-  background-color: #007bff;
-}
-.actions button:hover,
-button[type="submit"]:hover {
-  opacity: 0.9;
-}
-
-/* Formularios */
-form {
-  background: #fff;
-  padding: 1rem;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  margin-bottom: 1rem;
-}
-
-form label {
-  display: block;
-  margin-top: 0.5rem;
-  font-weight: bold;
-}
-
-form input,
-form textarea,
-form select {
-  width: 100%;
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  margin-top: 0.25rem;
-  font-size: 1rem;
+* {
   box-sizing: border-box;
 }
 
-/* Volumen */
-p span[id$="Volumen"] {
-  font-weight: bold;
+body {
+  margin: 0;
+  background: var(--page-bg);
+  color: var(--text-color);
+  font-family: var(--font-main);
+  min-height: 100vh;
 }
 
-/* Resumen de áreas/zonas */
-.resumen-item {
-  background: #fff;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  padding: 1rem;
-  margin-bottom: 1rem;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+img {
+  display: block;
+  max-width: 100%;
 }
 
-.resumen-item h3 {
-  margin-top: 0;
-  margin-bottom: 0.5rem;
+.d-none {
+  display: none !important;
 }
 
-/* Toast */
+.warehouse-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.page-header {
+  position: relative;
+  background: linear-gradient(135deg, rgba(112, 86, 255, 0.08), rgba(0, 196, 204, 0.08));
+  border-radius: var(--radius-lg);
+  padding: clamp(2rem, 4vw, 2.75rem);
+  overflow: hidden;
+  border: 1px solid rgba(112, 86, 255, 0.12);
+  box-shadow: var(--shadow-soft);
+}
+
+.page-header::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 15% 15%, rgba(112, 86, 255, 0.24), transparent 60%);
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.header-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--primary-color);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  position: relative;
+  z-index: 1;
+}
+
+.header-title {
+  margin: 1rem 0 0.5rem;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  font-weight: 700;
+  color: #171f34;
+  position: relative;
+  z-index: 1;
+}
+
+.header-description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted-color);
+  max-width: 640px;
+  position: relative;
+  z-index: 1;
+}
+
+.header-highlights {
+  position: relative;
+  z-index: 1;
+  margin-top: 2rem;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.highlight-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(112, 86, 255, 0.18);
+  padding: 1.25rem 1.5rem;
+  backdrop-filter: blur(12px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  box-shadow: 0 12px 32px -28px rgba(112, 86, 255, 0.9);
+}
+
+.card-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-color);
+  font-weight: 600;
+}
+
+.card-title {
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #171f34;
+}
+
+.card-subtitle {
+  font-size: 0.85rem;
+  color: var(--muted-color);
+}
+
+.warehouse-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.shell-header {
+  background: var(--card-bg);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 12px 40px -30px rgba(18, 26, 69, 0.55);
+  padding: clamp(1.5rem, 3vw, 2rem);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.shell-header__info {
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.shell-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: var(--radius-pill);
+  background: rgba(112, 86, 255, 0.1);
+  color: var(--primary-color);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.shell-title {
+  margin: 0;
+  font-size: clamp(1.2rem, 3vw, 1.7rem);
+  color: #1f2538;
+  font-weight: 600;
+}
+
+.shell-subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted-color);
+  max-width: 520px;
+}
+
+.shell-header__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.shell-action {
+  border-radius: var(--radius-pill);
+  border: 1px solid rgba(112, 86, 255, 0.25);
+  background: rgba(112, 86, 255, 0.08);
+  color: var(--primary-color);
+  padding: 0.65rem 1.5rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.shell-action[aria-pressed="true"] {
+  background: rgba(112, 86, 255, 0.18);
+  border-color: rgba(112, 86, 255, 0.38);
+}
+
+.shell-action:hover {
+  transform: translateY(-2px);
+  background: rgba(112, 86, 255, 0.14);
+  box-shadow: 0 12px 30px -22px rgba(112, 86, 255, 0.75);
+}
+
+.shell-action--primary {
+  background: linear-gradient(135deg, var(--primary-color), #8c75ff);
+  color: #ffffff;
+  border: none;
+  box-shadow: 0 18px 40px -28px rgba(112, 86, 255, 0.9);
+}
+
+.shell-action--primary:hover {
+  box-shadow: 0 22px 44px -30px rgba(112, 86, 255, 0.85);
+}
+
+.shell-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.summary-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.data-card,
+.forms-card {
+  background: var(--card-bg);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 18px 45px -32px rgba(18, 26, 69, 0.55);
+  padding: clamp(1.5rem, 3vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-height: 0;
+}
+
+.data-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.summary-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: var(--radius-pill);
+  background: rgba(112, 86, 255, 0.12);
+  color: var(--primary-color);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.data-card__title {
+  margin: 0;
+  font-size: clamp(1.1rem, 2.8vw, 1.6rem);
+  color: #1f2538;
+  font-weight: 600;
+}
+
+.data-card__description {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted-color);
+  max-width: 520px;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.data-table thead {
+  background: rgba(112, 86, 255, 0.08);
+  color: var(--primary-color);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.75rem;
+}
+
+.data-table th,
+.data-table td {
+  padding: 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.data-table tbody tr:hover {
+  background: rgba(112, 86, 255, 0.04);
+}
+
+.data-table .empty-row td {
+  text-align: center;
+  color: var(--muted-color);
+  font-style: italic;
+}
+
+.table-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.table-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4rem 0.9rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.table-action--edit {
+  background: rgba(112, 86, 255, 0.12);
+  color: var(--primary-color);
+}
+
+.table-action--edit:hover {
+  background: rgba(112, 86, 255, 0.18);
+  transform: translateY(-1px);
+}
+
+.table-action--delete {
+  background: rgba(255, 107, 107, 0.12);
+  color: #c53030;
+}
+
+.table-action--delete:hover {
+  background: rgba(255, 107, 107, 0.18);
+  transform: translateY(-1px);
+}
+
+.forms-card {
+  gap: 1rem;
+}
+
+.form-toggle__label {
+  font-size: 0.85rem;
+  color: var(--muted-color);
+}
+
+.formulario {
+  padding: clamp(1.25rem, 2.5vw, 1.75rem);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(112, 86, 255, 0.14);
+  background: linear-gradient(180deg, rgba(112, 86, 255, 0.05), rgba(255, 255, 255, 0.95));
+  box-shadow: 0 16px 40px -36px rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.formulario h4 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #1f2538;
+  font-weight: 600;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.form-group label {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--text-color);
+}
+
+.form-group input,
+.form-group textarea,
+.form-group select {
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  padding: 0.65rem 0.85rem;
+  font-size: 0.9rem;
+  background: rgba(245, 246, 251, 0.8);
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+  font-family: var(--font-main);
+}
+
+.form-group textarea {
+  resize: vertical;
+  min-height: 100px;
+}
+
+.form-group input:focus,
+.form-group textarea:focus,
+.form-group select:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(112, 86, 255, 0.18);
+}
+
+.dimension-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 0.75rem;
+}
+
+.form-helper {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted-color);
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .toast-message {
   position: fixed;
   bottom: 1rem;
   right: 1rem;
-  background: #333;
+  background: #1f2538;
   color: #fff;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  opacity: 0.9;
+  padding: 0.65rem 1.1rem;
+  border-radius: var(--radius-md);
+  box-shadow: 0 20px 40px -24px rgba(15, 23, 42, 0.45);
+  opacity: 0.95;
   z-index: 1000;
+}
+
+@media (max-width: 768px) {
+  .warehouse-page {
+    padding: 1.25rem;
+  }
+
+  .shell-header {
+    align-items: flex-start;
+  }
+
+  .shell-header__actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .shell-grid {
+    grid-template-columns: 1fr;
+  }
 }


### PR DESCRIPTION
## Summary
- Rebuild the áreas y zonas page with hero metrics, responsive data tables and split form layout to mirror the inventory and log modules.
- Refresh the áreas y zonas stylesheet with shared color variables, card design, table actions and mobile adjustments for a unified dashboard look.
- Update the management script to drive the new layout, maintain counters, toggle forms and use modern action buttons while preserving existing CRUD logic.

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca3e5e4688832c8b876c8821bc14eb