### PR TITLE
Improve account page layout

### DIFF
--- a/pages/account_suscrip/account_suscrip.html
+++ b/pages/account_suscrip/account_suscrip.html
@@ -21,8 +21,8 @@
   <link rel="stylesheet" href="../../styles/account_suscrip/account_suscrip.css" />
 </head>
 <body>
-  <div class="account-page container-fluid py-4 px-3 px-md-4">
-    <section class="page-header">
+  <main class="account-page container-fluid py-4 px-3 px-md-4">
+    <header class="page-header">
       <span class="header-eyebrow">Centro de control</span>
       <h1 class="header-title">Configuración de cuenta</h1>
       <p class="header-description">
@@ -40,9 +40,6 @@
                 alt="Foto de perfil"
                 width="84"
                 height="84"
-                width="80"
-                height="80"
-
               />
             </div>
             <div class="profile-card__info">
@@ -63,9 +60,6 @@
                 alt="Logo de la empresa"
                 width="92"
                 height="92"
-                width="56"
-                height="56"
-
               />
             </div>
             <div class="company-card__info">
@@ -91,13 +85,14 @@
           </ul>
         </article>
       </div>
-    </section>
+    </header>
 
-    <section class="account-panel">
-      <nav class="account-menu">
-        <span class="menu-eyebrow">Secciones</span>
-        <ul>
-          <li class="active" data-target="secUser">
+    <div class="account-layout">
+      <aside class="account-sidebar">
+        <nav class="account-menu" aria-label="Secciones de cuenta">
+          <span class="menu-eyebrow">Secciones</span>
+          <ul>
+            <li class="active" data-target="secUser">
             <span class="menu-icon" aria-hidden="true">
               <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6">
                 <circle cx="12" cy="8" r="4"></circle>
@@ -150,8 +145,9 @@
           </li>
         </ul>
       </nav>
+      </aside>
 
-      <div class="account-content">
+      <div class="account-main">
         <section id="secUser" class="account-section active">
           <header class="section-header">
             <span class="section-eyebrow">Perfil</span>
@@ -206,9 +202,6 @@
                 alt="Logo de la empresa"
                 width="112"
                 height="112"
-                width="72"
-                height="72"
-
               />
             </div>
             <div class="company-summary__info">
@@ -233,25 +226,6 @@
         </section>
 
         <section id="secSuscripcion" class="account-section">
-          <span class="fw-bold d-block mb-2">Suscripción actual</span>
-
-          <div class="subscription-card">
-            <div class="d-flex align-items-center gap-2 mb-2">
-              <span class="fw-bold">Estado:</span>
-              <span id="subscriptionStatusBadge" class="badge rounded-pill bg-secondary">Inactivo (0)</span>
-            </div>
-            <p class="mb-1"><strong>Última renovación:</strong> <span id="subscriptionLastRenewal">-</span></p>
-            <p class="mb-0"><strong>Próxima renovación:</strong> <span id="subscriptionNextRenewal">-</span></p>
-          </div>
-
-          <div id="subscriptionMessage" class="alert alert-warning d-none mt-3" role="alert"></div>
-
-          <div class="subscription-actions mt-3">
-            <button class="btn btn-success" id="btnSubscriptionToggle">Activar suscripción</button>
-            <button class="btn btn-outline-primary" id="btnSubscriptionRenew">Renovar por un mes</button>
-          </div>
-
-          <p class="subscription-note text-muted mt-2">Esta suscripción se guarda en este navegador y cambia el estado entre 0 (inactivo) y 1 (activo). Renueva cada mes con un solo clic.</p>
           <header class="section-header">
             <span class="section-eyebrow">Suscripción</span>
             <h2 class="section-title">Plan y facturación</h2>
@@ -260,19 +234,43 @@
             </p>
           </header>
 
-          <div class="plan-overview">
-            <div>
-              <span class="info-label">Plan actual</span>
-              <strong class="info-value" data-field="planActual">Gratuito</strong>
-            </div>
-            <div>
-              <span class="info-label">Renovación</span>
-              <strong class="info-value" data-field="fechaRenovacion">—</strong>
-            </div>
-            <div>
-              <span class="info-label">Método de pago</span>
-              <strong class="info-value" data-field="metodoPago">—</strong>
-            </div>
+          <div class="subscription-grid">
+            <article class="subscription-card">
+              <header class="subscription-card__header">
+                <span class="subscription-card__title">Suscripción actual</span>
+                <span id="subscriptionStatusBadge" class="badge rounded-pill bg-secondary">Inactivo (0)</span>
+              </header>
+              <dl class="subscription-card__details">
+                <div class="subscription-card__row">
+                  <dt>Última renovación</dt>
+                  <dd id="subscriptionLastRenewal">-</dd>
+                </div>
+                <div class="subscription-card__row">
+                  <dt>Próxima renovación</dt>
+                  <dd id="subscriptionNextRenewal">-</dd>
+                </div>
+              </dl>
+              <div id="subscriptionMessage" class="alert alert-warning d-none" role="alert"></div>
+              <div class="subscription-actions">
+                <button class="btn btn-success" id="btnSubscriptionToggle">Activar suscripción</button>
+                <button class="btn btn-outline-primary" id="btnSubscriptionRenew">Renovar por un mes</button>
+              </div>
+            </article>
+
+            <article class="plan-overview">
+              <div class="plan-overview__item">
+                <span class="info-label">Plan actual</span>
+                <strong class="info-value" data-field="planActual">Gratuito</strong>
+              </div>
+              <div class="plan-overview__item">
+                <span class="info-label">Renovación</span>
+                <strong class="info-value" data-field="fechaRenovacion">—</strong>
+              </div>
+              <div class="plan-overview__item">
+                <span class="info-label">Método de pago</span>
+                <strong class="info-value" data-field="metodoPago">—</strong>
+              </div>
+            </article>
           </div>
 
           <div class="section-actions section-actions--stack">
@@ -296,6 +294,10 @@
               <span class="btn-chip__label">Cancelar suscripción</span>
             </button>
           </div>
+
+          <p class="subscription-note text-muted">
+            Esta suscripción se guarda en este navegador y cambia el estado entre 0 (inactivo) y 1 (activo). Renueva cada mes con un solo clic.
+          </p>
         </section>
 
         <section id="secPlanes" class="account-section">
@@ -337,8 +339,8 @@
           </div>
         </section>
       </div>
-    </section>
-  </div>
+    </div>
+  </main>
 
   <div class="modal fade" id="modalEditarUsuario" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog">

--- a/styles/account_suscrip/account_suscrip.css
+++ b/styles/account_suscrip/account_suscrip.css
@@ -2,16 +2,15 @@
 
 :root {
   --avatar-size: clamp(72px, 18vw, 84px);
-  --logo-card-size: clamp(78px, 20vw, 92px);
-  --logo-summary-size: clamp(92px, 24vw, 112px);
-  --image-shell-bg: #ffffff;
+  --logo-card-size: clamp(78px, 22vw, 92px);
+  --logo-summary-size: clamp(84px, 24vw, 112px);
   --image-shell-bg: linear-gradient(
     135deg,
     rgba(255, 255, 255, 0.98) 0%,
     rgba(15, 180, 212, 0.12) 45%,
     rgba(255, 111, 145, 0.18) 100%
   );
-  --font-mono: 'JetBrains Mono', monospace;
+  --font-mono: "JetBrains Mono", monospace;
 }
 
 * {
@@ -26,77 +25,64 @@ body {
 }
 
 img {
-  max-width: 100%;
   display: block;
+  max-width: 100%;
+  height: auto;
 }
 
 .account-page {
   max-width: 1200px;
   margin: 0 auto;
+  padding: 0 1rem 3rem;
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
+  gap: 2rem;
 }
 
 .page-header {
   position: relative;
   background: var(--header-gradient);
+  color: var(--header-text-color);
   border-radius: var(--radius-lg);
-  padding: 2rem clamp(1.5rem, 3vw, 2.5rem);
-  overflow: hidden;
+  padding: clamp(1.75rem, 4vw, 2.5rem);
   border: 1px solid var(--primary-border-soft);
   box-shadow: var(--shadow-soft);
-  color: var(--header-text-color);
-}
-
-.page-header::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: transparent;
-  opacity: 0;
-  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  overflow: hidden;
 }
 
 .header-eyebrow {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-pill);
   background: var(--header-eyebrow-bg);
   color: var(--header-eyebrow-text);
   font-size: 0.75rem;
-  text-transform: uppercase;
   letter-spacing: 0.08em;
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
+  text-transform: uppercase;
   font-weight: 600;
-  position: relative;
-  z-index: 1;
 }
 
 .header-title {
-  margin: 1rem 0 0.5rem;
-  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  margin: 0;
+  font-size: clamp(1.9rem, 4vw, 2.7rem);
   font-weight: 700;
-  color: var(--header-text-color);
-  position: relative;
-  z-index: 1;
 }
 
 .header-description {
   margin: 0;
-  font-size: 0.95rem;
-  color: var(--header-text-color);
-  opacity: 0.85;
+  font-size: 0.96rem;
   max-width: 640px;
-  position: relative;
-  z-index: 1;
+  color: var(--header-text-color);
+  opacity: 0.9;
 }
 
 .header-highlights {
-  position: relative;
-  z-index: 1;
-  margin-top: 2rem;
+  margin-top: 1rem;
   display: grid;
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
@@ -107,11 +93,11 @@ img {
   border-radius: var(--radius-md);
   border: 1px solid var(--primary-outline);
   padding: 1.25rem 1.5rem;
-  backdrop-filter: blur(12px);
   display: flex;
   flex-direction: column;
-  gap: 1.15rem;
-  box-shadow: 0 12px 32px -28px rgba(255, 111, 145, 0.9);
+  gap: 1rem;
+  backdrop-filter: blur(10px);
+  box-shadow: 0 18px 36px -28px rgba(255, 111, 145, 0.55);
 }
 
 .profile-card__meta,
@@ -121,57 +107,24 @@ img {
   gap: 1rem;
 }
 
-.profile-card__avatar {
+.profile-card__avatar,
+.company-card__logo {
   width: var(--avatar-size);
-  max-width: 100%;
-  aspect-ratio: 1;
+  aspect-ratio: 1 / 1;
   border-radius: 50%;
   border: 3px solid rgba(255, 111, 145, 0.22);
   display: grid;
   place-items: center;
   overflow: hidden;
   background: var(--image-shell-bg);
-  box-shadow: 0 12px 28px -24px rgba(17, 24, 67, 0.6);
   flex-shrink: 0;
-}
-
-.profile-card__avatar img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  border-radius: 50%;
+  box-shadow: 0 12px 28px -24px rgba(17, 24, 67, 0.6);
 }
 
 .company-card__logo {
   width: var(--logo-card-size);
-  max-width: 100%;
-  aspect-ratio: 1;
-  border-radius: 22px;
-  border: 1px solid var(--primary-border-strong);
-  display: grid;
-  place-items: center;
-  overflow: hidden;
-  background: var(--image-shell-bg);
-  padding: 0.65rem;
-  box-shadow: 0 18px 36px -30px rgba(17, 24, 67, 0.55);
-  flex-shrink: 0;
-}
-
-.company-card__logo img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-  filter: drop-shadow(0 6px 10px rgba(17, 24, 67, 0.08));
-.profile-card__avatar,
-.company-card__logo {
-  width: 68px;
-  height: 68px;
-  border-radius: 50%;
-  border: 3px solid rgba(255, 111, 145, 0.2);
-  display: grid;
-  place-items: center;
-  overflow: hidden;
-  background: var(--primary-surface-extra);
+  border-radius: 20px;
+  padding: 0.5rem;
 }
 
 .profile-card__avatar img,
@@ -181,15 +134,19 @@ img {
   object-fit: cover;
 }
 
+.company-card__logo img {
+  object-fit: contain;
+}
+
 .card-label {
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
   padding: 0.3rem 0.65rem;
-  border-radius: 999px;
-  background: rgba(255, 111, 145, 0.1);
+  border-radius: var(--radius-pill);
+  background: rgba(255, 255, 255, 0.2);
   color: var(--primary-color);
-  font-size: 0.7rem;
+  font-size: 0.75rem;
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -201,16 +158,8 @@ img {
   color: #1f2538;
 }
 
-}
-
-.card-title {
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: #1f2538;
-}
-
 .card-subtitle {
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   color: var(--muted-color);
 }
 
@@ -228,11 +177,11 @@ img {
 
 .plan-card__details li {
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  background: var(--primary-surface-extra);
-  border-radius: 12px;
+  align-items: center;
   padding: 0.65rem 0.85rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.75);
   font-size: 0.85rem;
   color: var(--muted-color);
 }
@@ -242,20 +191,24 @@ img {
   color: #1f2538;
 }
 
-.account-panel {
+.account-layout {
   display: grid;
   grid-template-columns: minmax(220px, 260px) 1fr;
-  gap: 1.5rem;
+  gap: 1.75rem;
   align-items: start;
 }
 
+.account-sidebar {
+  position: sticky;
+  top: 1.5rem;
+}
+
 .account-menu {
-  width: 200px;
   background: var(--card-bg);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-color);
   padding: clamp(1.25rem, 3vw, 1.75rem);
-  box-shadow: 0 12px 40px -30px rgba(18, 26, 69, 0.55);
+  box-shadow: 0 18px 40px -32px rgba(18, 26, 69, 0.45);
 }
 
 .menu-eyebrow {
@@ -263,8 +216,8 @@ img {
   align-items: center;
   gap: 0.35rem;
   padding: 0.3rem 0.7rem;
-  border-radius: 999px;
-  background: rgba(255, 111, 145, 0.1);
+  border-radius: var(--radius-pill);
+  background: rgba(255, 111, 145, 0.12);
   color: var(--primary-color);
   font-size: 0.75rem;
   font-weight: 600;
@@ -301,12 +254,6 @@ img {
   box-shadow: 0 12px 30px -24px rgba(255, 111, 145, 0.7);
 }
 
-.account-menu li:hover .menu-icon,
-.account-menu li.active .menu-icon {
-  background: rgba(255, 111, 145, 0.15);
-  color: var(--primary-color);
-}
-
 .menu-icon {
   display: inline-flex;
   align-items: center;
@@ -320,13 +267,10 @@ img {
   transition: background 0.2s ease, color 0.2s ease;
 }
 
-.menu-title {
-  font-weight: 600;
-  color: #1f2538;
-  display: block;
-}
-
-
+.account-menu li:hover .menu-icon,
+.account-menu li.active .menu-icon {
+  background: rgba(255, 111, 145, 0.15);
+  color: var(--primary-color);
 }
 
 .menu-title {
@@ -340,53 +284,23 @@ img {
   color: var(--muted-color);
 }
 
-.account-content {
+.account-main {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
 }
 
 .account-section {
+  display: none;
   background: var(--card-bg);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-color);
   padding: clamp(1.5rem, 3vw, 2rem);
-  box-shadow: 0 12px 40px -30px rgba(18, 26, 69, 0.55);
-  display: none;
+  box-shadow: 0 18px 40px -32px rgba(18, 26, 69, 0.45);
 }
 
 .account-section.active {
   display: block;
-}
-
-.subscription-card {
-  background: #f8f9fc;
-  border: 1px solid rgba(0, 0, 0, 0.05);
-  border-radius: 8px;
-  padding: 16px;
-}
-
-.subscription-card p {
-  margin-bottom: 0.5rem;
-}
-
-.subscription-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-}
-
-.subscription-actions .btn {
-  min-width: 180px;
-}
-
-.subscription-note {
-  font-size: 0.85rem;
-  line-height: 1.4;
-}
-
-#subscriptionMessage {
-  font-size: 0.9rem;
 }
 
 .section-header {
@@ -401,8 +315,8 @@ img {
   align-items: center;
   gap: 0.35rem;
   padding: 0.3rem 0.7rem;
-  border-radius: 999px;
-  background: rgba(255, 111, 145, 0.1);
+  border-radius: var(--radius-pill);
+  background: rgba(255, 111, 145, 0.12);
   color: var(--primary-color);
   font-size: 0.75rem;
   font-weight: 600;
@@ -412,7 +326,7 @@ img {
 
 .section-title {
   margin: 0;
-  font-size: clamp(1.35rem, 3vw, 1.7rem);
+  font-size: clamp(1.35rem, 3vw, 1.75rem);
   font-weight: 600;
   color: #1f2538;
 }
@@ -443,8 +357,8 @@ img {
 
 .info-label {
   font-size: 0.75rem;
-  text-transform: uppercase;
   letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: var(--muted-color);
   font-weight: 600;
 }
@@ -459,12 +373,12 @@ img {
 .section-actions {
   margin-top: 1.5rem;
   display: flex;
-  justify-content: flex-start;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .section-actions--stack {
-  flex-wrap: wrap;
-  gap: 0.75rem;
+  justify-content: flex-start;
 }
 
 .cta-pill {
@@ -475,18 +389,17 @@ img {
   background: var(--primary-color);
   color: #fff;
   padding: 0.75rem 1.35rem;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   font-weight: 600;
   letter-spacing: 0.02em;
   cursor: pointer;
   box-shadow: 0 18px 32px -26px rgba(255, 111, 145, 0.9);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
 }
 
 .cta-pill:hover {
   transform: translateY(-2px);
   box-shadow: 0 24px 42px -28px rgba(255, 111, 145, 0.9);
-  color: #fff;
   filter: brightness(1.05);
 }
 
@@ -507,7 +420,7 @@ img {
   background: var(--primary-surface);
   color: var(--primary-color);
   border: 1px solid rgba(255, 111, 145, 0.25);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 0.65rem 1.1rem;
   font-weight: 600;
   cursor: pointer;
@@ -521,29 +434,12 @@ img {
 
 .btn-chip--danger {
   background: rgba(255, 107, 107, 0.12);
+  color: var(--danger-color);
   border-color: rgba(255, 107, 107, 0.3);
-  color: #dc4c64;
 }
 
 .btn-chip--danger:hover {
   background: rgba(255, 107, 107, 0.18);
-  box-shadow: 0 14px 28px -24px rgba(220, 76, 100, 0.8);
-}
-
-.btn-chip__icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.85);
-}
-
-.plan-overview {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
 .company-summary {
@@ -555,56 +451,121 @@ img {
 
 .company-summary__logo {
   width: var(--logo-summary-size);
-  max-width: 100%;
-  aspect-ratio: 1;
+  aspect-ratio: 1 / 1;
   border-radius: 24px;
-  background: var(--image-shell-bg);
-  display: grid;
-  place-items: center;
-  border: 1px solid rgba(255, 111, 145, 0.24);
-  overflow: hidden;
-  padding: clamp(0.85rem, 2vw, 1.25rem);
-  box-shadow: 0 20px 40px -32px rgba(17, 24, 67, 0.5);
-  flex-shrink: 0;
-}
-
-.plan-overview {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-}
-
-.company-summary {
-  display: flex;
-  align-items: center;
-  gap: 1.5rem;
-  flex-wrap: wrap;
-}
-
-.company-summary__logo {
-  width: 84px;
-  height: 84px;
-  border-radius: 22px;
   background: rgba(255, 111, 145, 0.1);
+  border: 1px solid rgba(255, 111, 145, 0.24);
   display: grid;
   place-items: center;
-  border: 1px solid rgba(255, 111, 145, 0.2);
   overflow: hidden;
+  padding: 0.85rem;
 }
-
 
 .company-summary__logo img {
   width: 100%;
   height: 100%;
   object-fit: contain;
-
-  filter: drop-shadow(0 6px 10px rgba(17, 24, 67, 0.08));
 }
 
 .company-summary__info {
   display: grid;
   gap: 0.35rem;
   min-width: 220px;
+}
+
+.subscription-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  margin-bottom: 1.5rem;
+}
+
+.subscription-card {
+  background: #f8f9fc;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  border-radius: var(--radius-md);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.subscription-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.subscription-card__title {
+  font-weight: 600;
+  font-size: 1rem;
+  color: #1f2538;
+}
+
+.subscription-card__details {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.subscription-card__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.subscription-card__row dt {
+  margin: 0;
+  font-weight: 600;
+  color: #1f2538;
+}
+
+.subscription-card__row dd {
+  margin: 0;
+  color: var(--muted-color);
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+}
+
+#subscriptionMessage {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.subscription-actions {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.subscription-actions .btn {
+  min-width: 180px;
+}
+
+.plan-overview {
+  background: var(--primary-surface-extra);
+  border: 1px solid var(--primary-border-soft);
+  border-radius: var(--radius-md);
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+  align-content: start;
+}
+
+.plan-overview__item {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.subscription-note {
+  margin: 1rem 0 0;
+  font-size: 0.85rem;
+  line-height: 1.45;
 }
 
 .table-wrapper {
@@ -644,23 +605,18 @@ img {
   border-radius: 18px;
 }
 
-.modal-header {
-  border-bottom: none;
-}
-
+.modal-header,
 .modal-footer {
-  border-top: none;
+  border-color: transparent;
 }
 
-@media (max-width: 992px) {
-  .account-panel {
+@media (max-width: 1100px) {
+  .account-layout {
     grid-template-columns: 1fr;
   }
 
-  .account-menu {
-    position: sticky;
-    top: 1rem;
-    z-index: 10;
+  .account-sidebar {
+    position: static;
   }
 }
 
@@ -674,7 +630,8 @@ img {
   }
 
   .cta-pill,
-  .btn-chip {
+  .btn-chip,
+  .subscription-actions .btn {
     width: 100%;
     justify-content: center;
   }
@@ -685,10 +642,9 @@ img {
     padding: 0 1rem 2rem;
   }
 
-  .plan-card__details li {
+  .subscription-card__row {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.35rem;
   }
 
   .subscription-actions {


### PR DESCRIPTION
## Summary
- reorganized the account page markup so the header and content sections follow a clearer main/sidebar structure and keep profile, company and plan highlights separated
- reworked the subscription area into a grid that combines a status card with the key plan facts for easier scanning
- refreshed the account page stylesheet to tighten spacing, align components and improve responsive behaviour on smaller screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb36076df0832c987bb98cfe5561a5