### PR TITLE
Add daily trend range controls for activity chart

### DIFF
--- a/pages/control_log/log.html
+++ b/pages/control_log/log.html
@@ -157,17 +157,35 @@
         </p>
       </div>
       <div class="insights-grid">
-        <article class="insight-chart">
+        <article class="insight-chart insight-chart--wide">
           <header class="insight-chart__header">
-            <h3 class="insight-chart__title">Actividades en el tiempo</h3>
-            <span class="insight-chart__subtitle">Totales por fecha</span>
+            <div class="insight-chart__heading">
+              <h3 class="insight-chart__title">Actividades en el tiempo</h3>
+              <span class="insight-chart__subtitle">Totales por fecha</span>
+            </div>
+            <div class="chart-range-controls" role="group" aria-label="Filtrar el rango de tiempo">
+              <button type="button" class="chart-range-btn" data-trend-range="week">Semana</button>
+              <button type="button" class="chart-range-btn" data-trend-range="month">Mes</button>
+              <button type="button" class="chart-range-btn is-active" data-trend-range="all">Todo</button>
+            </div>
           </header>
           <canvas id="activityTrendChart" aria-label="Gráfica de actividades por periodo" role="img"></canvas>
         </article>
         <article class="insight-chart">
           <header class="insight-chart__header">
-            <h3 class="insight-chart__title">Usuarios con más actividades</h3>
-            <span class="insight-chart__subtitle">Top 5</span>
+            <div class="insight-chart__heading">
+              <h3 class="insight-chart__title">Actividades por módulo</h3>
+              <span class="insight-chart__subtitle">Distribución de registros</span>
+            </div>
+          </header>
+          <canvas id="moduleActivityChart" aria-label="Gráfica de actividades por módulo" role="img"></canvas>
+        </article>
+        <article class="insight-chart">
+          <header class="insight-chart__header">
+            <div class="insight-chart__heading">
+              <h3 class="insight-chart__title">Usuarios con más actividades</h3>
+              <span class="insight-chart__subtitle">Top 5</span>
+            </div>
           </header>
           <canvas id="topUsersChart" aria-label="Gráfica de usuarios con más actividades" role="img"></canvas>
         </article>

--- a/scripts/control_log/log.js
+++ b/scripts/control_log/log.js
@@ -17,7 +17,9 @@
     const prevPageBtn = paginationControlsEl?.querySelector('[data-action="prev"]');
     const nextPageBtn = paginationControlsEl?.querySelector('[data-action="next"]');
     const activityTrendCanvas = document.getElementById('activityTrendChart');
+    const moduleActivityCanvas = document.getElementById('moduleActivityChart');
     const topUsersCanvas = document.getElementById('topUsersChart');
+    const trendRangeButtons = Array.from(document.querySelectorAll('[data-trend-range]'));
 
     let navegadorTimeZone = null;
 
@@ -59,6 +61,25 @@
         timeHeaderEl.textContent = `Hora (${timeZoneLabel})`;
     }
 
+    trendRangeButtons.forEach(button => {
+        if (button.classList.contains('is-active')) {
+            trendRange = button.dataset.trendRange || trendRange;
+        }
+
+        button.addEventListener('click', () => {
+            const nuevoRango = button.dataset.trendRange || 'all';
+            if (nuevoRango === trendRange) {
+                return;
+            }
+
+            trendRange = nuevoRango;
+            trendRangeButtons.forEach(btn => {
+                btn.classList.toggle('is-active', btn === button);
+            });
+            renderTrendChart();
+        });
+    });
+
     if (!filtroModulo || !filtroUsuario || !filtroRol || !tablaBody) {
         console.warn('La vista del log de control no está disponible. Se omite la inicialización.');
         return;
@@ -78,7 +99,15 @@
     let terminoBusqueda = '';
     let paginaActual = 1;
     let trendChart = null;
+    let moduleActivityChart = null;
     let topUsersChart = null;
+    let trendLabelsISO = [];
+    let trendSeries = [];
+    let trendRange = 'all';
+    const TREND_RANGE_DAYS = {
+        week: 7,
+        month: 30
+    };
 
     function escapeHtml(valor) {
         return String(valor ?? '')
@@ -161,6 +190,231 @@
             console.warn('No se pudo convertir la fecha y hora al huso horario configurado.', error);
             return { fechaLocal: '', horaLocal: '' };
         }
+    }
+
+    function formatearDiaMesDesdeISO(fechaISO, respaldo = '') {
+        if (!fechaISO) {
+            return respaldo;
+        }
+
+        const partes = String(fechaISO).split('-');
+        if (partes.length >= 3) {
+            const [anio, mes, dia] = partes;
+            if (dia && mes) {
+                return `${dia.padStart(2, '0')}/${mes.padStart(2, '0')}`;
+            }
+        }
+
+        return respaldo || fechaISO;
+    }
+
+    function formatearFechaCompletaDesdeISO(fechaISO) {
+        if (!fechaISO) {
+            return '';
+        }
+
+        try {
+            const date = new Date(`${fechaISO}T00:00:00Z`);
+            if (Number.isNaN(date.getTime())) {
+                return fechaISO;
+            }
+
+            const opciones = {
+                day: '2-digit',
+                month: '2-digit',
+                year: 'numeric'
+            };
+            if (navegadorTimeZone) {
+                opciones.timeZone = navegadorTimeZone;
+            }
+
+            return new Intl.DateTimeFormat('es', opciones).format(date);
+        } catch (error) {
+            console.warn('No se pudo formatear la fecha en formato completo.', error);
+            return fechaISO;
+        }
+    }
+
+    function extraerFechaISO(valor) {
+        if (!valor && valor !== 0) {
+            return '';
+        }
+
+        const texto = String(valor).trim();
+        if (!texto) {
+            return '';
+        }
+
+        const isoMatch = texto.match(/(\d{4})-(\d{2})-(\d{2})/);
+        if (isoMatch) {
+            return `${isoMatch[1]}-${isoMatch[2]}-${isoMatch[3]}`;
+        }
+
+        const dmyMatch = texto.match(/(\d{2})[\/-](\d{2})[\/-](\d{4})/);
+        if (dmyMatch) {
+            return `${dmyMatch[3]}-${dmyMatch[2]}-${dmyMatch[1]}`;
+        }
+
+        return '';
+    }
+
+    function construirSerieDiaria(datos = []) {
+        const totalesPorDia = new Map();
+        let fechaMinima = null;
+        let fechaMaxima = null;
+
+        datos.forEach(registro => {
+            const fechaISO = extraerFechaISO(registro?.fecha);
+            if (!fechaISO) {
+                return;
+            }
+
+            totalesPorDia.set(fechaISO, (totalesPorDia.get(fechaISO) || 0) + 1);
+            if (!fechaMinima || fechaISO < fechaMinima) {
+                fechaMinima = fechaISO;
+            }
+            if (!fechaMaxima || fechaISO > fechaMaxima) {
+                fechaMaxima = fechaISO;
+            }
+        });
+
+        if (!fechaMinima || !fechaMaxima) {
+            return [];
+        }
+
+        const serie = [];
+        let cursor = new Date(`${fechaMinima}T00:00:00Z`);
+        const limite = new Date(`${fechaMaxima}T00:00:00Z`);
+
+        while (!Number.isNaN(cursor.getTime()) && cursor <= limite) {
+            const iso = cursor.toISOString().slice(0, 10);
+            serie.push({
+                iso,
+                etiqueta: formatearDiaMesDesdeISO(iso),
+                total: totalesPorDia.get(iso) || 0
+            });
+            cursor.setUTCDate(cursor.getUTCDate() + 1);
+        }
+
+        return serie;
+    }
+
+    function obtenerSerieFiltradaPorRango() {
+        if (!Array.isArray(trendSeries) || trendSeries.length === 0) {
+            return [];
+        }
+
+        if (trendRange === 'all' || !TREND_RANGE_DAYS[trendRange]) {
+            return trendSeries.slice();
+        }
+
+        const dias = TREND_RANGE_DAYS[trendRange];
+        const total = trendSeries.length;
+
+        if (total >= dias) {
+            return trendSeries.slice(total - dias);
+        }
+
+        const resultado = trendSeries.slice();
+        const primerElemento = resultado[0];
+
+        if (!primerElemento) {
+            return resultado;
+        }
+
+        let cursor = new Date(`${primerElemento.iso}T00:00:00Z`);
+
+        while (!Number.isNaN(cursor.getTime()) && resultado.length < dias) {
+            cursor.setUTCDate(cursor.getUTCDate() - 1);
+            const iso = cursor.toISOString().slice(0, 10);
+            resultado.unshift({
+                iso,
+                etiqueta: formatearDiaMesDesdeISO(iso),
+                total: 0
+            });
+        }
+
+        return resultado;
+    }
+
+    function renderTrendChart() {
+        if (!activityTrendCanvas || !window.Chart) {
+            return;
+        }
+
+        const Chart = window.Chart;
+        const serie = obtenerSerieFiltradaPorRango();
+        const labels = serie.map(item => item.etiqueta);
+        const dataValues = serie.map(item => item.total);
+
+        trendLabelsISO = serie.map(item => item.iso);
+
+        if (!trendChart) {
+            trendChart = new Chart(activityTrendCanvas, {
+                type: 'line',
+                data: {
+                    labels,
+                    datasets: [{
+                        label: 'Actividades',
+                        data: dataValues,
+                        borderColor: '#6c5dd3',
+                        backgroundColor: 'rgba(108, 93, 211, 0.18)',
+                        tension: 0.35,
+                        fill: true,
+                        pointBackgroundColor: '#6c5dd3',
+                        pointBorderColor: '#fff',
+                        pointBorderWidth: 2,
+                        pointRadius: 4
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    scales: {
+                        x: {
+                            ticks: {
+                                color: '#525a6b'
+                            },
+                            grid: {
+                                display: false
+                            }
+                        },
+                        y: {
+                            beginAtZero: true,
+                            ticks: {
+                                color: '#525a6b',
+                                precision: 0,
+                                stepSize: 1
+                            },
+                            grid: {
+                                color: 'rgba(82, 90, 107, 0.12)'
+                            }
+                        }
+                    },
+                    plugins: {
+                        legend: { display: false },
+                        tooltip: {
+                            callbacks: {
+                                title: context => {
+                                    if (!context?.length) {
+                                        return '';
+                                    }
+                                    const index = context[0].dataIndex;
+                                    const iso = trendLabelsISO[index];
+                                    const titulo = formatearFechaCompletaDesdeISO(iso);
+                                    return titulo || context[0].label;
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+            return;
+        }
+
+        trendChart.data.labels = labels;
+        trendChart.data.datasets[0].data = dataValues;
+        trendChart.update();
     }
 
     function filtrarPorBusqueda(datos = []) {
@@ -318,59 +572,56 @@
     }
 
     function actualizarCharts(datos = []) {
-        if (!window.Chart || (!activityTrendCanvas && !topUsersCanvas)) {
+        if (!window.Chart || (!activityTrendCanvas && !moduleActivityCanvas && !topUsersCanvas)) {
             return;
         }
 
         const Chart = window.Chart;
 
         if (activityTrendCanvas) {
-            const trendMap = new Map();
+            trendSeries = construirSerieDiaria(datos);
+            renderTrendChart();
+        }
+
+        if (moduleActivityCanvas) {
+            const modulesMap = new Map();
 
             datos.forEach(reg => {
-                const baseFecha = reg?.fecha ? String(reg.fecha) : '';
-                const conversion = convertirFechaHoraZona(reg?.fecha, reg?.hora);
-                const etiqueta = conversion.fechaLocal || baseFecha || 'Sin fecha';
-                const claveOrden = baseFecha || etiqueta;
-                const anterior = trendMap.get(claveOrden) || { etiqueta, total: 0 };
-                anterior.total += 1;
-                anterior.etiqueta = etiqueta;
-                trendMap.set(claveOrden, anterior);
+                const modulo = reg?.modulo ? String(reg.modulo) : 'Sin módulo';
+                modulesMap.set(modulo, (modulesMap.get(modulo) || 0) + 1);
             });
 
-            const trendEntries = Array.from(trendMap.entries()).sort(([a], [b]) => {
-                if (!a && !b) {
-                    return 0;
-                }
-                if (!a) {
-                    return 1;
-                }
-                if (!b) {
-                    return -1;
-                }
-                return a.localeCompare(b);
-            });
+            const moduleEntries = Array.from(modulesMap.entries()).sort((a, b) => b[1] - a[1]);
 
-            const labels = trendEntries.map(([, value]) => value.etiqueta);
-            const dataValues = trendEntries.map(([, value]) => value.total);
+            const labels = moduleEntries.map(([nombre]) => nombre);
+            const dataValues = moduleEntries.map(([, total]) => total);
 
-            if (!trendChart) {
-                trendChart = new Chart(activityTrendCanvas, {
+            if (!moduleActivityChart) {
+                moduleActivityChart = new Chart(moduleActivityCanvas, {
                     type: 'bar',
                     data: {
                         labels,
                         datasets: [{
-                            label: 'Actividades',
+                            label: 'Actividades registradas',
                             data: dataValues,
-                            backgroundColor: '#6c5dd3'
+                            backgroundColor: '#54d2d2',
+                            borderRadius: 8,
+                            maxBarThickness: 48
                         }]
                     },
                     options: {
                         responsive: true,
                         maintainAspectRatio: false,
                         scales: {
-                            x: { ticks: { color: '#525a6b' } },
-                            y: { beginAtZero: true, ticks: { color: '#525a6b', precision: 0 } }
+                            x: {
+                                ticks: { color: '#525a6b' },
+                                grid: { display: false }
+                            },
+                            y: {
+                                beginAtZero: true,
+                                ticks: { color: '#525a6b', precision: 0, stepSize: 1 },
+                                grid: { color: 'rgba(82, 90, 107, 0.1)' }
+                            }
                         },
                         plugins: {
                             legend: { display: false }
@@ -378,9 +629,9 @@
                     }
                 });
             } else {
-                trendChart.data.labels = labels;
-                trendChart.data.datasets[0].data = dataValues;
-                trendChart.update();
+                moduleActivityChart.data.labels = labels;
+                moduleActivityChart.data.datasets[0].data = dataValues;
+                moduleActivityChart.update();
             }
         }
 

--- a/styles/control_log/log.css
+++ b/styles/control_log/log.css
@@ -520,7 +520,7 @@ body {
 
 .insights-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1.5rem;
 }
 
@@ -532,10 +532,21 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  min-height: 320px;
+  min-height: 220px;
+}
+
+.insight-chart--wide {
+  grid-column: 1 / -1;
+  min-height: 260px;
 }
 
 .insight-chart__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.insight-chart__heading {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
@@ -553,10 +564,69 @@ body {
   color: var(--muted-color);
 }
 
+.chart-range-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: #f5f6fb;
+  align-self: flex-start;
+}
+
+.chart-range-btn {
+  border: none;
+  background: transparent;
+  color: var(--muted-color);
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chart-range-btn:hover {
+  background: rgba(108, 93, 211, 0.12);
+  color: #4a3dbd;
+}
+
+.chart-range-btn.is-active {
+  background: #6c5dd3;
+  color: #fff;
+  box-shadow: 0 6px 16px -10px rgba(108, 93, 211, 0.8);
+}
+
+.chart-range-btn:focus-visible {
+  outline: 2px solid rgba(108, 93, 211, 0.6);
+  outline-offset: 2px;
+}
+
 .insight-chart canvas {
   width: 100% !important;
-  height: 100% !important;
-  flex: 1;
+  height: 220px !important;
+  flex: 0 0 auto;
+}
+
+.insight-chart--wide canvas {
+  height: 260px !important;
+}
+
+@media (min-width: 768px) {
+  .insight-chart__header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .insight-chart__heading {
+    flex: 1 1 auto;
+  }
+
+  .chart-range-controls {
+    align-self: center;
+  }
 }
 
 .empty-state {


### PR DESCRIPTION
## Summary
- add range selector buttons to the activity trend insight and adjust headers to accommodate them
- compute a contiguous daily activity series, filling empty days and filtering it by week, month or all ranges before rendering the chart

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc3a3bc1bc832c941dd02d9b9a2539