### PR TITLE
Add pagination and activity insights to control log

### DIFF
--- a/pages/control_log/log.html
+++ b/pages/control_log/log.html
@@ -132,12 +132,53 @@
           <tbody id="logTableBody"></tbody>
         </table>
       </div>
+      <div class="table-footer">
+        <div class="pagination-info" id="paginationInfo" aria-live="polite">Sin registros</div>
+        <div class="pagination-controls" id="paginationControls" aria-label="Paginación de actividades">
+          <button class="page-btn" type="button" data-action="prev" disabled>
+            <span aria-hidden="true">&larr;</span>
+            <span class="visually-hidden">Página anterior</span>
+          </button>
+          <div class="page-numbers" id="paginationPages"></div>
+          <button class="page-btn" type="button" data-action="next" disabled>
+            <span aria-hidden="true">&rarr;</span>
+            <span class="visually-hidden">Página siguiente</span>
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <section class="insights-card">
+      <div class="insights-heading">
+        <span class="insights-eyebrow">Panorama general</span>
+        <h2 class="insights-title">Tendencias y usuarios destacados</h2>
+        <p class="insights-description">
+          Visualiza la evolución de las actividades y los usuarios con más registros para identificar patrones clave.
+        </p>
+      </div>
+      <div class="insights-grid">
+        <article class="insight-chart">
+          <header class="insight-chart__header">
+            <h3 class="insight-chart__title">Actividades en el tiempo</h3>
+            <span class="insight-chart__subtitle">Totales por fecha</span>
+          </header>
+          <canvas id="activityTrendChart" aria-label="Gráfica de actividades por periodo" role="img"></canvas>
+        </article>
+        <article class="insight-chart">
+          <header class="insight-chart__header">
+            <h3 class="insight-chart__title">Usuarios con más actividades</h3>
+            <span class="insight-chart__subtitle">Top 5</span>
+          </header>
+          <canvas id="topUsersChart" aria-label="Gráfica de usuarios con más actividades" role="img"></canvas>
+        </article>
+      </div>
     </section>
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="../../scripts/control_log/log.js"></script>
 </body>

--- a/styles/control_log/log.css
+++ b/styles/control_log/log.css
@@ -299,6 +299,75 @@ body {
   box-shadow: inset 0 1px 0 rgba(255, 111, 145, 0.08);
 }
 
+.table-footer {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.pagination-info {
+  font-size: 0.9rem;
+  color: var(--muted-color);
+}
+
+.pagination-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.page-btn,
+.page-number {
+  border: 1px solid var(--border-color);
+  background: #fff;
+  color: #39425a;
+  border-radius: var(--radius-sm);
+  padding: 0.35rem 0.65rem;
+  font-size: 0.85rem;
+  min-width: 36px;
+  min-height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.page-btn[disabled],
+.page-number[disabled] {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.page-btn:not([disabled]):hover,
+.page-number:not([disabled]):hover {
+  background: var(--primary-surface);
+  color: var(--primary-color);
+  border-color: var(--primary-outline);
+  transform: translateY(-1px);
+}
+
+.page-number.active {
+  background: var(--primary-color);
+  color: #fff;
+  border-color: var(--primary-color);
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .log-table {
   width: 100%;
   border-collapse: separate;
@@ -402,6 +471,92 @@ body {
   background: var(--primary-surface-extra);
   color: #2b3454;
   font-weight: 500;
+}
+
+.insights-card {
+  background: var(--card-bg);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.5rem, 3vw, 2rem);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 18px 40px -32px rgba(18, 26, 69, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.insights-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.insights-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(108, 93, 211, 0.12);
+  color: #5a4ec6;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.insights-title {
+  margin: 0;
+  font-size: clamp(1.2rem, 3vw, 1.6rem);
+  color: #1f2538;
+  font-weight: 600;
+}
+
+.insights-description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted-color);
+  max-width: 620px;
+}
+
+.insights-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.insight-chart {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 320px;
+}
+
+.insight-chart__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.insight-chart__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #1f2538;
+}
+
+.insight-chart__subtitle {
+  font-size: 0.85rem;
+  color: var(--muted-color);
+}
+
+.insight-chart canvas {
+  width: 100% !important;
+  height: 100% !important;
+  flex: 1;
 }
 
 .empty-state {


### PR DESCRIPTION
## Summary
- add pagination controls to the activity table to show 10 registros por página y navegación accesible
- incluir panel de insights con gráficas de tendencias temporales y top de usuarios usando Chart.js
- actualizar estilos para paginación, gráficos y elementos de apoyo visual

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc2dd2b830832ca80fcf1371a43956