### PR TITLE
Hook global search to database and honor custom colors

### DIFF
--- a/pages/main_menu/global_search.html
+++ b/pages/main_menu/global_search.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OPTISTOCK - Buscador General</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" href="../../styles/main_menu/main_menu.css">
+</head>
+<body class="search-page-body">
+    <div class="sidebar">
+        <div class="sidebar-header">
+            <img src="/images/logobarrablanco.png" alt="Logo de OptiStock" class="sidebar-logo">
+        </div>
+        <div class="sidebar-menu">
+            <a href="main_menu.html">
+                <i class="fas fa-arrow-left"></i> <span>Volver al panel</span>
+            </a>
+            <a class="active">
+                <i class="fas fa-search"></i> <span>Buscador global</span>
+            </a>
+        </div>
+    </div>
+
+    <div class="topbar">
+        <button class="menu-toggle" id="menuToggle">
+            <i class="fas fa-bars"></i>
+        </button>
+        <div class="topbar-title">Buscador global</div>
+        <div class="topbar-actions">
+            <div class="search-bar">
+                <i class="fas fa-search"></i>
+                <input type="text" id="globalSearchInput" placeholder="Buscar productos, movimientos, usuarios...">
+            </div>
+            <div class="notification-bell" title="Alertas">
+                <i class="fas fa-bell"></i>
+            </div>
+            <div class="alert-settings" title="Preferencias">
+                <i class="fas fa-sliders-h"></i>
+            </div>
+            <div class="user-profile">
+                <img src="../../images/profile.jpg" alt="Usuario">
+                <div class="user-info">
+                    <span class="user-name">Administrador</span>
+                    <span class="user-role">Supervisor</span>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <main class="content search-page">
+        <section class="search-summary">
+            <article class="search-summary-card">
+                <div class="summary-label">Coincidencias encontradas</div>
+                <div class="summary-value" id="resultsCount">0</div>
+                <p class="summary-description">Actualiza en tiempo real mientras escribes.</p>
+            </article>
+            <article class="search-summary-card">
+                <div class="summary-label">Atajos destacados</div>
+                <ul class="summary-links" id="quickLinks">
+                    <li><button data-query="stock bajo">Stock bajo</button></li>
+                    <li><button data-query="ingreso">Registrar ingreso</button></li>
+                    <li><button data-query="proveedores">Proveedores</button></li>
+                </ul>
+            </article>
+        </section>
+
+        <section class="search-results" id="searchResults">
+            <div class="search-placeholder">
+                <i class="fas fa-search"></i>
+                <h2>Comienza a escribir para ver resultados</h2>
+                <p>Puedes buscar productos, órdenes de salida, alertas críticas o usuarios del equipo.</p>
+            </div>
+        </section>
+    </main>
+
+    <script src="../../scripts/main_menu/global_search.js"></script>
+</body>
+</html>

--- a/scripts/main_menu/global_search.js
+++ b/scripts/main_menu/global_search.js
@@ -1,0 +1,411 @@
+const body = document.body;
+const sidebar = document.querySelector('.sidebar');
+const menuToggle = document.getElementById('menuToggle');
+const searchInput = document.getElementById('globalSearchInput');
+const searchResultsContainer = document.getElementById('searchResults');
+const resultsCount = document.getElementById('resultsCount');
+const quickLinks = document.getElementById('quickLinks');
+const summaryDescription = document.querySelector('.summary-description');
+
+const params = new URLSearchParams(window.location.search);
+const initialQuery = (params.get('q') || '').trim();
+if (searchInput && initialQuery) {
+    searchInput.value = initialQuery;
+}
+
+if (menuToggle && sidebar) {
+    menuToggle.addEventListener('click', () => {
+        if (window.innerWidth <= 992) {
+            const isActive = sidebar.classList.toggle('active');
+            body.classList.toggle('sidebar-open', isActive);
+        }
+    });
+
+    document.addEventListener('click', event => {
+        if (window.innerWidth > 992) return;
+        if (!sidebar.contains(event.target) && !menuToggle.contains(event.target)) {
+            sidebar.classList.remove('active');
+            body.classList.remove('sidebar-open');
+        }
+    });
+
+    window.addEventListener('resize', () => {
+        if (window.innerWidth > 992) {
+            sidebar.classList.remove('active');
+            body.classList.remove('sidebar-open');
+        }
+    });
+}
+
+const userNameEl = document.querySelector('.user-name');
+const userRoleEl = document.querySelector('.user-role');
+const userImgEl = document.querySelector('.user-profile img');
+
+if (userNameEl) {
+    const nombre = localStorage.getItem('usuario_nombre');
+    if (nombre) userNameEl.textContent = nombre;
+}
+
+if (userRoleEl) {
+    const rol = localStorage.getItem('usuario_rol');
+    if (rol) userRoleEl.textContent = rol;
+}
+
+if (userImgEl) {
+    let fotoPerfil = localStorage.getItem('foto_perfil') || '/images/profile.jpg';
+    if (fotoPerfil && !fotoPerfil.startsWith('/')) {
+        fotoPerfil = '/' + fotoPerfil;
+    }
+    userImgEl.onerror = () => {
+        userImgEl.src = '/images/profile.jpg';
+    };
+    userImgEl.src = fotoPerfil;
+}
+
+function normalizeHex(hexColor) {
+    if (!hexColor) return null;
+    let hex = hexColor.trim();
+    if (!hex.startsWith('#')) return null;
+    hex = hex.slice(1);
+    if (hex.length === 3) {
+        hex = hex.split('').map(ch => ch + ch).join('');
+    }
+    if (hex.length !== 6) return null;
+    return hex.toLowerCase();
+}
+
+function getContrastingColor(hexColor) {
+    const hex = normalizeHex(hexColor);
+    if (!hex) return '#ffffff';
+    const r = parseInt(hex.slice(0, 2), 16);
+    const g = parseInt(hex.slice(2, 4), 16);
+    const b = parseInt(hex.slice(4, 6), 16);
+    const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+    return brightness > 128 ? '#000000' : '#ffffff';
+}
+
+function hexToRgb(hexColor) {
+    const hex = normalizeHex(hexColor);
+    if (!hex) return null;
+    return {
+        r: parseInt(hex.slice(0, 2), 16),
+        g: parseInt(hex.slice(2, 4), 16),
+        b: parseInt(hex.slice(4, 6), 16)
+    };
+}
+
+function updatePrimaryPalette(baseColor) {
+    const rgb = hexToRgb(baseColor);
+    if (!rgb) return;
+    const { r, g, b } = rgb;
+    const rootStyle = document.documentElement.style;
+    rootStyle.setProperty('--primary-color', baseColor);
+    rootStyle.setProperty('--primary-soft', `rgba(${r}, ${g}, ${b}, 0.16)`);
+    rootStyle.setProperty('--primary-border-soft', `rgba(${r}, ${g}, ${b}, 0.12)`);
+    rootStyle.setProperty('--primary-border-strong', `rgba(${r}, ${g}, ${b}, 0.22)`);
+    rootStyle.setProperty('--primary-border-heavy', `rgba(${r}, ${g}, ${b}, 0.32)`);
+    rootStyle.setProperty('--primary-surface-extra', `rgba(${r}, ${g}, ${b}, 0.08)`);
+    rootStyle.setProperty('--primary-surface', `rgba(${r}, ${g}, ${b}, 0.12)`);
+    rootStyle.setProperty('--primary-surface-strong', `rgba(${r}, ${g}, ${b}, 0.18)`);
+    rootStyle.setProperty('--primary-surface-heavy', `rgba(${r}, ${g}, ${b}, 0.24)`);
+    rootStyle.setProperty('--primary-outline', `rgba(${r}, ${g}, ${b}, 0.18)`);
+    rootStyle.setProperty('--primary-outline-strong', `rgba(${r}, ${g}, ${b}, 0.28)`);
+    rootStyle.setProperty('--primary-shadow-soft', `rgba(${r}, ${g}, ${b}, 0.35)`);
+    rootStyle.setProperty('--primary-shadow-strong', `rgba(${r}, ${g}, ${b}, 0.5)`);
+    rootStyle.setProperty('--primary-shadow-heavy', `rgba(${r}, ${g}, ${b}, 0.65)`);
+    rootStyle.setProperty('--header-gradient', baseColor);
+}
+
+function applySidebarColor(color) {
+    if (!color) return;
+    document.documentElement.style.setProperty('--sidebar-color', color);
+    document.documentElement.style.setProperty('--sidebar-text-color', getContrastingColor(color));
+}
+
+function applyTopbarColor(color) {
+    if (!color) return;
+    const textColor = getContrastingColor(color);
+    document.documentElement.style.setProperty('--topbar-color', color);
+    document.documentElement.style.setProperty('--topbar-text-color', textColor);
+    document.documentElement.style.setProperty('--header-text-color', textColor);
+    document.documentElement.style.setProperty('--header-muted-color', textColor);
+    updatePrimaryPalette(color);
+}
+
+let searchDataset = [];
+let datasetReady = false;
+let datasetError = null;
+let pendingQuery = initialQuery;
+
+function mostrarPlaceholder(titulo, descripcion = '', iconClass = 'fa-search') {
+    if (!searchResultsContainer) return;
+    searchResultsContainer.innerHTML = `
+        <div class="search-placeholder">
+            <i class="fas ${iconClass}"></i>
+            <h2>${titulo}</h2>
+            ${descripcion ? `<p>${descripcion}</p>` : ''}
+        </div>
+    `;
+}
+
+function normalizarTexto(texto) {
+    return texto
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '');
+}
+
+function filtrarResultados(termino) {
+    const terminoNormalizado = normalizarTexto(termino.trim());
+
+    if (!terminoNormalizado) {
+        return searchDataset;
+    }
+
+    return searchDataset.filter(item => {
+        const titulo = normalizarTexto(item.titulo || '');
+        const descripcion = normalizarTexto(item.descripcion || '');
+        const categoria = normalizarTexto(item.categoria || '');
+        return (
+            titulo.includes(terminoNormalizado) ||
+            descripcion.includes(terminoNormalizado) ||
+            categoria.includes(terminoNormalizado)
+        );
+    });
+}
+
+function crearGrupoHTML(categoria, elementos) {
+    const group = document.createElement('article');
+    group.className = 'search-group';
+
+    const header = document.createElement('header');
+    header.className = 'search-group-header';
+    header.innerHTML = `
+        <div class="group-info">
+            <span class="group-icon"><i class="fas fa-folder-open"></i></span>
+            <h2>${categoria}</h2>
+        </div>
+        <span class="group-count">${elementos.length}</span>
+    `;
+
+    const list = document.createElement('ul');
+    list.className = 'search-list';
+
+    elementos.forEach(item => {
+        const li = document.createElement('li');
+        li.className = 'search-item';
+        li.innerHTML = `
+            <div class="item-content">
+                <h3>${item.titulo}</h3>
+                <p>${item.descripcion}</p>
+            </div>
+            <a class="item-action" href="${item.url}">${item.accion}</a>
+        `;
+        list.appendChild(li);
+    });
+
+    group.appendChild(header);
+    group.appendChild(list);
+    return group;
+}
+
+function renderResultados(termino) {
+    if (!searchResultsContainer || !resultsCount) return;
+    pendingQuery = termino;
+
+    if (!datasetReady) {
+        mostrarPlaceholder('Cargando datos de tu empresa...', 'Estamos preparando tus registros más recientes.', 'fa-spinner fa-spin');
+        resultsCount.textContent = '0';
+        return;
+    }
+
+    if (datasetError) {
+        mostrarPlaceholder('No pudimos cargar la búsqueda', datasetError, 'fa-triangle-exclamation');
+        resultsCount.textContent = '0';
+        return;
+    }
+
+    const consulta = termino.trim();
+    const totalDisponible = searchDataset.length;
+    const resultados = filtrarResultados(consulta);
+
+    if (consulta) {
+        resultsCount.textContent = resultados.length.toString();
+    } else {
+        resultsCount.textContent = totalDisponible.toString();
+    }
+
+    if (!consulta) {
+        mostrarPlaceholder('Comienza a escribir para ver resultados', 'Puedes buscar productos, movimientos, áreas o usuarios de tu equipo.');
+        return;
+    }
+
+    if (resultados.length === 0) {
+        mostrarPlaceholder('Sin coincidencias', 'Prueba con otro término o revisa las categorías disponibles.');
+        return;
+    }
+
+    const agrupados = resultados.reduce((acc, item) => {
+        if (!acc[item.categoria]) {
+            acc[item.categoria] = [];
+        }
+        acc[item.categoria].push(item);
+        return acc;
+    }, {});
+
+    searchResultsContainer.innerHTML = '';
+
+    Object.keys(agrupados)
+        .sort((a, b) => a.localeCompare(b, 'es'))
+        .forEach(categoria => {
+            const grupo = crearGrupoHTML(categoria, agrupados[categoria]);
+            searchResultsContainer.appendChild(grupo);
+        });
+}
+
+async function cargarConfiguracionVisual(idEmpresa) {
+    try {
+        const response = await fetch('/scripts/php/get_configuracion_empresa.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id_empresa: Number(idEmpresa) })
+        });
+
+        if (!response.ok) {
+            throw new Error('Error al obtener la configuración visual');
+        }
+
+        const { success, config } = await response.json();
+        if (!success || !config) return;
+
+        if (config.color_sidebar) {
+            applySidebarColor(config.color_sidebar);
+        }
+
+        if (config.color_topbar) {
+            applyTopbarColor(config.color_topbar);
+        }
+    } catch (error) {
+        console.error('No se pudo cargar la configuración visual:', error);
+    }
+}
+
+async function cargarDatosBusqueda(idEmpresa) {
+    if (summaryDescription) {
+        summaryDescription.textContent = 'Sincronizando información con la base de datos...';
+    }
+
+    mostrarPlaceholder('Cargando datos de tu empresa...', 'Estamos preparando tus registros más recientes.', 'fa-spinner fa-spin');
+
+    try {
+        const response = await fetch(`/scripts/php/get_global_search.php?id_empresa=${encodeURIComponent(idEmpresa)}`, {
+            credentials: 'include'
+        });
+
+        if (!response.ok) {
+            throw new Error('Error al solicitar resultados de búsqueda.');
+        }
+
+        const data = await response.json();
+
+        if (!data.success) {
+            datasetReady = true;
+            datasetError = data.message || 'No se pudo obtener información de la base de datos.';
+            renderResultados(pendingQuery);
+            return;
+        }
+
+        searchDataset = Array.isArray(data.results) ? data.results : [];
+        datasetReady = true;
+        datasetError = null;
+
+        if (summaryDescription) {
+            if (searchDataset.length > 0) {
+                summaryDescription.textContent = `Listo. Tienes ${searchDataset.length} elementos indexados para buscar.`;
+            } else {
+                summaryDescription.textContent = 'Tu empresa aún no tiene registros para mostrar. Agrega productos, movimientos o usuarios.';
+            }
+        }
+
+        renderResultados(pendingQuery);
+    } catch (error) {
+        console.error('Error cargando los datos de búsqueda:', error);
+        datasetReady = true;
+        datasetError = 'Ocurrió un problema al conectarnos con la base de datos. Intenta nuevamente más tarde.';
+        if (summaryDescription) {
+            summaryDescription.textContent = 'No fue posible conectar con la base de datos. Intenta nuevamente en unos minutos.';
+        }
+        renderResultados(pendingQuery);
+    }
+}
+
+async function initializeSearchPage() {
+    const userId = localStorage.getItem('usuario_id');
+    if (!userId) {
+        datasetReady = true;
+        datasetError = 'Tu sesión expiró. Por favor inicia sesión nuevamente.';
+        renderResultados('');
+        setTimeout(() => {
+            window.location.href = '../../pages/regis_login/login/login.html';
+        }, 2000);
+        return;
+    }
+
+    let empresaId = localStorage.getItem('id_empresa');
+
+    try {
+        const response = await fetch('/scripts/php/check_empresa.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ usuario_id: userId })
+        });
+
+        const data = await response.json();
+        if (data.success && data.empresa_id) {
+            empresaId = data.empresa_id;
+            localStorage.setItem('id_empresa', data.empresa_id);
+        }
+    } catch (error) {
+        console.warn('No se pudo verificar la empresa del usuario:', error);
+    }
+
+    if (!empresaId) {
+        datasetReady = true;
+        datasetError = 'No encontramos una empresa asociada a tu usuario. Solicita acceso al administrador.';
+        renderResultados('');
+        return;
+    }
+
+    await Promise.all([
+        cargarConfiguracionVisual(empresaId),
+        cargarDatosBusqueda(empresaId)
+    ]);
+}
+
+if (quickLinks) {
+    quickLinks.addEventListener('click', event => {
+        const button = event.target.closest('button[data-query]');
+        if (!button) return;
+        const query = button.getAttribute('data-query');
+        if (searchInput) {
+            searchInput.value = query;
+        }
+        renderResultados(query);
+    });
+}
+
+if (searchInput) {
+    searchInput.addEventListener('input', event => {
+        renderResultados(event.target.value);
+    });
+
+    searchInput.addEventListener('keydown', event => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            renderResultados(event.target.value);
+        }
+    });
+}
+
+renderResultados(initialQuery);
+initializeSearchPage();

--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -11,6 +11,8 @@ const alertMovCriticos = document.getElementById('alertMovCriticos');
 const alertFallosInventario = document.getElementById('alertFallosInventario');
 const saveAlertSettings = document.getElementById('saveAlertSettings');
 const cancelAlertSettings = document.getElementById('cancelAlertSettings');
+const topbarSearchInput = document.querySelector('.topbar .search-bar input');
+const topbarSearchIcon = document.querySelector('.topbar .search-bar i');
 
 let navegadorTimeZone = null;
 
@@ -87,12 +89,95 @@ function sendPushNotification(title, message) {
     }
 }
 
+function openGlobalSearch(query) {
+    const searchUrl = query ? `global_search.html?q=${encodeURIComponent(query)}` : 'global_search.html';
+    window.location.href = searchUrl;
+}
+
+if (topbarSearchInput) {
+    topbarSearchInput.addEventListener('keydown', event => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            openGlobalSearch(topbarSearchInput.value.trim());
+        }
+    });
+}
+
+if (topbarSearchIcon) {
+    topbarSearchIcon.addEventListener('click', () => {
+        const query = topbarSearchInput ? topbarSearchInput.value.trim() : '';
+        openGlobalSearch(query);
+    });
+}
+
+function normalizeHex(hexColor) {
+    if (!hexColor) return null;
+    let hex = hexColor.trim();
+    if (!hex.startsWith('#')) return null;
+    hex = hex.slice(1);
+    if (hex.length === 3) {
+        hex = hex.split('').map(ch => ch + ch).join('');
+    }
+    if (hex.length !== 6) return null;
+    return hex.toLowerCase();
+}
+
 function getContrastingColor(hexColor) {
-    const r = parseInt(hexColor.slice(1, 3), 16);
-    const g = parseInt(hexColor.slice(3, 5), 16);
-    const b = parseInt(hexColor.slice(5, 7), 16);
+    const hex = normalizeHex(hexColor);
+    if (!hex) return '#ffffff';
+    const r = parseInt(hex.slice(0, 2), 16);
+    const g = parseInt(hex.slice(2, 4), 16);
+    const b = parseInt(hex.slice(4, 6), 16);
     const brightness = (r * 299 + g * 587 + b * 114) / 1000;
     return brightness > 128 ? '#000000' : '#ffffff';
+}
+
+function hexToRgb(hexColor) {
+    const hex = normalizeHex(hexColor);
+    if (!hex) return null;
+    return {
+        r: parseInt(hex.slice(0, 2), 16),
+        g: parseInt(hex.slice(2, 4), 16),
+        b: parseInt(hex.slice(4, 6), 16)
+    };
+}
+
+function updatePrimaryPalette(baseColor) {
+    const rgb = hexToRgb(baseColor);
+    if (!rgb) return;
+    const { r, g, b } = rgb;
+    const rootStyle = document.documentElement.style;
+    rootStyle.setProperty('--primary-color', baseColor);
+    rootStyle.setProperty('--primary-soft', `rgba(${r}, ${g}, ${b}, 0.16)`);
+    rootStyle.setProperty('--primary-border-soft', `rgba(${r}, ${g}, ${b}, 0.12)`);
+    rootStyle.setProperty('--primary-border-strong', `rgba(${r}, ${g}, ${b}, 0.22)`);
+    rootStyle.setProperty('--primary-border-heavy', `rgba(${r}, ${g}, ${b}, 0.32)`);
+    rootStyle.setProperty('--primary-surface-extra', `rgba(${r}, ${g}, ${b}, 0.08)`);
+    rootStyle.setProperty('--primary-surface', `rgba(${r}, ${g}, ${b}, 0.12)`);
+    rootStyle.setProperty('--primary-surface-strong', `rgba(${r}, ${g}, ${b}, 0.18)`);
+    rootStyle.setProperty('--primary-surface-heavy', `rgba(${r}, ${g}, ${b}, 0.24)`);
+    rootStyle.setProperty('--primary-outline', `rgba(${r}, ${g}, ${b}, 0.18)`);
+    rootStyle.setProperty('--primary-outline-strong', `rgba(${r}, ${g}, ${b}, 0.28)`);
+    rootStyle.setProperty('--primary-shadow-soft', `rgba(${r}, ${g}, ${b}, 0.35)`);
+    rootStyle.setProperty('--primary-shadow-strong', `rgba(${r}, ${g}, ${b}, 0.5)`);
+    rootStyle.setProperty('--primary-shadow-heavy', `rgba(${r}, ${g}, ${b}, 0.65)`);
+    rootStyle.setProperty('--header-gradient', baseColor);
+}
+
+function applySidebarColor(color) {
+    if (!color) return;
+    document.documentElement.style.setProperty('--sidebar-color', color);
+    document.documentElement.style.setProperty('--sidebar-text-color', getContrastingColor(color));
+}
+
+function applyTopbarColor(color) {
+    if (!color) return;
+    const textColor = getContrastingColor(color);
+    document.documentElement.style.setProperty('--topbar-color', color);
+    document.documentElement.style.setProperty('--topbar-text-color', textColor);
+    document.documentElement.style.setProperty('--header-text-color', textColor);
+    document.documentElement.style.setProperty('--header-muted-color', textColor);
+    updatePrimaryPalette(color);
 }
 
 
@@ -746,13 +831,11 @@ document.querySelectorAll('#sidebarColors button').forEach(btn => {
         colorSidebarSeleccionado = btn.dataset.color;
         document.querySelectorAll('#sidebarColors button').forEach(b => b.style.border = '2px solid #ccc');
         btn.style.border = '3px solid black';
-        document.documentElement.style.setProperty('--sidebar-color', colorSidebarSeleccionado);
-        const textColor = getContrastingColor(colorSidebarSeleccionado);
-        document.documentElement.style.setProperty('--sidebar-text-color', textColor);
+        applySidebarColor(colorSidebarSeleccionado);
 
-        document.documentElement.style.setProperty('--topbar-color', colorTopbarSeleccionado);
-        const topbarText = getContrastingColor(colorTopbarSeleccionado);
-        document.documentElement.style.setProperty('--topbar-text-color', topbarText);
+        if (colorTopbarSeleccionado) {
+            applyTopbarColor(colorTopbarSeleccionado);
+        }
     });
 });
 
@@ -761,9 +844,7 @@ document.querySelectorAll('#topbarColors button').forEach(btn => {
         colorTopbarSeleccionado = btn.dataset.color;
         document.querySelectorAll('#topbarColors button').forEach(b => b.style.border = '2px solid #ccc');
         btn.style.border = '3px solid black';
-        document.documentElement.style.setProperty('--topbar-color', colorTopbarSeleccionado);
-        const textColor = getContrastingColor(colorTopbarSeleccionado);
-        document.documentElement.style.setProperty('--topbar-text-color', textColor);
+        applyTopbarColor(colorTopbarSeleccionado);
     });
 });
 
@@ -958,9 +1039,7 @@ function cargarConfiguracionVisual(idEmpresa) {
     .then(({ success, config }) => {
         if (success && config) {
             if (config.color_sidebar) {
-                document.documentElement.style.setProperty('--sidebar-color', config.color_sidebar);
-                const textColor = getContrastingColor(config.color_sidebar);
-                document.documentElement.style.setProperty('--sidebar-text-color', textColor);
+                applySidebarColor(config.color_sidebar);
                 colorSidebarSeleccionado = config.color_sidebar;
                 document.querySelectorAll('#sidebarColors button').forEach(b => b.style.border = '2px solid #ccc');
                 const btn = document.querySelector(`#sidebarColors button[data-color="${config.color_sidebar}"]`);
@@ -968,9 +1047,7 @@ function cargarConfiguracionVisual(idEmpresa) {
 
             }
             if (config.color_topbar) {
-                document.documentElement.style.setProperty('--topbar-color', config.color_topbar);
-                const textColor = getContrastingColor(config.color_topbar);
-                document.documentElement.style.setProperty('--topbar-text-color', textColor);
+                applyTopbarColor(config.color_topbar);
 
                 colorTopbarSeleccionado = config.color_topbar;
                 document.querySelectorAll('#topbarColors button').forEach(b => b.style.border = '2px solid #ccc');

--- a/scripts/php/get_global_search.php
+++ b/scripts/php/get_global_search.php
@@ -1,0 +1,252 @@
+<?php
+session_start();
+header('Content-Type: application/json; charset=utf-8');
+
+$servername = "localhost";
+$username   = "u296155119_Admin";
+$password   = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+$conn = new mysqli($servername, $username, $password, $database);
+
+if ($conn->connect_error) {
+    echo json_encode([
+        'success' => false,
+        'message' => 'Error de conexión a la base de datos.'
+    ]);
+    exit;
+}
+
+$conn->set_charset('utf8mb4');
+
+if (!isset($_SESSION['usuario_id'])) {
+    echo json_encode([
+        'success' => false,
+        'message' => 'Sesión no válida. Inicia sesión nuevamente.'
+    ]);
+    $conn->close();
+    exit;
+}
+
+$userId = (int) $_SESSION['usuario_id'];
+$idEmpresa = isset($_GET['id_empresa']) ? (int) $_GET['id_empresa'] : 0;
+
+if ($idEmpresa <= 0) {
+    $empresaStmt = $conn->prepare(
+        "SELECT e.id_empresa
+         FROM empresa e
+         LEFT JOIN usuario_empresa ue ON ue.id_empresa = e.id_empresa
+         WHERE e.usuario_creador = ? OR ue.id_usuario = ?
+         ORDER BY e.fecha_registro DESC
+         LIMIT 1"
+    );
+
+    if ($empresaStmt) {
+        $empresaStmt->bind_param('ii', $userId, $userId);
+        $empresaStmt->execute();
+        $empresaStmt->bind_result($empresaId);
+        if ($empresaStmt->fetch()) {
+            $idEmpresa = (int) $empresaId;
+        }
+        $empresaStmt->close();
+    }
+}
+
+if ($idEmpresa <= 0) {
+    echo json_encode([
+        'success' => false,
+        'message' => 'No se encontró una empresa asociada a tu usuario.'
+    ]);
+    $conn->close();
+    exit;
+}
+
+function sanitizeText(?string $value): string {
+    return htmlspecialchars($value ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+
+function formatDateTime(?string $value): string {
+    if (!$value) {
+        return '';
+    }
+
+    try {
+        $date = new DateTime($value);
+        return $date->format('d/m/Y H:i');
+    } catch (Exception $e) {
+        return $value;
+    }
+}
+
+$results = [];
+
+$productosSql = "SELECT p.id, p.nombre, p.descripcion, p.stock, p.last_movimiento, p.last_tipo, z.nombre AS zona_nombre
+                 FROM productos p
+                 LEFT JOIN zonas z ON z.id = p.zona_id
+                 WHERE p.empresa_id = ?
+                 ORDER BY p.nombre ASC";
+
+if ($productosStmt = $conn->prepare($productosSql)) {
+    $productosStmt->bind_param('i', $idEmpresa);
+    $productosStmt->execute();
+    $productosResult = $productosStmt->get_result();
+
+    while ($row = $productosResult->fetch_assoc()) {
+        $descripcionPartes = [];
+        $descripcionPartes[] = 'Stock: ' . (int) $row['stock'] . ' unidades';
+        if (!empty($row['zona_nombre'])) {
+            $descripcionPartes[] = 'Zona ' . sanitizeText($row['zona_nombre']);
+        }
+        if (!empty($row['last_movimiento'])) {
+            $descripcionPartes[] = 'Último movimiento ' . formatDateTime($row['last_movimiento']);
+        }
+
+        $descripcion = implode(' · ', array_filter($descripcionPartes));
+        if (!$descripcion && !empty($row['descripcion'])) {
+            $descripcion = sanitizeText($row['descripcion']);
+        }
+
+        $results[] = [
+            'categoria' => 'Productos',
+            'titulo' => sanitizeText($row['nombre']),
+            'descripcion' => $descripcion,
+            'accion' => 'Ver en inventario',
+            'url' => '../gest_inve/inventario_basico.html'
+        ];
+    }
+
+    $productosStmt->close();
+}
+
+$movimientosSql = "SELECT m.id, m.tipo, m.cantidad, m.fecha_movimiento, p.nombre AS producto_nombre
+                   FROM movimientos m
+                   LEFT JOIN productos p ON p.id = m.producto_id
+                   WHERE m.empresa_id = ?
+                   ORDER BY m.fecha_movimiento DESC
+                   LIMIT 50";
+
+if ($movimientosStmt = $conn->prepare($movimientosSql)) {
+    $movimientosStmt->bind_param('i', $idEmpresa);
+    $movimientosStmt->execute();
+    $movimientosResult = $movimientosStmt->get_result();
+
+    while ($row = $movimientosResult->fetch_assoc()) {
+        $titulo = ucfirst($row['tipo'] ?? 'movimiento') . ' #' . str_pad((string) $row['id'], 4, '0', STR_PAD_LEFT);
+        $descripcionPartes = [];
+
+        if (!empty($row['producto_nombre'])) {
+            $descripcionPartes[] = 'Producto: ' . sanitizeText($row['producto_nombre']);
+        }
+
+        $descripcionPartes[] = 'Cantidad: ' . (int) $row['cantidad'];
+
+        if (!empty($row['fecha_movimiento'])) {
+            $descripcionPartes[] = formatDateTime($row['fecha_movimiento']);
+        }
+
+        $results[] = [
+            'categoria' => 'Movimientos',
+            'titulo' => sanitizeText($titulo),
+            'descripcion' => implode(' · ', array_filter($descripcionPartes)),
+            'accion' => 'Revisar movimiento',
+            'url' => '../control_log/log.html'
+        ];
+    }
+
+    $movimientosStmt->close();
+}
+
+$usuariosSql = "SELECT DISTINCT u.id_usuario, u.nombre, u.apellido, u.rol, u.correo
+                FROM usuario u
+                LEFT JOIN usuario_empresa ue ON ue.id_usuario = u.id_usuario
+                LEFT JOIN empresa e ON e.usuario_creador = u.id_usuario
+                WHERE ue.id_empresa = ? OR e.id_empresa = ?
+                ORDER BY u.nombre ASC, u.apellido ASC";
+
+if ($usuariosStmt = $conn->prepare($usuariosSql)) {
+    $usuariosStmt->bind_param('ii', $idEmpresa, $idEmpresa);
+    $usuariosStmt->execute();
+    $usuariosResult = $usuariosStmt->get_result();
+
+    while ($row = $usuariosResult->fetch_assoc()) {
+        $nombreCompleto = trim(($row['nombre'] ?? '') . ' ' . ($row['apellido'] ?? ''));
+        $descripcionPartes = [];
+        if (!empty($row['rol'])) {
+            $descripcionPartes[] = 'Rol: ' . sanitizeText($row['rol']);
+        }
+        if (!empty($row['correo'])) {
+            $descripcionPartes[] = sanitizeText($row['correo']);
+        }
+
+        $results[] = [
+            'categoria' => 'Usuarios',
+            'titulo' => sanitizeText($nombreCompleto ?: 'Usuario sin nombre'),
+            'descripcion' => implode(' · ', $descripcionPartes),
+            'accion' => 'Gestionar usuario',
+            'url' => '../admin_usuar/administracion_usuarios.html'
+        ];
+    }
+
+    $usuariosStmt->close();
+}
+
+$areasSql = "SELECT nombre, descripcion, volumen FROM areas WHERE id_empresa = ? ORDER BY nombre ASC";
+if ($areasStmt = $conn->prepare($areasSql)) {
+    $areasStmt->bind_param('i', $idEmpresa);
+    $areasStmt->execute();
+    $areasResult = $areasStmt->get_result();
+
+    while ($row = $areasResult->fetch_assoc()) {
+        $descripcionPartes = [];
+        if (!empty($row['descripcion'])) {
+            $descripcionPartes[] = sanitizeText($row['descripcion']);
+        }
+        if (!empty($row['volumen'])) {
+            $descripcionPartes[] = 'Volumen: ' . sanitizeText($row['volumen']);
+        }
+
+        $results[] = [
+            'categoria' => 'Áreas',
+            'titulo' => sanitizeText($row['nombre']),
+            'descripcion' => implode(' · ', array_filter($descripcionPartes)),
+            'accion' => 'Gestionar áreas',
+            'url' => '../area_almac_v2/gestion_areas_zonas.html'
+        ];
+    }
+
+    $areasStmt->close();
+}
+
+$zonasSql = "SELECT nombre, descripcion, tipo_almacenamiento FROM zonas WHERE id_empresa = ? ORDER BY nombre ASC";
+if ($zonasStmt = $conn->prepare($zonasSql)) {
+    $zonasStmt->bind_param('i', $idEmpresa);
+    $zonasStmt->execute();
+    $zonasResult = $zonasStmt->get_result();
+
+    while ($row = $zonasResult->fetch_assoc()) {
+        $descripcionPartes = [];
+        if (!empty($row['descripcion'])) {
+            $descripcionPartes[] = sanitizeText($row['descripcion']);
+        }
+        if (!empty($row['tipo_almacenamiento'])) {
+            $descripcionPartes[] = 'Tipo: ' . sanitizeText($row['tipo_almacenamiento']);
+        }
+
+        $results[] = [
+            'categoria' => 'Zonas',
+            'titulo' => sanitizeText($row['nombre']),
+            'descripcion' => implode(' · ', array_filter($descripcionPartes)),
+            'accion' => 'Gestionar zonas',
+            'url' => '../area_almac_v2/gestion_areas_zonas.html'
+        ];
+    }
+
+    $zonasStmt->close();
+}
+
+$conn->close();
+
+echo json_encode([
+    'success' => true,
+    'results' => $results
+], JSON_UNESCAPED_UNICODE);

--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -191,6 +191,198 @@ img {
     font-size: 0.95rem;
 }
 
+/* Search page */
+.search-page-body {
+    background: var(--page-bg);
+}
+
+.search-page {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.search-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.search-summary-card {
+    background: var(--primary-surface);
+    border-radius: var(--radius-lg);
+    padding: 1.6rem;
+    box-shadow: 0 28px 60px -48px rgba(15, 40, 65, 0.65);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.summary-label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(255, 255, 255, 0.65);
+    font-weight: 600;
+}
+
+.summary-value {
+    font-size: clamp(2.4rem, 3vw, 2.9rem);
+    font-weight: 700;
+    color: var(--accent-color);
+    text-shadow: 0 18px 42px rgba(0, 0, 0, 0.35);
+}
+
+.summary-description {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.72);
+}
+
+.summary-links {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin: 0;
+    padding: 0;
+}
+
+.summary-links button {
+    border: none;
+    border-radius: var(--radius-pill);
+    padding: 0.55rem 1.2rem;
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    font-weight: 500;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.summary-links button:hover {
+    background: rgba(255, 255, 255, 0.2);
+    transform: translateY(-2px);
+    box-shadow: 0 18px 30px -24px rgba(0, 0, 0, 0.45);
+}
+
+.search-results {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.search-placeholder {
+    padding: 3.5rem 1.5rem;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: var(--radius-lg);
+    border: 1px dashed rgba(255, 255, 255, 0.2);
+    text-align: center;
+    color: rgba(255, 255, 255, 0.7);
+    display: grid;
+    gap: 1rem;
+    justify-items: center;
+}
+
+.search-placeholder i {
+    font-size: 2rem;
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.search-group {
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    box-shadow: 0 28px 55px -48px rgba(15, 40, 65, 0.5);
+    overflow: hidden;
+}
+
+.search-group-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.2rem 1.6rem;
+    background: rgba(0, 0, 0, 0.15);
+}
+
+.group-info {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.group-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.15);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+}
+
+.search-group-header h2 {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: #fff;
+}
+
+.group-count {
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.75);
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-pill);
+    padding: 0.35rem 0.85rem;
+}
+
+.search-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.search-item {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1.4rem 1.6rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.search-item:first-child {
+    border-top: none;
+}
+
+.item-content h3 {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 0.35rem;
+}
+
+.item-content p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.item-action {
+    align-self: center;
+    padding: 0.65rem 1.4rem;
+    border-radius: var(--radius-pill);
+    background: var(--accent-color);
+    color: #0f172a;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.item-action:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 35px -28px rgba(15, 40, 65, 0.6);
+}
+
 .notification-bell,
 .alert-settings {
     position: relative;


### PR DESCRIPTION
## Summary
- replace the mocked global search dataset with live results fetched from a new PHP endpoint that queries productos, movimientos, usuarios, áreas y zonas de la empresa
- load the saved topbar/sidebar color configuration inside the search page and extend the main menu theming helpers so the entire palette updates with the chosen colors
- add the backend endpoint that infers la empresa activa por sesión and returns sanitized, grouped search entries ready for the client

## Testing
- php -l scripts/php/get_global_search.php

------
https://chatgpt.com/codex/tasks/task_e_68cc518a5798832ca49601544d8932a3