### PR TITLE
Adjust chart sizing on control log page

### DIFF
--- a/pages/control_log/log.html
+++ b/pages/control_log/log.html
@@ -157,12 +157,19 @@
         </p>
       </div>
       <div class="insights-grid">
-        <article class="insight-chart">
+        <article class="insight-chart insight-chart--wide">
           <header class="insight-chart__header">
             <h3 class="insight-chart__title">Actividades en el tiempo</h3>
             <span class="insight-chart__subtitle">Totales por fecha</span>
           </header>
           <canvas id="activityTrendChart" aria-label="Gráfica de actividades por periodo" role="img"></canvas>
+        </article>
+        <article class="insight-chart">
+          <header class="insight-chart__header">
+            <h3 class="insight-chart__title">Actividades por módulo</h3>
+            <span class="insight-chart__subtitle">Distribución de registros</span>
+          </header>
+          <canvas id="moduleActivityChart" aria-label="Gráfica de actividades por módulo" role="img"></canvas>
         </article>
         <article class="insight-chart">
           <header class="insight-chart__header">

--- a/styles/control_log/log.css
+++ b/styles/control_log/log.css
@@ -520,7 +520,7 @@ body {
 
 .insights-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1.5rem;
 }
 
@@ -532,7 +532,12 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  min-height: 320px;
+  min-height: 220px;
+}
+
+.insight-chart--wide {
+  grid-column: 1 / -1;
+  min-height: 260px;
 }
 
 .insight-chart__header {
@@ -555,8 +560,12 @@ body {
 
 .insight-chart canvas {
   width: 100% !important;
-  height: 100% !important;
-  flex: 1;
+  height: 220px !important;
+  flex: 0 0 auto;
+}
+
+.insight-chart--wide canvas {
+  height: 260px !important;
 }
 
 .empty-state {


### PR DESCRIPTION
## Summary
- reduce the insight card sizing so the charts render compactly by default
- cap the chart canvas height to avoid the visuals stretching vertically
- convert the activity trend visualization into a full-width DD/MM line chart and add a module distribution chart above the top users breakdown

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc3a3bc1bc832c941dd02d9b9a2539