### PR TITLE
Improve mobile responsiveness across pages

### DIFF
--- a/styles/Admin_usuar/administracion_usuarios.css
+++ b/styles/Admin_usuar/administracion_usuarios.css
@@ -667,6 +667,20 @@ body {
 }
 
 @media (max-width: 576px) {
+  .users-page {
+    padding: 0 16px;
+  }
+
+  .page-header,
+  .filters-card,
+  .table-card {
+    padding: 1.3rem;
+  }
+
+  .header-title {
+    font-size: clamp(1.5rem, 5vw, 2rem);
+  }
+
   .filters-actions {
     flex-direction: column;
     align-items: stretch;

--- a/styles/Area_almac/areas_zonas.css
+++ b/styles/Area_almac/areas_zonas.css
@@ -480,6 +480,37 @@ img {
 }
 
 @media (max-width: 576px) {
+  .warehouse-page {
+    padding: 0 16px;
+  }
+
+  .page-header {
+    padding: 1.6rem;
+  }
+
+  .header-title {
+    font-size: clamp(1.45rem, 5vw, 2rem);
+  }
+
+  .shell-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1rem;
+  }
+
+  .shell-header__actions {
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .shell-action {
+    width: 100%;
+  }
+
+  .highlight-card {
+    padding: 1rem;
+  }
+
   .dimension-row,
   .sublevels-container > div {
     grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));

--- a/styles/Area_almac_v2/gestion_areas_zonas.css
+++ b/styles/Area_almac_v2/gestion_areas_zonas.css
@@ -466,3 +466,37 @@ img {
     grid-template-columns: 1fr;
   }
 }
+
+@media (max-width: 576px) {
+  .warehouse-page {
+    padding: 1rem 1.1rem;
+  }
+
+  .page-header {
+    padding: 1.6rem;
+  }
+
+  .header-title {
+    font-size: clamp(1.4rem, 6vw, 1.9rem);
+  }
+
+  .shell-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1rem;
+  }
+
+  .shell-header__actions {
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .shell-action {
+    width: 100%;
+    text-align: center;
+  }
+
+  .highlight-card {
+    padding: 1rem;
+  }
+}

--- a/styles/account_suscrip/account_suscrip.css
+++ b/styles/account_suscrip/account_suscrip.css
@@ -642,6 +642,22 @@ img {
     padding: 0 1rem 2rem;
   }
 
+  .page-header,
+  .highlight-card,
+  .account-menu,
+  .profile-card,
+  .subscription-card {
+    padding: 1.4rem;
+  }
+
+  .header-title {
+    font-size: clamp(1.6rem, 5vw, 2.1rem);
+  }
+
+  .header-highlights {
+    grid-template-columns: 1fr;
+  }
+
   .subscription-card__row {
     flex-direction: column;
     align-items: flex-start;
@@ -653,5 +669,15 @@ img {
 
   .subscription-actions .btn {
     min-width: 100%;
+  }
+
+  .account-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .plan-card__details li {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.35rem;
   }
 }

--- a/styles/control_log/log.css
+++ b/styles/control_log/log.css
@@ -697,6 +697,20 @@ body {
 }
 
 @media (max-width: 576px) {
+  .log-page {
+    padding: 0 16px;
+  }
+
+  .page-header,
+  .filters-card,
+  .table-card {
+    padding: 1.4rem;
+  }
+
+  .header-title {
+    font-size: clamp(1.5rem, 5vw, 2rem);
+  }
+
   .filters-actions {
     flex-direction: column;
     align-items: stretch;

--- a/styles/gest_inve/inventario.css
+++ b/styles/gest_inve/inventario.css
@@ -557,6 +557,18 @@ img {
 }
 
 @media (max-width: 576px) {
+  .inventory-page {
+    padding: 0 16px;
+  }
+
+  .page-header {
+    padding: 1.6rem;
+  }
+
+  .header-title {
+    font-size: clamp(1.5rem, 5vw, 2rem);
+  }
+
   .inventory-tabs {
     grid-template-columns: 1fr;
   }

--- a/styles/gest_inve/inventario_basico.css
+++ b/styles/gest_inve/inventario_basico.css
@@ -597,6 +597,18 @@ img {
 }
 
 @media (max-width: 576px) {
+  .inventory-page {
+    padding: 0 16px;
+  }
+
+  .page-header {
+    padding: 1.6rem;
+  }
+
+  .header-title {
+    font-size: clamp(1.5rem, 5vw, 2rem);
+  }
+
   .inventory-table {
     min-width: 480px;
   }

--- a/styles/index/index.css
+++ b/styles/index/index.css
@@ -97,3 +97,53 @@ h2.h4 {
         font-size: 2.5rem;
     }
 }
+
+@media (max-width: 576px) {
+    .container-fluid {
+        padding: 40px 16px;
+    }
+
+    .content img {
+        max-width: 260px;
+    }
+
+    .lead {
+        font-size: 1rem;
+        margin-bottom: 24px;
+    }
+
+    .btn-light {
+        width: 100%;
+        font-size: 1.05rem;
+        padding: 12px 18px;
+    }
+
+    .nav-links {
+        margin-bottom: 30px;
+    }
+
+    .nav-links a {
+        display: inline-block;
+        margin: 0 8px;
+        font-size: 0.95rem;
+    }
+}
+
+@media (max-width: 420px) {
+    h1 {
+        font-size: 2rem;
+    }
+
+    .lead {
+        font-size: 0.95rem;
+    }
+
+    .content {
+        padding: 0 6px;
+    }
+
+    .btn-light {
+        font-size: 1rem;
+        padding: 10px 16px;
+    }
+}

--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -943,8 +943,54 @@ img {
 }
 
 @media (max-width: 576px) {
+    .topbar {
+        flex-wrap: wrap;
+        height: auto;
+        padding: 12px 16px;
+        gap: 12px;
+    }
+
+    .topbar-title {
+        font-size: 1.05rem;
+    }
+
+    .topbar-actions {
+        width: 100%;
+        justify-content: space-between;
+        gap: 10px;
+    }
+
+    .notification-bell,
+    .alert-settings,
+    .menu-toggle {
+        width: 36px;
+        height: 36px;
+    }
+
+    .user-profile {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .user-profile img {
+        width: 38px;
+        height: 38px;
+    }
+
+    .content {
+        padding: 20px 16px;
+    }
+
     .page-header {
-        padding: 1.75rem;
+        padding: 1.6rem;
+    }
+
+    .header-title {
+        font-size: clamp(1.5rem, 5vw, 2rem);
+    }
+
+    .header-actions {
+        gap: 0.75rem;
     }
 
     .quick-actions {
@@ -953,5 +999,7 @@ img {
 
     .btn {
         width: 100%;
+        font-size: 0.9rem;
+        padding: 10px 16px;
     }
 }

--- a/styles/regis_login/login/login.css
+++ b/styles/regis_login/login/login.css
@@ -65,3 +65,59 @@ body {
     justify-content: center;
     font-size: 16px;
 }
+
+@media (max-width: 768px) {
+    body {
+        padding: 30px 16px;
+        height: auto;
+        min-height: 100vh;
+    }
+
+    .nav-links {
+        top: 16px;
+        right: 20px;
+    }
+
+    .login-container {
+        width: min(90vw, 360px);
+        padding: 18px;
+    }
+
+    .register-section {
+        flex-direction: column;
+        gap: 12px;
+        text-align: center;
+    }
+
+    .register-section p {
+        text-align: center;
+        margin-bottom: 8px;
+    }
+}
+
+@media (max-width: 480px) {
+    body {
+        padding-top: 60px;
+    }
+
+    .nav-links {
+        position: static;
+        text-align: center;
+        margin-bottom: 20px;
+    }
+
+    .nav-links a {
+        display: inline-block;
+        margin: 0 8px;
+        font-size: 0.95rem;
+    }
+
+    .login-container {
+        width: 100%;
+        padding: 16px;
+    }
+
+    .register-section {
+        width: 100%;
+    }
+}

--- a/styles/regis_login/login/pass_recuperar.css
+++ b/styles/regis_login/login/pass_recuperar.css
@@ -82,3 +82,42 @@ a {
 a:hover {
     text-decoration: underline;
 }
+
+@media (max-width: 768px) {
+    body {
+        padding: 40px 16px;
+        height: auto;
+        min-height: 100vh;
+    }
+
+    .container {
+        margin: 40px auto;
+        padding: 28px 22px;
+        width: 100%;
+    }
+
+    h2 {
+        font-size: 24px;
+    }
+}
+
+@media (max-width: 480px) {
+    .container {
+        margin: 20px auto;
+        padding: 22px 18px;
+    }
+
+    h2 {
+        font-size: 22px;
+    }
+
+    input,
+    button {
+        font-size: 14px;
+        padding: 10px;
+    }
+
+    label {
+        font-size: 13px;
+    }
+}

--- a/styles/regis_login/regist/regist_google.css
+++ b/styles/regis_login/regist/regist_google.css
@@ -51,3 +51,36 @@ button {
 button:hover {
     background-color: #1a254d;
 }
+
+@media (max-width: 768px) {
+    body {
+        padding: 40px 16px;
+        min-height: 100vh;
+    }
+
+    .container {
+        margin: 60px auto;
+        padding: 24px;
+        width: 100%;
+    }
+}
+
+@media (max-width: 480px) {
+    body {
+        padding: 30px 12px;
+    }
+
+    .container {
+        margin: 30px auto;
+        padding: 20px;
+    }
+
+    .container h3 {
+        font-size: 1.25rem;
+    }
+
+    button {
+        font-size: 15px;
+        padding: 10px;
+    }
+}

--- a/styles/regis_login/regist/regist_inter.css
+++ b/styles/regis_login/regist/regist_inter.css
@@ -31,3 +31,39 @@ p {
     margin-top: 15px;
     font-size: 16px;
 }
+
+@media (max-width: 768px) {
+    body {
+        padding: 40px 16px;
+        min-height: 100vh;
+    }
+
+    .container {
+        margin: 60px auto;
+        padding: 24px;
+        width: 100%;
+    }
+
+    p {
+        font-size: 15px;
+    }
+}
+
+@media (max-width: 480px) {
+    body {
+        padding: 30px 12px;
+    }
+
+    .container {
+        margin: 30px auto;
+        padding: 20px;
+    }
+
+    h3 {
+        font-size: 1.35rem;
+    }
+
+    p {
+        font-size: 14px;
+    }
+}

--- a/styles/regis_login/regist/registro_empresa.css
+++ b/styles/regis_login/regist/registro_empresa.css
@@ -72,3 +72,43 @@ button {
 button:hover {
     background-color: #333;
 }
+
+@media (max-width: 768px) {
+    body {
+        padding: 40px 16px;
+    }
+
+    .container {
+        padding: 28px 24px;
+        margin: 40px auto;
+    }
+
+    h1 {
+        font-size: 1.75rem;
+    }
+}
+
+@media (max-width: 480px) {
+    body {
+        padding: 30px 12px;
+    }
+
+    .container {
+        padding: 22px 18px;
+        margin: 20px auto;
+    }
+
+    h1 {
+        font-size: 1.5rem;
+    }
+
+    label {
+        font-size: 13px;
+    }
+
+    input,
+    select,
+    button {
+        font-size: 0.95rem;
+    }
+}

--- a/styles/regis_login/regist/registro_p1.css
+++ b/styles/regis_login/regist/registro_p1.css
@@ -33,3 +33,31 @@ body {
     font-size: 14px;
     display: none;
 }
+
+@media (max-width: 768px) {
+    body {
+        padding: 40px 16px;
+        min-height: 100vh;
+    }
+
+    .login-container {
+        width: min(92vw, 360px);
+        padding: 18px;
+    }
+}
+
+@media (max-width: 480px) {
+    body {
+        padding: 30px 12px;
+    }
+
+    .login-container {
+        width: 100%;
+        padding: 16px;
+        border-radius: 16px;
+    }
+
+    .login-container h3 {
+        font-size: 1.25rem;
+    }
+}

--- a/styles/regis_login/regist/registro_p2.css
+++ b/styles/regis_login/regist/registro_p2.css
@@ -47,3 +47,40 @@ body {
 .text-center {
     text-align: center;
 }
+
+@media (max-width: 768px) {
+    body {
+        padding: 30px 16px;
+    }
+
+    .container {
+        margin-top: 20px;
+    }
+
+    .register-section {
+        margin: 30px auto;
+        padding: 18px;
+    }
+}
+
+@media (max-width: 480px) {
+    body {
+        padding: 24px 12px;
+    }
+
+    .register-section {
+        margin: 20px auto;
+        padding: 16px;
+        border-radius: 16px;
+    }
+
+    .register-section h2 {
+        font-size: 1.4rem;
+    }
+
+    .btn-primary {
+        width: 100%;
+        font-size: 0.95rem;
+        padding: 10px;
+    }
+}

--- a/styles/reports/reportes.css
+++ b/styles/reports/reportes.css
@@ -453,3 +453,35 @@ body {
     text-align: center;
   }
 }
+
+@media (max-width: 480px) {
+  .page-hero {
+    padding: 26px 18px;
+  }
+
+  .hero-title {
+    font-size: 1.65rem;
+  }
+
+  .hero-description {
+    font-size: 0.95rem;
+  }
+
+  .filters-card,
+  .chart-card,
+  .results-card,
+  .history-card {
+    padding: 18px;
+  }
+
+  .filters-grid,
+  .metricas-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .field input,
+  .field select {
+    font-size: 0.9rem;
+    padding: 10px;
+  }
+}


### PR DESCRIPTION
## Summary
- adjust the public landing page layout with tighter mobile breakpoints and button scaling
- refine login and registration flows so cards, text, and spacing adapt on phones
- tighten dashboard and management modules with narrower paddings and stacked controls on small viewports

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc50d77f10832c8d69c0d8369a5bee