### PR TITLE
Fix mobile topbar layout and duplicate dropdown caret

### DIFF
--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -273,6 +273,10 @@ img {
     color: var(--topbar-text-color);
 }
 
+.topbar .dropdown-toggle::after {
+    display: none;
+}
+
 .dropdown-menu {
     display: none;
     position: absolute;
@@ -952,13 +956,21 @@ img {
     .topbar {
         padding: 8px 14px;
         padding-left: 14px;
-        height: 60px;
+        height: auto;
         gap: 8px;
+        flex-wrap: wrap;
+        align-items: flex-start;
+        row-gap: 12px;
+    }
+
+    .menu-toggle {
+        order: 0;
     }
 
     .topbar-title {
+        order: 1;
+        flex: 1 1 auto;
         font-size: 1rem;
-        flex: 1;
         min-width: 0;
         white-space: nowrap;
         overflow: hidden;
@@ -966,24 +978,15 @@ img {
     }
 
     .topbar-actions {
-        flex: 1;
+        order: 2;
+        flex: 1 1 100%;
+        display: flex;
+        align-items: center;
         justify-content: flex-end;
-        gap: 8px;
+        gap: 10px;
         min-width: 0;
         flex-wrap: wrap;
-        height: auto;
-        padding: 12px 16px;
-        gap: 12px;
-    }
-
-    .topbar-title {
-        font-size: 1.05rem;
-    }
-
-    .topbar-actions {
-        width: 100%;
-        justify-content: space-between;
-        gap: 10px;
+        padding: 0;
     }
 
     .notification-bell,
@@ -995,12 +998,20 @@ img {
     }
 
     .user-profile {
-        gap: 6px;
+        order: 1;
+        flex: 1 1 100%;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+        padding: 8px 12px;
+        border-radius: 14px;
+        background: rgba(255, 255, 255, 0.18);
     }
 
     .user-profile img {
-        width: 32px;
-        height: 32px;
+        width: 38px;
+        height: 38px;
     }
 
     .user-info {
@@ -1020,22 +1031,13 @@ img {
         font-size: 0.85rem;
         width: 36px;
         height: 36px;
-    }
-
-    .user-profile {
-        width: 100%;
-        justify-content: space-between;
-    }
-
-    .user-profile img {
-        width: 38px;
-        height: 38px;
+        margin-left: auto;
     }
 
     .content {
         padding: 20px 16px;
-        margin-top: 60px;
-        min-height: calc(100vh - 60px);
+        margin-top: calc(60px + 64px);
+        min-height: calc(100vh - (60px + 64px));
     }
 
     .page-header {


### PR DESCRIPTION
## Summary
- restructure the topbar layout for small screens so icons and user data stack cleanly
- adjust mobile spacings to keep the main content clear of the fixed header
- hide the Bootstrap-generated dropdown caret to avoid a duplicated arrow in embedded pages

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cc598fefdc832ca5180fdeba21c85c