### PR TITLE
Fix tutorial overlay positioning and selectors

### DIFF
--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -353,7 +353,7 @@ const tutorialSteps = [
     {
         title: "Áreas y Zonas de Almacén",
         content: "Desde este módulo podrás gestionar todas las áreas y zonas de tu almacén, asignar ubicaciones y configurar la distribución física de tus productos.",
-        element: document.querySelector('.sidebar-menu a[href="pages/almacen/areas_zonas.html"]')
+        element: document.querySelector('.sidebar-menu a[data-page="area_almac_v2/gestion_areas_zonas.html"]')
     },
     {
         title: "Gestión de Inventario",
@@ -363,7 +363,7 @@ const tutorialSteps = [
     {
         title: "Administración de Usuarios",
         content: "Gestiona los accesos, permisos y roles de todos los usuarios del sistema. Asigna responsabilidades y controla quién puede realizar cada operación.",
-        element: document.querySelector('.sidebar-menu a[href="pages/usuarios/administracion_usuarios.html"]')
+        element: document.querySelector('.sidebar-menu a[data-page="admin_usuar/administracion_usuarios.html"]')
     },
     {
         title: "Dashboard Principal",
@@ -373,7 +373,7 @@ const tutorialSteps = [
     {
         title: "Generación de Reportes",
         content: "Crea reportes detallados de inventario, movimientos y cualquier otra información relevante para la toma de decisiones.",
-        element: document.querySelector('.sidebar-menu a[href="pages/reports/reportes.html"]')
+        element: document.querySelector('.sidebar-menu a[data-page="reports/reportes.html"]')
     },
     {
         title: "Personalización",
@@ -421,18 +421,25 @@ function showTutorialStep(step) {
 
     currentStep = step;
     const stepData = tutorialSteps[step];
-    
+
     // Update content
     tutorialTitle.textContent = stepData.title;
     tutorialContent.innerHTML = `<p>${stepData.content}</p>`;
     tutorialIndicator.textContent = `Paso ${step + 1} de ${tutorialSteps.length}`;
-    
+
     // Update next button text for last step
     if (step === tutorialSteps.length - 1) {
         nextTutorial.textContent = 'Finalizar';
     } else {
         nextTutorial.textContent = 'Siguiente';
     }
+
+    // Reset card positioning styles before applying new values
+    tutorialCard.style.transform = 'none';
+    tutorialCard.style.top = '';
+    tutorialCard.style.left = '';
+    tutorialCard.style.right = '';
+    tutorialCard.style.bottom = '';
 
     // Remove previous spotlight
     document.querySelectorAll('.tutorial-spotlight').forEach(el => {
@@ -449,7 +456,7 @@ function showTutorialStep(step) {
     if (stepData.element) {
         // Add spotlight class to element
         stepData.element.classList.add('tutorial-spotlight');
-        
+
         // Create hole in overlay
         const rect = stepData.element.getBoundingClientRect();
         tutorialHole = document.createElement('div');
@@ -459,14 +466,14 @@ function showTutorialStep(step) {
         tutorialHole.style.left = `${rect.left}px`;
         tutorialHole.style.top = `${rect.top}px`;
         tutorialOverlayBg.appendChild(tutorialHole);
-        
+
         // Position card near the element
-        const cardWidth = 500;
+        const cardWidth = Math.min(tutorialCard.offsetWidth || 480, window.innerWidth - 40);
         const cardLeft = Math.min(
             window.innerWidth - cardWidth - 20,
             Math.max(20, rect.left + (rect.width / 2) - (cardWidth / 2))
         );
-        
+
         const cardTop = rect.bottom + 20;
         if (cardTop + tutorialCard.offsetHeight > window.innerHeight) {
             // If card doesn't fit below, position it above
@@ -475,7 +482,8 @@ function showTutorialStep(step) {
             tutorialCard.style.top = `${cardTop}px`;
         }
         tutorialCard.style.left = `${cardLeft}px`;
-        
+        tutorialCard.style.transform = 'none';
+
         // Scroll element into view if needed
         setTimeout(() => {
             stepData.element.scrollIntoView({

--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -705,7 +705,7 @@ img {
 /* Tutorial */
 .tutorial-spotlight {
     position: relative;
-    z-index: 1002;
+    z-index: 3002;
     animation: pulse 2s infinite;
 }
 
@@ -725,7 +725,7 @@ img {
     position: fixed;
     inset: 0;
     background: rgba(15, 23, 42, 0.65);
-    z-index: 1000;
+    z-index: 3000;
 }
 
 .tutorial-hole {
@@ -742,7 +742,7 @@ img {
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1001;
+    z-index: 3001;
     pointer-events: none;
 }
 
@@ -753,6 +753,7 @@ img {
     max-width: 480px;
     box-shadow: var(--shadow-soft);
     pointer-events: auto;
+    position: absolute;
     animation: fadeIn 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary
- raise the tutorial overlay and spotlight z-index values and absolutely position the card so the tour sits above other UI elements
- reset the tutorial card placement on each step and compute its position next to the highlighted element for consistent behaviour
- update sidebar selectors used by the tour to match the current data-page attributes so the corresponding sections are highlighted correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb389d4280832c8144d9e0edac6f90