### PR TITLE
Add slide animation when opening sidebar

### DIFF
--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -37,6 +37,21 @@ body {
     line-height: 1.6;
 }
 
+body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--transition-speed) ease;
+    z-index: 60;
+}
+
+body.sidebar-open::before {
+    opacity: 1;
+}
+
 img {
     max-width: 100%;
     display: block;
@@ -56,9 +71,8 @@ img {
     z-index: 100;
     display: flex;
     flex-direction: column;
-    transition: width var(--transition-speed) ease, transform var(--transition-speed) ease;
+    transition: transform var(--transition-speed) ease, width var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
     transform: translateX(0);
-    transition: width var(--transition-speed) ease;
     border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
     overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- ensure the sidebar transform animates smoothly when toggled
- add a subtle overlay when the sidebar is open so the rest of the page is not displaced visually

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb167d5320832c8f21e1177dbefa2d