### PR TITLE
Ajusta disposición de gráficas en log de control

### DIFF
--- a/pages/control_log/log.html
+++ b/pages/control_log/log.html
@@ -177,8 +177,6 @@
               <h3 class="insight-chart__title">Actividades por módulo</h3>
               <span class="insight-chart__subtitle">Distribución de registros</span>
             </div>
-            <h3 class="insight-chart__title">Actividades por módulo</h3>
-            <span class="insight-chart__subtitle">Distribución de registros</span>
           </header>
           <canvas id="moduleActivityChart" aria-label="Gráfica de actividades por módulo" role="img"></canvas>
         </article>
@@ -188,8 +186,6 @@
               <h3 class="insight-chart__title">Usuarios con más actividades</h3>
               <span class="insight-chart__subtitle">Top 5</span>
             </div>
-            <h3 class="insight-chart__title">Usuarios con más actividades</h3>
-            <span class="insight-chart__subtitle">Top 5</span>
           </header>
           <canvas id="topUsersChart" aria-label="Gráfica de usuarios con más actividades" role="img"></canvas>
         </article>

--- a/styles/control_log/log.css
+++ b/styles/control_log/log.css
@@ -520,8 +520,14 @@ body {
 
 .insights-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: minmax(0, 1fr);
   gap: 1.5rem;
+}
+
+@media (min-width: 900px) {
+  .insights-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .insight-chart {


### PR DESCRIPTION
## Summary
- elimina encabezados duplicados en las tarjetas de gráficas de actividades por módulo y usuarios con más actividades
- ajusta la cuadrícula de insights para que las tarjetas se distribuyan en una o dos columnas según el ancho disponible

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc4e6c174c832c939ecbdda36cbb2b