### PR TITLE
Round sidebar edges and extend topbar behind

### DIFF
--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -59,6 +59,8 @@ img {
     transition: width var(--transition-speed) ease, transform var(--transition-speed) ease;
     transform: translateX(0);
     transition: width var(--transition-speed) ease;
+    border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+    overflow: hidden;
 }
 
 .sidebar-header {
@@ -116,15 +118,16 @@ img {
     height: var(--topbar-height);
     position: fixed;
     top: 0;
-    left: var(--sidebar-width);
+    left: 0;
     right: 0;
     display: flex;
     align-items: center;
     justify-content: space-between;
     padding: 0 32px;
+    padding-left: calc(var(--sidebar-width) + 32px);
     border-bottom: none;
     box-shadow: 0 22px 45px -28px rgba(255, 111, 145, 0.55);
-    z-index: 90;
+    z-index: 80;
     color: var(--topbar-text-color);
 }
 
@@ -915,9 +918,9 @@ img {
     }
 
     .topbar {
-        left: 0;
         padding: 0 24px;
-}
+        padding-left: 24px;
+    }
 
 /* Modal */
 .modal-overlay,
@@ -981,7 +984,8 @@ img {
     }
 
     .topbar {
-        left: 240px;
+        padding: 0 24px;
+        padding-left: 24px;
     }
 
     .content {
@@ -1008,8 +1012,8 @@ img {
     }
 
     .topbar {
-        left: 0;
         padding: 0 20px;
+        padding-left: 20px;
     }
 
     .content {
@@ -1029,6 +1033,7 @@ img {
 @media (max-width: 768px) {
     .topbar {
         padding: 0 20px;
+        padding-left: 20px;
     }
 
     .content {


### PR DESCRIPTION
## Summary
- round the dashboard sidebar so its outer edge matches the card styling
- let the fixed topbar stretch behind the sidebar and offset its content with responsive padding overrides

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cb11968510832c986887d62099a783