### PR TITLE
Simplify control log layout

### DIFF
--- a/pages/control_log/log.html
+++ b/pages/control_log/log.html
@@ -18,35 +18,34 @@
   <link rel="stylesheet" href="../../styles/control_log/log.css" />
 </head>
 <body>
-  <div class="log-page container-fluid py-4 px-3 px-md-4">
-    <section class="page-header">
-      <span class="header-eyebrow">Registro de Actividades</span>
-      <h1 class="header-title">Log de control</h1>
-      <p class="header-description">
-        Monitorea y audita cada acción realizada en tu plataforma para mantener el control de los procesos críticos.
-      </p>
-      <div class="header-stats">
-        <div class="stat-card">
-          <span class="stat-label">Registros totales</span>
-          <strong class="stat-value" id="totalRegistros">0</strong>
+  <div class="log-page container py-4">
+    <header class="log-header">
+      <div class="log-header__copy">
+        <p class="log-eyebrow">Registro de actividades</p>
+        <h1 class="log-title">Log de control</h1>
+        <p class="log-description">
+          Monitorea y audita las acciones clave de tu plataforma sin saturar la pantalla.
+        </p>
+      </div>
+      <div class="log-header__stats">
+        <div class="mini-stat">
+          <span class="mini-stat__label">Registros totales</span>
+          <strong class="mini-stat__value" id="totalRegistros">0</strong>
         </div>
-        <div class="stat-card">
-          <span class="stat-label">Última actualización</span>
-          <strong class="stat-value" id="lastUpdated">—</strong>
+        <div class="mini-stat">
+          <span class="mini-stat__label">Última actualización</span>
+          <strong class="mini-stat__value" id="lastUpdated">—</strong>
         </div>
       </div>
-    </section>
+    </header>
 
-    <section class="filters-card">
-      <div class="filters-heading">
-        <div>
-          <span class="filters-eyebrow">Filtros principales</span>
-          <h2 class="filters-title">Refina el historial por módulo, usuario o rol</h2>
-        </div>
-        <div class="filters-actions">
+    <section class="log-controls">
+      <div class="log-controls__heading">
+        <h2>Filtros rápidos</h2>
+        <div class="export-buttons">
           <button id="exportPdf" class="btn-icon" title="Exportar PDF">
             <span class="btn-icon__circle">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
                 <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
                 <polyline points="14 2 14 8 20 8"></polyline>
                 <line x1="16" y1="13" x2="8" y2="13"></line>
@@ -58,7 +57,7 @@
           </button>
           <button id="exportExcel" class="btn-icon" title="Exportar Excel">
             <span class="btn-icon__circle">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
                 <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
                 <polyline points="14 2 14 8 20 8"></polyline>
                 <path d="M8 13h4"></path>
@@ -70,10 +69,9 @@
           </button>
         </div>
       </div>
-
-      <div class="filters-grid">
-        <div class="filter-field">
-          <label for="filtroModulo" class="form-label">Módulo</label>
+      <div class="log-controls__grid">
+        <label class="control-field">
+          <span>Módulo</span>
           <select id="filtroModulo" class="form-select">
             <option value="">Todos los módulos</option>
             <option value="Inventario">Inventario</option>
@@ -82,62 +80,91 @@
             <option value="Zonas">Zonas</option>
             <option value="Reportes">Reportes</option>
           </select>
-        </div>
-        <div class="filter-field">
-          <label for="filtroUsuario" class="form-label">Usuario</label>
+        </label>
+        <label class="control-field">
+          <span>Usuario</span>
           <select id="filtroUsuario" class="form-select">
             <option value="">Todos los usuarios</option>
           </select>
-        </div>
-        <div class="filter-field">
-          <label for="filtroRol" class="form-label">Rol</label>
+        </label>
+        <label class="control-field">
+          <span>Rol</span>
           <select id="filtroRol" class="form-select">
             <option value="">Todos los roles</option>
             <option value="Administrador">Administrador</option>
             <option value="Empleado">Empleado</option>
           </select>
-        </div>
-      </div>
-    </section>
-
-    <section class="table-card">
-      <div class="table-heading">
-        <div>
-          <h2 class="table-title">Historial de actividades recientes</h2>
-          <span class="table-subtitle" id="logCount">Sin registros disponibles</span>
-        </div>
-        <div class="table-tools">
+        </label>
+        <label class="control-field control-field--search">
+          <span>Búsqueda</span>
           <div class="search-field">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
               <circle cx="11" cy="11" r="7"></circle>
               <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
             </svg>
-            <input type="search" id="logSearch" placeholder="Buscar por usuario, módulo o acción" aria-label="Buscar en el log" />
+            <input type="search" id="logSearch" placeholder="Buscar en el log" aria-label="Buscar en el log" />
           </div>
-        </div>
-      </div>
-
-      <div class="log-table-wrapper">
-        <table id="logTable" class="log-table">
-          <thead>
-            <tr>
-              <th scope="col">Fecha</th>
-              <th scope="col" id="timeHeader">Hora</th>
-              <th scope="col">Usuario</th>
-              <th scope="col">Rol</th>
-              <th scope="col">Módulo</th>
-              <th scope="col">Acción</th>
-            </tr>
-          </thead>
-          <tbody id="logTableBody"></tbody>
-        </table>
+        </label>
       </div>
     </section>
+
+    <div class="log-main">
+      <section class="log-table-card">
+        <header class="log-table-card__header">
+          <div>
+            <h2 class="section-title">Historial reciente</h2>
+            <span class="section-subtitle" id="logCount">Sin registros disponibles</span>
+          </div>
+        </header>
+        <div class="log-table-wrapper">
+          <table id="logTable" class="log-table">
+            <thead>
+              <tr>
+                <th scope="col">Fecha</th>
+                <th scope="col" id="timeHeader">Hora</th>
+                <th scope="col">Usuario</th>
+                <th scope="col">Rol</th>
+                <th scope="col">Módulo</th>
+                <th scope="col">Acción</th>
+              </tr>
+            </thead>
+            <tbody id="logTableBody"></tbody>
+          </table>
+        </div>
+        <footer class="log-table-card__footer">
+          <div class="pagination-info" id="paginationInfo" aria-live="polite">Sin registros</div>
+          <div class="pagination-controls" id="paginationControls" aria-label="Paginación de actividades">
+            <button class="page-btn" type="button" data-action="prev" disabled>
+              <span aria-hidden="true">&larr;</span>
+              <span class="visually-hidden">Página anterior</span>
+            </button>
+            <div class="page-numbers" id="paginationPages"></div>
+            <button class="page-btn" type="button" data-action="next" disabled>
+              <span aria-hidden="true">&rarr;</span>
+              <span class="visually-hidden">Página siguiente</span>
+            </button>
+          </div>
+        </footer>
+      </section>
+
+      <aside class="log-insights">
+        <h2 class="section-title">Insights rápidos</h2>
+        <div class="insight-card">
+          <h3>Actividades en el tiempo</h3>
+          <canvas id="activityTrendChart" height="180" aria-label="Gráfica de actividades por periodo" role="img"></canvas>
+        </div>
+        <div class="insight-card">
+          <h3>Top de usuarios</h3>
+          <canvas id="topUsersChart" height="180" aria-label="Gráfica de usuarios con más actividades" role="img"></canvas>
+        </div>
+      </aside>
+    </div>
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="../../scripts/control_log/log.js"></script>
 </body>

--- a/styles/control_log/log.css
+++ b/styles/control_log/log.css
@@ -7,476 +7,343 @@
 body {
   margin: 0;
   font-family: var(--font-main);
-  background: var(--page-bg);
-  color: var(--text-color);
+  background: #f3f4f8;
+  color: #1f2430;
 }
 
 .log-page {
-  max-width: 1200px;
+  max-width: 1100px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
+  gap: 1.5rem;
 }
 
-.page-header {
-  position: relative;
-  background: var(--header-gradient);
-  border-radius: var(--radius-lg);
-  padding: 2rem clamp(1.5rem, 3vw, 2.5rem);
-  overflow: hidden;
-  border: 1px solid var(--primary-border-soft);
-  box-shadow: var(--shadow-soft);
-  color: var(--header-text-color);
-}
-
-.page-header::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: transparent;
-  opacity: 0;
-  pointer-events: none;
-}
-
-.header-eyebrow {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  background: var(--header-eyebrow-bg);
-  color: var(--header-eyebrow-text);
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  font-weight: 600;
-  position: relative;
-  z-index: 1;
-}
-
-.header-title {
-  margin: 1rem 0 0.5rem;
-  font-size: clamp(1.8rem, 4vw, 2.6rem);
-  font-weight: 700;
-  color: var(--header-text-color);
-  position: relative;
-  z-index: 1;
-}
-
-.header-description {
-  margin: 0;
-  font-size: 0.95rem;
-  color: var(--header-text-color);
-  opacity: 0.85;
-  max-width: 620px;
-  position: relative;
-  z-index: 1;
-}
-
-.header-stats {
-  position: relative;
-  z-index: 1;
-  margin-top: 1.75rem;
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-}
-
-.stat-card {
-  background: rgba(255, 255, 255, 0.9);
-  border-radius: var(--radius-md);
-  padding: 1rem 1.25rem;
-  border: 1px solid var(--primary-outline);
-  backdrop-filter: blur(12px);
-}
-
-.stat-label {
-  display: block;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--muted-color);
-  margin-bottom: 0.25rem;
-}
-
-.stat-value {
-  font-size: 1.5rem;
-  font-weight: 700;
-  color: #171f34;
-}
-
-.filters-card {
-  background: var(--card-bg);
-  border-radius: var(--radius-lg);
-  padding: clamp(1.5rem, 3vw, 2rem);
-  border: 1px solid var(--border-color);
-  box-shadow: 0 12px 40px -30px rgba(18, 26, 69, 0.55);
-  display: flex;
-  flex-direction: column;
-  gap: 1.75rem;
-}
-
-.filters-heading {
+.log-header {
   display: flex;
   flex-wrap: wrap;
+  align-items: flex-start;
   justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
+  gap: 1.25rem;
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 10px 30px -24px rgba(15, 23, 42, 0.4);
 }
 
-.filters-eyebrow {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.3rem 0.7rem;
-  border-radius: 999px;
-  background: rgba(255, 111, 145, 0.1);
-  color: var(--primary-color);
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.06em;
+.log-header__copy {
+  flex: 1 1 260px;
+}
+
+.log-eyebrow {
+  margin: 0;
   text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #6b7280;
 }
 
-.filters-title {
-  margin: 0.4rem 0 0;
-  font-size: clamp(1.1rem, 3vw, 1.45rem);
-  color: #1f2538;
-  font-weight: 600;
+.log-title {
+  margin: 0.35rem 0;
+  font-size: clamp(1.6rem, 3vw, 2.1rem);
+  font-weight: 700;
+}
+
+.log-description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #4b5563;
   max-width: 520px;
 }
 
-.filters-actions {
+.log-header__stats {
   display: flex;
+  flex: 1 1 220px;
   gap: 0.75rem;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.mini-stat {
+  min-width: 160px;
+  padding: 0.85rem 1rem;
+  border-radius: 10px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: #f9fafb;
+}
+
+.mini-stat__label {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #6b7280;
+  margin-bottom: 0.25rem;
+}
+
+.mini-stat__value {
+  font-size: 1.4rem;
+  font-family: "JetBrains Mono", monospace;
+  color: #111827;
+}
+
+.log-controls {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.log-controls__heading {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.log-controls__heading h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.export-buttons {
+  display: flex;
+  gap: 0.5rem;
 }
 
 .btn-icon {
   display: inline-flex;
   align-items: center;
-  gap: 0.55rem;
-  border: none;
-  background: var(--primary-surface);
-  color: var(--primary-color);
-  padding: 0.65rem 1rem;
+  gap: 0.45rem;
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  background: rgba(99, 102, 241, 0.08);
+  color: #3730a3;
+  padding: 0.45rem 0.75rem;
   border-radius: 999px;
   cursor: pointer;
+  font-size: 0.8rem;
   font-weight: 600;
-  font-size: 0.85rem;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  transition: background 0.2s ease, transform 0.2s ease;
 }
 
 .btn-icon:hover {
-  background: var(--primary-surface-strong);
-  box-shadow: 0 12px 30px -22px rgba(255, 111, 145, 0.9);
-  transform: translateY(-2px);
+  background: rgba(99, 102, 241, 0.16);
+  transform: translateY(-1px);
 }
 
 .btn-icon__circle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: 28px;
+  height: 28px;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.9);
-  color: var(--primary-color);
+  background: #ffffff;
 }
 
-.btn-icon__label {
-  letter-spacing: 0.02em;
-}
-
-.filters-grid {
+.log-controls__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1.25rem;
-}
-
-.filter-field {
-  display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
-}
-
-.filter-field .form-label {
-  font-weight: 600;
-  font-size: 0.85rem;
-  color: var(--muted-color);
-  margin: 0;
-}
-
-.filter-field .form-select {
-  border-radius: 12px;
-  border: 1px solid var(--border-color);
-  padding: 0.65rem 0.95rem;
-  font-size: 0.92rem;
-  box-shadow: none;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.filter-field .form-select:focus {
-  border-color: rgba(255, 111, 145, 0.6);
-  box-shadow: 0 0 0 0.25rem rgba(255, 111, 145, 0.18);
-}
-
-.table-card {
-  background: var(--card-bg);
-  border-radius: var(--radius-lg);
-  padding: clamp(1.5rem, 3vw, 2rem);
-  border: 1px solid var(--border-color);
-  box-shadow: 0 16px 44px -34px rgba(18, 26, 69, 0.55);
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.table-heading {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  gap: 1rem;
-  align-items: flex-start;
-}
-
-.table-title {
-  margin: 0;
-  font-size: clamp(1.2rem, 3vw, 1.6rem);
-  font-weight: 600;
-  color: #1b2236;
-}
-
-.table-subtitle {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-size: 0.85rem;
-  color: var(--muted-color);
-  margin-top: 0.35rem;
-  background: rgba(255, 111, 145, 0.1);
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-}
-
-.table-tools {
-  display: flex;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 0.75rem;
-  align-items: center;
+}
+
+.control-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+.control-field span {
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #6b7280;
+}
+
+.control-field--search {
+  grid-column: span 2;
 }
 
 .search-field {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 0.5rem;
-  background: var(--primary-surface-extra);
-  border-radius: 999px;
-  padding: 0.4rem 0.9rem;
-  border: 1px solid rgba(255, 111, 145, 0.16);
-}
-
-.search-field svg {
-  color: var(--primary-color);
+  gap: 0.35rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 8px;
+  padding: 0.35rem 0.6rem;
+  background: #f9fafb;
 }
 
 .search-field input {
   border: none;
   background: transparent;
+  outline: none;
   font-size: 0.9rem;
-  width: 220px;
-  color: var(--text-color);
+  flex: 1;
 }
 
-.search-field input:focus {
-  outline: none;
+.log-main {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  align-items: flex-start;
+}
+
+.log-table-card {
+  flex: 1 1 60%;
+  min-width: 320px;
+  background: #ffffff;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+}
+
+.log-table-card__header {
+  padding: 1rem 1.25rem 0.75rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.section-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.section-subtitle {
+  font-size: 0.85rem;
+  color: #6b7280;
 }
 
 .log-table-wrapper {
-  border-radius: var(--radius-md);
-  border: 1px solid var(--border-color);
-  overflow: hidden;
   overflow-x: auto;
-  box-shadow: inset 0 1px 0 rgba(255, 111, 145, 0.08);
 }
 
 .log-table {
   width: 100%;
-  border-collapse: separate;
-  border-spacing: 0;
-  font-size: 0.92rem;
-  min-width: 680px;
+  border-collapse: collapse;
+  font-size: 0.9rem;
 }
 
-.log-table thead th {
-  position: sticky;
-  top: 0;
-  background: var(--primary-color);
-  color: white;
-  font-weight: 600;
+.log-table thead {
+  background: #f3f4f6;
+}
+
+.log-table th,
+.log-table td {
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.05);
   text-align: left;
-  padding: 0.95rem 1.1rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.18);
-  letter-spacing: 0.02em;
-  z-index: 2;
-}
-
-.log-table thead th:first-child {
-  border-top-left-radius: 12px;
-}
-
-.log-table thead th:last-child {
-  border-top-right-radius: 12px;
-}
-
-.log-table tbody tr {
-  background: #ffffff;
-  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease;
-}
-
-.log-table tbody tr:nth-child(even) {
-  background: #fbfaff;
 }
 
 .log-table tbody tr:hover {
-  background: var(--primary-surface);
-  transform: translateX(4px);
-  box-shadow: inset 4px 0 0 rgba(255, 111, 145, 0.45);
+  background: #f9fafb;
 }
 
-.log-table td {
-  padding: 0.9rem 1.1rem;
-  border-bottom: 1px solid rgba(255, 111, 145, 0.12);
-  color: #20263f;
-  vertical-align: middle;
+.log-table-card__footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.85rem 1.25rem;
 }
 
-.log-table td:first-child {
-  font-variant-numeric: tabular-nums;
+.pagination-info {
+  font-size: 0.8rem;
+  color: #6b7280;
 }
 
-.cell-time {
-  font-family: 'JetBrains Mono', 'Fira Mono', monospace;
-  font-size: 0.85rem;
-  color: var(--muted-color);
-}
-
-.cell-user {
-  font-weight: 600;
-  color: #1c2340;
-}
-
-.cell-role {
-  width: 1%;
-}
-
-.role-chip,
-.module-chip {
+.pagination-controls {
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
-  font-size: 0.78rem;
-  font-weight: 600;
-  padding: 0.3rem 0.6rem;
-  border-radius: 999px;
-  background: rgba(255, 111, 145, 0.16);
-  color: var(--primary-color);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
 }
 
-.module-chip {
-  background: rgba(15, 180, 212, 0.18);
-  color: #007b83;
-}
-
-.cell-action {
-  max-width: 320px;
-}
-
-.action-text {
+.page-btn {
+  border: none;
+  background: #e5e7eb;
+  color: #374151;
+  border-radius: 6px;
+  width: 32px;
+  height: 32px;
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.35rem 0.6rem;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.page-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.page-numbers {
+  display: inline-flex;
+  gap: 0.25rem;
+}
+
+.page-number {
+  min-width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: #374151;
+  cursor: pointer;
+}
+
+.page-number.is-active,
+.page-number.active {
+  background: #312e81;
+  color: #ffffff;
+  border-color: #312e81;
+}
+
+.log-insights {
+  flex: 1 1 250px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.insight-card {
+  background: #ffffff;
   border-radius: 12px;
-  background: var(--primary-surface-extra);
-  color: #2b3454;
-  font-weight: 500;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  padding: 0.85rem 1rem 0.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
 }
 
-.empty-state {
-  text-align: center;
-  padding: 2.5rem 1rem;
-  color: var(--muted-color);
-  font-weight: 500;
+.insight-card h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
 }
 
-.empty-state span {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.9rem;
-  border-radius: 999px;
-  background: var(--primary-surface);
-  color: var(--primary-color);
-}
-
-@media (max-width: 992px) {
-  .filters-heading {
-    align-items: flex-start;
-  }
-
-  .filters-actions {
-    width: 100%;
-    justify-content: flex-start;
-  }
-
-  .search-field input {
-    width: 160px;
-  }
+.insight-card canvas {
+  width: 100%;
 }
 
 @media (max-width: 768px) {
-  .page-header,
-  .filters-card,
-  .table-card {
-    padding: 1.4rem;
+  .control-field--search {
+    grid-column: span 1;
   }
 
-  .filters-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .table-heading {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .search-field {
-    width: 100%;
-  }
-
-  .search-field input {
-    width: 100%;
-  }
-
-  .log-table {
-    min-width: 100%;
-  }
-}
-
-@media (max-width: 576px) {
-  .filters-actions {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .btn-icon {
-    width: 100%;
-    justify-content: center;
-  }
-
-  .header-stats {
-    grid-template-columns: 1fr;
+  .log-header__stats {
+    justify-content: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- reestructuré la vista del log para usar un encabezado y controles compactos que no ocupen toda la pantalla
- coloqué la tabla y los insights en un diseño lateral con tarjetas pequeñas para mantener los gráficos visibles sin dominar la página
- actualicé los estilos para el nuevo acomodo más liviano y responsivo

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc2dd2b830832ca80fcf1371a43956