### PR TITLE
Add global search view and navigation for topbar search

### DIFF
--- a/pages/main_menu/global_search.html
+++ b/pages/main_menu/global_search.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OPTISTOCK - Buscador General</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" href="../../styles/main_menu/main_menu.css">
+</head>
+<body class="search-page-body">
+    <div class="sidebar">
+        <div class="sidebar-header">
+            <img src="/images/logobarrablanco.png" alt="Logo de OptiStock" class="sidebar-logo">
+        </div>
+        <div class="sidebar-menu">
+            <a href="main_menu.html">
+                <i class="fas fa-arrow-left"></i> <span>Volver al panel</span>
+            </a>
+            <a class="active">
+                <i class="fas fa-search"></i> <span>Buscador global</span>
+            </a>
+        </div>
+    </div>
+
+    <div class="topbar">
+        <button class="menu-toggle" id="menuToggle">
+            <i class="fas fa-bars"></i>
+        </button>
+        <div class="topbar-title">Buscador global</div>
+        <div class="topbar-actions">
+            <div class="search-bar">
+                <i class="fas fa-search"></i>
+                <input type="text" id="globalSearchInput" placeholder="Buscar productos, movimientos, usuarios...">
+            </div>
+            <div class="notification-bell" title="Alertas">
+                <i class="fas fa-bell"></i>
+            </div>
+            <div class="alert-settings" title="Preferencias">
+                <i class="fas fa-sliders-h"></i>
+            </div>
+            <div class="user-profile">
+                <img src="../../images/profile.jpg" alt="Usuario">
+                <div class="user-info">
+                    <span class="user-name">Administrador</span>
+                    <span class="user-role">Supervisor</span>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <main class="content search-page">
+        <section class="search-summary">
+            <article class="search-summary-card">
+                <div class="summary-label">Coincidencias encontradas</div>
+                <div class="summary-value" id="resultsCount">0</div>
+                <p class="summary-description">Actualiza en tiempo real mientras escribes.</p>
+            </article>
+            <article class="search-summary-card">
+                <div class="summary-label">Atajos destacados</div>
+                <ul class="summary-links" id="quickLinks">
+                    <li><button data-query="stock bajo">Stock bajo</button></li>
+                    <li><button data-query="ingreso">Registrar ingreso</button></li>
+                    <li><button data-query="proveedores">Proveedores</button></li>
+                </ul>
+            </article>
+        </section>
+
+        <section class="search-results" id="searchResults">
+            <div class="search-placeholder">
+                <i class="fas fa-search"></i>
+                <h2>Comienza a escribir para ver resultados</h2>
+                <p>Puedes buscar productos, órdenes de salida, alertas críticas o usuarios del equipo.</p>
+            </div>
+        </section>
+    </main>
+
+    <script src="../../scripts/main_menu/global_search.js"></script>
+</body>
+</html>

--- a/scripts/main_menu/global_search.js
+++ b/scripts/main_menu/global_search.js
@@ -1,0 +1,247 @@
+const body = document.body;
+const sidebar = document.querySelector('.sidebar');
+const menuToggle = document.getElementById('menuToggle');
+const searchInput = document.getElementById('globalSearchInput');
+const searchResultsContainer = document.getElementById('searchResults');
+const resultsCount = document.getElementById('resultsCount');
+const quickLinks = document.getElementById('quickLinks');
+
+if (menuToggle && sidebar) {
+    menuToggle.addEventListener('click', () => {
+        if (window.innerWidth <= 992) {
+            const isActive = sidebar.classList.toggle('active');
+            body.classList.toggle('sidebar-open', isActive);
+        }
+    });
+
+    document.addEventListener('click', event => {
+        if (window.innerWidth > 992) return;
+        if (!sidebar.contains(event.target) && !menuToggle.contains(event.target)) {
+            sidebar.classList.remove('active');
+            body.classList.remove('sidebar-open');
+        }
+    });
+
+    window.addEventListener('resize', () => {
+        if (window.innerWidth > 992) {
+            sidebar.classList.remove('active');
+            body.classList.remove('sidebar-open');
+        }
+    });
+}
+
+const userNameEl = document.querySelector('.user-name');
+const userRoleEl = document.querySelector('.user-role');
+const userImgEl = document.querySelector('.user-profile img');
+
+if (userNameEl) {
+    const nombre = localStorage.getItem('usuario_nombre');
+    if (nombre) userNameEl.textContent = nombre;
+}
+
+if (userRoleEl) {
+    const rol = localStorage.getItem('usuario_rol');
+    if (rol) userRoleEl.textContent = rol;
+}
+
+if (userImgEl) {
+    let fotoPerfil = localStorage.getItem('foto_perfil') || '/images/profile.jpg';
+    if (fotoPerfil && !fotoPerfil.startsWith('/')) {
+        fotoPerfil = '/' + fotoPerfil;
+    }
+    userImgEl.onerror = () => {
+        userImgEl.src = '/images/profile.jpg';
+    };
+    userImgEl.src = fotoPerfil;
+}
+
+const searchDataset = [
+    {
+        categoria: 'Productos',
+        titulo: 'Baterías AA',
+        descripcion: 'Stock actual: 120 unidades · Zona A1 · Rotación alta',
+        accion: 'Ver ficha',
+        url: '../gest_inve/inventario_basico.html'
+    },
+    {
+        categoria: 'Productos',
+        titulo: 'Monitor 24"',
+        descripcion: 'Stock bajo · Zona D4 · 1 unidad disponible',
+        accion: 'Ir al inventario',
+        url: '../gest_inve/inventario_basico.html'
+    },
+    {
+        categoria: 'Órdenes',
+        titulo: 'Orden de ingreso #00891',
+        descripcion: 'Pendiente de verificación · 24 artículos · Registrada hoy 09:30h',
+        accion: 'Revisar orden',
+        url: '../area_almac_v2/gestion_areas_zonas.html'
+    },
+    {
+        categoria: 'Órdenes',
+        titulo: 'Orden de salida #00652',
+        descripcion: 'Ruta programada · Requiere confirmación de despacho',
+        accion: 'Confirmar despacho',
+        url: '../area_almac_v2/gestion_areas_zonas.html'
+    },
+    {
+        categoria: 'Alertas',
+        titulo: 'Stock crítico - Cables HDMI',
+        descripcion: 'Última reposición hace 15 días · Zona B2 · Prioridad alta',
+        accion: 'Ver alertas',
+        url: 'main_menu.html#stockAlertsCard'
+    },
+    {
+        categoria: 'Alertas',
+        titulo: 'Incidencia de lectura QR',
+        descripcion: '3 fallos consecutivos en lector del muelle 4 · Revisar hardware',
+        accion: 'Registrar mantenimiento',
+        url: '../control_log/log.html'
+    },
+    {
+        categoria: 'Usuarios',
+        titulo: 'María Ramírez',
+        descripcion: 'Supervisora de zona · Último acceso hace 2 horas · 18 movimientos hoy',
+        accion: 'Ver perfil',
+        url: '../admin_usuar/administracion_usuarios.html'
+    },
+    {
+        categoria: 'Usuarios',
+        titulo: 'Pablo Torres',
+        descripcion: 'Auxiliar de inventario · 12 tareas pendientes de cierre',
+        accion: 'Asignar tareas',
+        url: '../admin_usuar/administracion_usuarios.html'
+    },
+    {
+        categoria: 'Reportes',
+        titulo: 'Reporte de rotación semanal',
+        descripcion: 'Comparativa con la semana anterior · Variación +8%',
+        accion: 'Abrir reporte',
+        url: '../reports/reportes.html'
+    },
+    {
+        categoria: 'Reportes',
+        titulo: 'Resumen de auditoría',
+        descripcion: 'Cobertura 95% del inventario · Pendientes por revisar: 4 ítems',
+        accion: 'Revisar resumen',
+        url: '../reports/reportes.html'
+    }
+];
+
+function normalizarTexto(texto) {
+    return texto
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '');
+}
+
+function filtrarResultados(termino) {
+    const terminoNormalizado = normalizarTexto(termino.trim());
+
+    if (!terminoNormalizado) {
+        return searchDataset;
+    }
+
+    return searchDataset.filter(item => {
+        const titulo = normalizarTexto(item.titulo);
+        const descripcion = normalizarTexto(item.descripcion);
+        return titulo.includes(terminoNormalizado) || descripcion.includes(terminoNormalizado);
+    });
+}
+
+function crearGrupoHTML(categoria, elementos) {
+    const group = document.createElement('article');
+    group.className = 'search-group';
+
+    const header = document.createElement('header');
+    header.className = 'search-group-header';
+    header.innerHTML = `
+        <div class="group-info">
+            <span class="group-icon"><i class="fas fa-folder-open"></i></span>
+            <h2>${categoria}</h2>
+        </div>
+        <span class="group-count">${elementos.length}</span>
+    `;
+
+    const list = document.createElement('ul');
+    list.className = 'search-list';
+
+    elementos.forEach(item => {
+        const li = document.createElement('li');
+        li.className = 'search-item';
+        li.innerHTML = `
+            <div class="item-content">
+                <h3>${item.titulo}</h3>
+                <p>${item.descripcion}</p>
+            </div>
+            <a class="item-action" href="${item.url}">${item.accion}</a>
+        `;
+        list.appendChild(li);
+    });
+
+    group.appendChild(header);
+    group.appendChild(list);
+    return group;
+}
+
+function renderResultados(termino) {
+    const resultados = filtrarResultados(termino);
+    resultsCount.textContent = resultados.length;
+    searchResultsContainer.innerHTML = '';
+
+    if (resultados.length === 0) {
+        searchResultsContainer.innerHTML = `
+            <div class="search-placeholder">
+                <i class="fas fa-search"></i>
+                <h2>Sin coincidencias</h2>
+                <p>Prueba con otro término o revisa las categorías disponibles.</p>
+            </div>
+        `;
+        return;
+    }
+
+    const agrupados = resultados.reduce((acc, item) => {
+        if (!acc[item.categoria]) {
+            acc[item.categoria] = [];
+        }
+        acc[item.categoria].push(item);
+        return acc;
+    }, {});
+
+    Object.keys(agrupados)
+        .sort()
+        .forEach(categoria => {
+            const grupo = crearGrupoHTML(categoria, agrupados[categoria]);
+            searchResultsContainer.appendChild(grupo);
+        });
+}
+
+if (quickLinks) {
+    quickLinks.addEventListener('click', event => {
+        const button = event.target.closest('button[data-query]');
+        if (!button) return;
+        const query = button.getAttribute('data-query');
+        searchInput.value = query;
+        renderResultados(query);
+    });
+}
+
+if (searchInput) {
+    const params = new URLSearchParams(window.location.search);
+    const initialQuery = params.get('q') || '';
+    if (initialQuery) {
+        searchInput.value = initialQuery;
+        renderResultados(initialQuery);
+    }
+
+    searchInput.addEventListener('input', event => {
+        renderResultados(event.target.value);
+    });
+
+    searchInput.addEventListener('keydown', event => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            renderResultados(event.target.value);
+        }
+    });
+}

--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -11,6 +11,8 @@ const alertMovCriticos = document.getElementById('alertMovCriticos');
 const alertFallosInventario = document.getElementById('alertFallosInventario');
 const saveAlertSettings = document.getElementById('saveAlertSettings');
 const cancelAlertSettings = document.getElementById('cancelAlertSettings');
+const topbarSearchInput = document.querySelector('.topbar .search-bar input');
+const topbarSearchIcon = document.querySelector('.topbar .search-bar i');
 
 let navegadorTimeZone = null;
 
@@ -85,6 +87,27 @@ function sendPushNotification(title, message) {
     } else {
         alert(message);
     }
+}
+
+function openGlobalSearch(query) {
+    const searchUrl = query ? `global_search.html?q=${encodeURIComponent(query)}` : 'global_search.html';
+    window.location.href = searchUrl;
+}
+
+if (topbarSearchInput) {
+    topbarSearchInput.addEventListener('keydown', event => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            openGlobalSearch(topbarSearchInput.value.trim());
+        }
+    });
+}
+
+if (topbarSearchIcon) {
+    topbarSearchIcon.addEventListener('click', () => {
+        const query = topbarSearchInput ? topbarSearchInput.value.trim() : '';
+        openGlobalSearch(query);
+    });
 }
 
 function getContrastingColor(hexColor) {

--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -191,6 +191,198 @@ img {
     font-size: 0.95rem;
 }
 
+/* Search page */
+.search-page-body {
+    background: var(--page-bg);
+}
+
+.search-page {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.search-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.search-summary-card {
+    background: var(--primary-surface);
+    border-radius: var(--radius-lg);
+    padding: 1.6rem;
+    box-shadow: 0 28px 60px -48px rgba(15, 40, 65, 0.65);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.summary-label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(255, 255, 255, 0.65);
+    font-weight: 600;
+}
+
+.summary-value {
+    font-size: clamp(2.4rem, 3vw, 2.9rem);
+    font-weight: 700;
+    color: var(--accent-color);
+    text-shadow: 0 18px 42px rgba(0, 0, 0, 0.35);
+}
+
+.summary-description {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.72);
+}
+
+.summary-links {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin: 0;
+    padding: 0;
+}
+
+.summary-links button {
+    border: none;
+    border-radius: var(--radius-pill);
+    padding: 0.55rem 1.2rem;
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    font-weight: 500;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.summary-links button:hover {
+    background: rgba(255, 255, 255, 0.2);
+    transform: translateY(-2px);
+    box-shadow: 0 18px 30px -24px rgba(0, 0, 0, 0.45);
+}
+
+.search-results {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.search-placeholder {
+    padding: 3.5rem 1.5rem;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: var(--radius-lg);
+    border: 1px dashed rgba(255, 255, 255, 0.2);
+    text-align: center;
+    color: rgba(255, 255, 255, 0.7);
+    display: grid;
+    gap: 1rem;
+    justify-items: center;
+}
+
+.search-placeholder i {
+    font-size: 2rem;
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.search-group {
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    box-shadow: 0 28px 55px -48px rgba(15, 40, 65, 0.5);
+    overflow: hidden;
+}
+
+.search-group-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.2rem 1.6rem;
+    background: rgba(0, 0, 0, 0.15);
+}
+
+.group-info {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.group-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.15);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+}
+
+.search-group-header h2 {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: #fff;
+}
+
+.group-count {
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.75);
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-pill);
+    padding: 0.35rem 0.85rem;
+}
+
+.search-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.search-item {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1.4rem 1.6rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.search-item:first-child {
+    border-top: none;
+}
+
+.item-content h3 {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 0.35rem;
+}
+
+.item-content p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.item-action {
+    align-self: center;
+    padding: 0.65rem 1.4rem;
+    border-radius: var(--radius-pill);
+    background: var(--accent-color);
+    color: #0f172a;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.item-action:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 35px -28px rgba(15, 40, 65, 0.6);
+}
+
 .notification-bell,
 .alert-settings {
     position: relative;


### PR DESCRIPTION
## Summary
- add a dedicated global search page that reuses the existing dashboard layout and highlights quick links and result summaries
- build a lightweight client-side search dataset with grouping, filtering, and responsive sidebar/profile behaviour for the preview
- wire the topbar search bar to open the global search experience and extend the shared styles with search result components

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc518a5798832ca49601544d8932a3