### PR TITLE
Adjust chart sizing on control log page

### DIFF
--- a/styles/control_log/log.css
+++ b/styles/control_log/log.css
@@ -532,7 +532,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  min-height: 320px;
+  min-height: 220px;
 }
 
 .insight-chart__header {
@@ -555,8 +555,8 @@ body {
 
 .insight-chart canvas {
   width: 100% !important;
-  height: 100% !important;
-  flex: 1;
+  height: 220px !important;
+  flex: 0 0 auto;
 }
 
 .empty-state {


### PR DESCRIPTION
## Summary
- reduce the minimum height of the control log insight cards so the graphs render smaller by default
- cap the chart canvas height to avoid the visuals stretching vertically

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc3a3bc1bc832c941dd02d9b9a2539