### PR TITLE
Rebuild reports dashboard layout

### DIFF
--- a/pages/reports/reportes.html
+++ b/pages/reports/reportes.html
@@ -3,221 +3,173 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Centro de reportes</title>
+  <title>Reportes · OptiStock</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="../../styles/reports/reportes.css" />
 </head>
 <body>
-  <main class="reports-page">
-    <div class="reports-container">
-      <section class="page-hero">
-        <span class="hero-eyebrow">Analítica</span>
-        <h1 class="hero-title">Reportes y métricas</h1>
-        <p class="hero-description">
-          Configura reportes personalizados con los mismos tonos y acabados visuales que el resto de OptiStock. Activa filtros,
-          consulta tendencias y descarga la información en un par de clics.
+  <main class="report-layout">
+    <section class="report-hero">
+      <div class="report-hero__content">
+        <p class="report-hero__badge">Centro de análisis</p>
+        <h1 class="report-hero__title">Reportes OptiStock</h1>
+        <p class="report-hero__subtitle">
+          Reúne métricas clave de inventarios, usuarios y áreas de trabajo. Ajusta los filtros, visualiza las tendencias y exporta tus hallazgos en PDF o Excel sin salir de la plataforma.
         </p>
-        <div id="metricas" class="hero-metrics"></div>
-      </section>
+        <div id="metricas" class="metrics-grid" aria-live="polite"></div>
+      </div>
+      <div class="report-hero__brand" aria-hidden="true">
+        <img src="../../images/optistockLogo.png" alt="" />
+      </div>
+    </section>
 
-      <section class="reports-shell">
-        <div class="shell-grid">
-          <aside class="filters-card" aria-labelledby="tituloFiltros">
-            <header class="card-header">
-              <span class="card-eyebrow">Configuración</span>
-              <h2 id="tituloFiltros" class="card-title">Filtra tu reporte</h2>
-              <p class="card-description">Combina módulos, fechas y atributos para ajustar la información exportada.</p>
-            </header>
-  <!-- Métricas resumidas -->
-  <div id="metricas" class="metricas-grid mb-3"></div>
-
-            <div class="filters-group">
-              <span class="field-label">Módulos</span>
-              <div class="chip-group">
-                <label class="chip-option"><input type="checkbox" class="modulo" value="inventarios" /> <span>Inventarios</span></label>
-                <label class="chip-option"><input type="checkbox" class="modulo" value="usuarios" /> <span>Usuarios</span></label>
-                <label class="chip-option"><input type="checkbox" class="modulo" value="areas" /> <span>Áreas</span></label>
-                <label class="chip-option"><input type="checkbox" class="modulo" value="zonas" /> <span>Zonas</span></label>
-              </div>
-            </div>
-
-            <div class="filters-grid">
-              <label class="field">
-                <span class="field-label">Desde</span>
-                <input type="date" id="fInicio" />
-              </label>
-              <label class="field">
-                <span class="field-label">Hasta</span>
-                <input type="date" id="fFin" />
-              </label>
-              <label class="field">
-                <span class="field-label">Categoría</span>
-                <input type="text" id="fCategoria" placeholder="Todas" />
-              </label>
-              <label class="field">
-                <span class="field-label">Zona</span>
-                <input type="text" id="fZona" placeholder="Todas" />
-              </label>
-              <label class="field">
-                <span class="field-label">Rol</span>
-                <select id="fRol">
-                  <option value="">Todos</option>
-                  <option value="administrador">Administrador</option>
-                  <option value="supervisor">Supervisor</option>
-                  <option value="almacenista">Almacenista</option>
-                  <option value="mantenimiento">Mantenimiento</option>
-                  <option value="etiquetador">Etiquetador</option>
-                </select>
-              </label>
-            </div>
-
-            <div class="action-buttons">
-              <button id="generarPdf" class="action-btn action-btn--primary">Exportar PDF</button>
-              <button id="generarExcel" class="action-btn">Exportar Excel</button>
-              <button id="programarBtn" class="action-btn action-btn--ghost">Programar automático</button>
-            </div>
-          </aside>
-
-          <article class="chart-card" aria-labelledby="tituloGrafica">
-            <header class="card-header">
-              <span class="card-eyebrow">Tendencias</span>
-              <h2 id="tituloGrafica" class="card-title">Movimientos por mes</h2>
-              <p class="card-description">Observa la evolución de los registros incluidos en tu filtro actual.</p>
-            </header>
-            <canvas id="graficaTendencias" height="180"></canvas>
-          </article>
-        </div>
-
-        <article class="results-card" aria-labelledby="tituloResultados">
-          <header class="card-header">
-            <span class="card-eyebrow">Detalle</span>
-            <div class="card-header__row">
-              <h2 id="tituloResultados" class="card-title">Registros filtrados</h2>
-              <span id="estadoResultados" class="results-counter">0 registros encontrados.</span>
-            </div>
-            <p class="card-description">Consulta los movimientos que cumplen con los criterios seleccionados.</p>
-          </header>
-          <div class="table-wrapper">
-            <table id="tablaResultados" class="data-table">
-              <thead>
-                <tr>
-                  <th>#</th>
-                  <th>Módulo</th>
-                  <th>Fecha</th>
-                  <th>Categoría</th>
-                  <th>Zona</th>
-                  <th>Rol</th>
-                  <th>Detalle</th>
-                  <th class="text-end">Cantidad</th>
-                </tr>
-              </thead>
-              <tbody></tbody>
-            </table>
-            <p id="sinDatos" class="empty-message">No hay movimientos que coincidan con los filtros seleccionados.</p>
-          </div>
-        </article>
-      </section>
-
-      <section class="history-card" aria-labelledby="tituloHistorial">
-        <header class="card-header">
-          <span class="card-eyebrow">Historial</span>
-          <h2 id="tituloHistorial" class="card-title">Reportes generados</h2>
-          <p class="card-description">Guarda hasta 20 exportaciones recientes para volver a compartirlas.</p>
+    <section class="report-panels">
+      <aside class="filter-panel" aria-labelledby="panelFiltrosTitulo">
+        <header class="panel-heading">
+          <h2 id="panelFiltrosTitulo">Arma tu reporte</h2>
+          <p>Selecciona los módulos y el rango de fechas que deseas analizar.</p>
         </header>
-        <div class="table-wrapper">
-          <table id="tablaHistorial" class="data-table">
-            <thead>
-              <tr>
-                <th>ID</th>
-                <th>Fecha</th>
-                <th>Resumen</th>
-                <th>Acciones</th>
-              </tr>
-            </thead>
-            <tbody></tbody>
-          </table>
+        <form class="filters-form" autocomplete="off">
+          <fieldset class="filters-form__group">
+            <legend>Módulos</legend>
+            <label class="chip">
+              <input type="checkbox" class="modulo" value="inventarios" />
+              <span>Inventarios</span>
+            </label>
+            <label class="chip">
+              <input type="checkbox" class="modulo" value="usuarios" />
+              <span>Usuarios</span>
+            </label>
+            <label class="chip">
+              <input type="checkbox" class="modulo" value="areas" />
+              <span>Áreas</span>
+            </label>
+            <label class="chip">
+              <input type="checkbox" class="modulo" value="zonas" />
+              <span>Zonas</span>
+            </label>
+          </fieldset>
+
+          <div class="filters-grid">
+            <label class="field">
+              <span>Desde</span>
+              <input type="date" id="fInicio" />
+            </label>
+            <label class="field">
+              <span>Hasta</span>
+              <input type="date" id="fFin" />
+            </label>
+            <label class="field">
+              <span>Categoría</span>
+              <input type="text" id="fCategoria" placeholder="Todas" />
+            </label>
+            <label class="field">
+              <span>Zona</span>
+              <input type="text" id="fZona" placeholder="Todas" />
+            </label>
+            <label class="field">
+              <span>Rol</span>
+              <select id="fRol">
+                <option value="">Todos</option>
+                <option value="administrador">Administrador</option>
+                <option value="supervisor">Supervisor</option>
+                <option value="almacenista">Almacenista</option>
+                <option value="mantenimiento">Mantenimiento</option>
+                <option value="etiquetador">Etiquetador</option>
+              </select>
+            </label>
+          </div>
+        </form>
+        <div class="filters-actions">
+          <button id="generarPdf" type="button" class="btn btn--primary">Exportar PDF</button>
+          <button id="generarExcel" type="button" class="btn">Exportar Excel</button>
+          <button id="programarBtn" type="button" class="btn btn--ghost">Programar reporte</button>
         </div>
+      </aside>
+
+      <section class="chart-panel" aria-labelledby="panelGraficaTitulo">
+        <header class="panel-heading">
+          <h2 id="panelGraficaTitulo">Tendencia de movimientos</h2>
+          <p>Observa la cantidad total registrada por mes según tus filtros.</p>
+        </header>
+        <canvas id="graficaTendencias" height="200" role="img" aria-label="Gráfica de tendencia de movimientos"></canvas>
       </section>
-    </div>
+    </section>
+
+    <section class="report-results" aria-labelledby="panelResultadosTitulo">
+      <header class="panel-heading">
+        <h2 id="panelResultadosTitulo">Registros filtrados</h2>
+        <p id="estadoResultados" class="results-summary" aria-live="polite">Aplica filtros para comenzar.</p>
+      </header>
+      <div class="table-wrapper">
+        <table id="tablaResultados" class="data-table">
+          <thead>
+            <tr>
+              <th scope="col">#</th>
+              <th scope="col">Módulo</th>
+              <th scope="col">Fecha</th>
+              <th scope="col">Categoría</th>
+              <th scope="col">Zona</th>
+              <th scope="col">Rol</th>
+              <th scope="col">Detalle</th>
+              <th scope="col" class="text-end">Cantidad</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+        <p id="sinDatos" class="empty-message">No hay coincidencias con los filtros seleccionados.</p>
+      </div>
+    </section>
+
+    <section class="report-history" aria-labelledby="panelHistorialTitulo">
+      <header class="panel-heading">
+        <h2 id="panelHistorialTitulo">Historial de exportaciones</h2>
+        <p>Los últimos 20 reportes generados se guardan para volver a compartirlos.</p>
+      </header>
+      <div class="table-wrapper">
+        <table id="tablaHistorial" class="data-table">
+          <thead>
+            <tr>
+              <th scope="col">Folio</th>
+              <th scope="col">Fecha</th>
+              <th scope="col">Resumen</th>
+              <th scope="col">Acciones</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </section>
   </main>
 
-  <div id="modalProgramar" class="modal" role="dialog" aria-modal="true" aria-labelledby="tituloProgramacion">
-    <div class="modal-content">
-      <header class="modal-header">
-        <h3 id="tituloProgramacion">Programar reportes</h3>
-        <p>Elige la frecuencia con la que deseas generar automáticamente un PDF.</p>
+  <div id="modalProgramar" class="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitulo" aria-hidden="true" tabindex="-1">
+    <div class="modal__backdrop" data-close="modal"></div>
+    <div class="modal__content" role="document" tabindex="-1">
+      <header class="modal__header">
+        <h3 id="modalTitulo">Programar reporte automático</h3>
+        <p>Elige cada cuánto tiempo quieres generar un PDF con los filtros actuales.</p>
       </header>
       <label class="field">
-        <span class="field-label">Frecuencia</span>
+        <span>Frecuencia</span>
         <select id="intervalo">
           <option value="diario">Diario</option>
           <option value="semanal">Semanal</option>
           <option value="mensual">Mensual</option>
         </select>
       </label>
-      <div class="modal-actions">
-        <button id="guardarProgramacion" class="action-btn action-btn--primary">Guardar</button>
-        <button id="cancelarProgramacion" class="action-btn">Cancelar</button>
+      <div class="modal__actions">
+        <button id="guardarProgramacion" type="button" class="btn btn--primary">Guardar</button>
+        <button id="cancelarProgramacion" type="button" class="btn">Cancelar</button>
       </div>
     </div>
-    <button id="generarPdf" class="btn btn-primary me-2">Exportar PDF</button>
-    <button id="generarExcel" class="btn btn-secondary me-2">Exportar Excel</button>
-    <button id="programarBtn" class="btn btn-warning">Programar automático</button>
   </div>
 
-  <!-- Resultados -->
-  <div id="estadoResultados" class="estado-resultados mb-2"></div>
-  <div class="tabla-resultados mb-4">
-    <table id="tablaResultados" class="table table-bordered table-sm">
-      <thead>
-        <tr>
-          <th>#</th>
-          <th>Módulo</th>
-          <th>Fecha</th>
-          <th>Categoría</th>
-          <th>Zona</th>
-          <th>Rol</th>
-          <th>Detalle</th>
-          <th>Cantidad</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
-    <p id="sinDatos" class="mensaje-vacio">No hay movimientos que coincidan con los filtros seleccionados.</p>
-  </div>
-
-  <!-- Historial -->
-  <h5>Historial de Reportes</h5>
-  <table id="tablaHistorial" class="table table-bordered table-sm">
-    <thead>
-      <tr><th>ID</th><th>Fecha</th><th>Módulos</th><th>Acciones</th></tr>
-    </thead>
-    <tbody></tbody>
-  </table>
-</div>
-
-<!-- Modal de programación -->
-<div id="modalProgramar" class="modal">
-  <div class="modal-content">
-    <label>Intervalo
-      <select id="intervalo">
-        <option value="diario">Diario</option>
-        <option value="semanal">Semanal</option>
-        <option value="mensual">Mensual</option>
-      </select>
-    </label>
-    <div class="mt-3 text-end">
-      <button id="guardarProgramacion" class="btn btn-primary me-2">Guardar</button>
-      <button id="cancelarProgramacion" class="btn btn-secondary">Cancelar</button>
-    </div>
-  </div>
-
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" integrity="sha512-oBr+gwxObn2ymlk/wEYBLETymFcpnSUsctNk6heAQ7Ez+KQEiC5EvhczHxVn9Yx8RJWb1x1o1t4bm/FYnSX8mg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" integrity="sha512-/FZqqw9zM+dAf5BgU984wgKLF6ig84yYI6FqdtYYdlcYNSeNBY0d5hDOGOZa2m30IZHuZOKA8J1Bs8LZp+e7Bw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js" integrity="sha512-SLzeps2sonMSKcwk5Y8ZndKyVKoU9pYNCXS6/4FwXk4Hknc0NrF4Pjk6HoydxHDBPPfQtbDNRsTA70vsK1tn4w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js" integrity="sha384-S1RyhokW2N1DbStO2Qd6hw2yYB9H9n1tFoZT3zh7+BTtPlqvGjufH6G+j6lJzi10" crossorigin="anonymous"></script>
   <script src="../../scripts/reports/reportes.js"></script>
 </body>
 </html>

--- a/scripts/reports/reportes.js
+++ b/scripts/reports/reportes.js
@@ -28,6 +28,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const guardarProgramacionBtn = document.getElementById('guardarProgramacion');
   const cancelarProgramacionBtn = document.getElementById('cancelarProgramacion');
   const intervaloSelect = document.getElementById('intervalo');
+  const modalBackdrop = modal?.querySelector('[data-close="modal"]');
+  const modalContent = modal?.querySelector('.modal__content');
   const graficaCanvas = document.getElementById('graficaTendencias');
   const ctxGrafica = graficaCanvas ? graficaCanvas.getContext('2d') : null;
 
@@ -50,18 +52,22 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('generarExcel')?.addEventListener('click', () => exportar('excel'));
 
   if (programarBtn && modal) {
-    programarBtn.addEventListener('click', () => {
-      modal.style.display = 'flex';
-    });
+    programarBtn.addEventListener('click', () => toggleModal(true));
   }
 
   guardarProgramacionBtn?.addEventListener('click', guardarProgramacion);
 
-  if (cancelarProgramacionBtn && modal) {
-    cancelarProgramacionBtn.addEventListener('click', () => {
-      modal.style.display = 'none';
-    });
+  if (cancelarProgramacionBtn) {
+    cancelarProgramacionBtn.addEventListener('click', () => toggleModal(false));
   }
+
+  modalBackdrop?.addEventListener('click', () => toggleModal(false));
+
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape' && modal?.getAttribute('aria-hidden') === 'false') {
+      toggleModal(false);
+    }
+  });
 
   modulos.forEach(modulo => modulo.addEventListener('change', actualizarVista));
   [fInicio, fFin, fCategoria, fZona].forEach(input => {
@@ -153,8 +159,7 @@ document.addEventListener('DOMContentLoaded', () => {
     metricasDiv.innerHTML = '';
 
     if (datos.length === 0) {
-      metricasDiv.innerHTML = '<p class="empty-message">Ajusta los filtros para ver información resumida.</p>';
-      metricasDiv.innerHTML = '<p class="mensaje-vacio">Ajusta los filtros para ver información resumida.</p>';
+      metricasDiv.innerHTML = '<p class="metrics-empty">Ajusta los filtros para ver información resumida.</p>';
       return;
     }
 
@@ -186,9 +191,6 @@ document.addEventListener('DOMContentLoaded', () => {
       <span class="metric-card__label">${titulo}</span>
       <strong class="metric-card__value">${valor}</strong>
     `;
-    const tarjeta = document.createElement('div');
-    tarjeta.className = 'metric-card';
-    tarjeta.innerHTML = `<span class="metric-title">${titulo}</span><strong>${valor}</strong>`;
     return tarjeta;
   }
 
@@ -224,8 +226,6 @@ document.addEventListener('DOMContentLoaded', () => {
             data: valores,
             borderColor: colorPrimario,
             backgroundColor: superficiePrimaria,
-            borderColor: '#0d6efd',
-            backgroundColor: 'rgba(13, 110, 253, 0.15)',
             tension: 0.25,
             fill: true
           }]
@@ -253,8 +253,6 @@ document.addEventListener('DOMContentLoaded', () => {
               ticks: { color: colorTenue },
               grid: { color: colorBordes }
             }
-          scales: {
-            y: { beginAtZero: true }
           }
         }
       });
@@ -265,7 +263,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  function exportar(tipo) {
+  async function exportar(tipo) {
     const filtros = actualizarVista();
     if (datosFiltrados.length === 0) {
       alert('No hay información para exportar con los filtros seleccionados.');
@@ -274,21 +272,65 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const id = 'REP-' + Date.now();
     if (tipo === 'pdf') {
-      exportarPDF(id, filtros, datosFiltrados);
+      await exportarPDF(id, filtros, datosFiltrados);
     } else {
       exportarExcel(id, filtros, datosFiltrados);
     }
     guardarHistorial(id, filtros, datosFiltrados.length);
   }
 
-  function exportarPDF(id, filtros, datos) {
+  async function exportarPDF(id, filtros, datos) {
     const { jsPDF } = window.jspdf;
-    const doc = new jsPDF();
+    const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
 
-    doc.setFontSize(14);
-    doc.text('Reporte ' + id, 10, 10);
-    doc.setFontSize(11);
-    doc.text('Generado: ' + new Date().toLocaleString(), 10, 18);
+    const paginaAncho = doc.internal.pageSize.getWidth();
+    const paginaAlto = doc.internal.pageSize.getHeight();
+
+    let logoDataUrl = null;
+    try {
+      logoDataUrl = await cargarImagenBase64('images/optistockLogo.png');
+    } catch (error) {
+      console.warn('No se pudo cargar el logotipo para el PDF.', error);
+    }
+
+    if (logoDataUrl) {
+      const marcaAguaEstado = doc.GState ? new doc.GState({ opacity: 0.06 }) : null;
+      if (marcaAguaEstado) {
+        doc.setGState(marcaAguaEstado);
+      }
+      const marcaAguaTam = paginaAncho * 0.65;
+      const marcaAguaX = (paginaAncho - marcaAguaTam) / 2;
+      const marcaAguaY = (paginaAlto - marcaAguaTam) / 2;
+      doc.addImage(logoDataUrl, 'PNG', marcaAguaX, marcaAguaY, marcaAguaTam, marcaAguaTam, undefined, 'SLOW');
+      if (marcaAguaEstado) {
+        const gStateNormal = new doc.GState({ opacity: 1 });
+        doc.setGState(gStateNormal);
+      }
+    }
+
+    const margenLateral = 14;
+    const encabezadoAltura = 20;
+
+    if (logoDataUrl) {
+      const logoAncho = 28;
+      const logoAlto = 28;
+      doc.addImage(logoDataUrl, 'PNG', margenLateral, 12, logoAncho, logoAlto, undefined, 'FAST');
+      doc.setFontSize(18);
+      doc.setTextColor(31, 41, 55);
+      doc.text('OptiStock', margenLateral + logoAncho + 6, 20);
+      doc.setFontSize(11);
+      doc.setTextColor(107, 114, 128);
+      doc.text('Reporte de actividades', margenLateral + logoAncho + 6, 26);
+    } else {
+      doc.setFontSize(18);
+      doc.setTextColor(31, 41, 55);
+      doc.text('OptiStock - Reporte de actividades', margenLateral, 20);
+    }
+
+    doc.setTextColor(100, 116, 139);
+    doc.setFontSize(10);
+    doc.text(`Folio: ${id}`, margenLateral, 42);
+    doc.text(`Generado: ${new Date().toLocaleString()}`, paginaAncho - margenLateral, 42, { align: 'right' });
 
     doc.autoTable({
       head: [['Filtro', 'Valor']],
@@ -299,7 +341,21 @@ document.addEventListener('DOMContentLoaded', () => {
         ['Zona', filtros.zona || 'Todas'],
         ['Rol', filtros.rol || 'Todos']
       ],
-      startY: 26
+      startY: encabezadoAltura + 32,
+      theme: 'grid',
+      styles: {
+        fontSize: 10,
+        cellPadding: 3,
+        textColor: [55, 65, 81]
+      },
+      headStyles: {
+        fillColor: [255, 111, 145],
+        textColor: 255,
+        halign: 'left'
+      },
+      alternateRowStyles: {
+        fillColor: [255, 243, 247]
+      }
     });
 
     doc.autoTable({
@@ -314,9 +370,28 @@ document.addEventListener('DOMContentLoaded', () => {
         item.descripcion,
         item.cantidad
       ]),
-      startY: doc.lastAutoTable.finalY + 6,
-      styles: { fontSize: 9 }
+      startY: doc.lastAutoTable.finalY + 8,
+      styles: {
+        fontSize: 9,
+        cellPadding: 2,
+        textColor: [31, 41, 55]
+      },
+      headStyles: {
+        fillColor: [79, 70, 229],
+        textColor: 255
+      },
+      alternateRowStyles: {
+        fillColor: [237, 233, 254]
+      }
     });
+
+    const pieY = doc.lastAutoTable.finalY + 10;
+    if (pieY < paginaAlto - 12) {
+      doc.setFontSize(9);
+      doc.setTextColor(148, 163, 184);
+      doc.text('OptiStock · Gestión inteligente de inventarios', margenLateral, paginaAlto - 12);
+      doc.text('https://optistock.local', paginaAncho - margenLateral, paginaAlto - 12, { align: 'right' });
+    }
 
     doc.save(id + '.pdf');
   }
@@ -368,13 +443,11 @@ document.addEventListener('DOMContentLoaded', () => {
         <td>${registro.id}</td>
         <td>${formatearFechaHora(registro.fecha)}</td>
         <td>${registro.modulos} · ${registro.registros} registro${registro.registros === 1 ? '' : 's'}</td>
-        <td><button class="link-button" data-id="${registro.id}">Compartir</button></td>
-        <td><button class="btn-share" data-id="${registro.id}">Compartir</button></td>
+        <td><button class="btn-share" data-id="${registro.id}" type="button">Compartir</button></td>
       `;
       historialBody.appendChild(tr);
     });
 
-    historialBody.querySelectorAll('.link-button').forEach(btn => {
     historialBody.querySelectorAll('.btn-share').forEach(btn => {
       btn.addEventListener('click', () => compartir(btn.dataset.id));
     });
@@ -399,9 +472,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const val = intervaloSelect.value;
     localStorage.setItem('reportInterval', val);
     configurarProgramacion();
-    if (modal) {
-      modal.style.display = 'none';
-    }
+    toggleModal(false);
   }
 
   function cargarProgramacion() {
@@ -430,7 +501,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     programacion = setInterval(() => {
-      exportar('pdf');
+      exportar('pdf').catch(error => console.error('Error al generar el reporte programado:', error));
       if ('Notification' in window && Notification.permission === 'granted') {
         new Notification('Reporte generado automáticamente', { body: 'Se creó un PDF con los filtros vigentes.' });
       }
@@ -455,5 +526,39 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function capitalizar(texto) {
     return texto.charAt(0).toUpperCase() + texto.slice(1);
+  }
+
+  function cargarImagenBase64(src) {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.crossOrigin = 'anonymous';
+      img.onload = () => {
+        const canvas = document.createElement('canvas');
+        canvas.width = img.naturalWidth;
+        canvas.height = img.naturalHeight;
+        const contexto = canvas.getContext('2d');
+        contexto.drawImage(img, 0, 0);
+        resolve(canvas.toDataURL('image/png'));
+      };
+      img.onerror = () => reject(new Error('No se pudo cargar la imagen: ' + src));
+      img.src = src;
+      if (img.complete && img.naturalWidth) {
+        img.onload();
+      }
+    });
+  }
+
+  function toggleModal(mostrar) {
+    if (!modal) {
+      return;
+    }
+
+    modal.setAttribute('aria-hidden', mostrar ? 'false' : 'true');
+
+    if (mostrar) {
+      (modalContent || modal).focus({ preventScroll: true });
+    } else {
+      programarBtn?.focus({ preventScroll: true });
+    }
   }
 });

--- a/styles/reports/reportes.css
+++ b/styles/reports/reportes.css
@@ -1,97 +1,111 @@
 @import url("../theme/palette.css");
 
 * {
-  margin: 0;
-  padding: 0;
   box-sizing: border-box;
 }
 
 body {
-  font-family: var(--font-main);
-  background: var(--page-bg);
-  color: var(--text-color);
+  margin: 0;
+  font-family: var(--font-main, "Poppins", sans-serif);
+  background: var(--page-bg, #f5f6fb);
+  color: var(--text-color, #1f2937);
   line-height: 1.6;
 }
 
-.reports-page {
-  min-height: 100vh;
-  padding: 64px 0 80px;
+img {
+  max-width: 100%;
+  display: block;
 }
 
-.reports-container {
+.report-layout {
   width: min(1120px, 92%);
   margin: 0 auto;
+  padding: 56px 0 80px;
   display: flex;
   flex-direction: column;
+  gap: 40px;
+}
+
+.report-hero {
+  display: grid;
   gap: 32px;
-}
-
-.page-hero {
-  background: linear-gradient(135deg, var(--header-gradient), var(--accent-color));
-  color: var(--header-text-color);
   padding: 40px;
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-soft);
-  overflow: hidden;
+  border-radius: 24px;
+  background: linear-gradient(135deg, var(--primary-color, #ff6f91), var(--accent-color, #0fb4d4));
+  color: var(--header-text-color, #ffffff);
   position: relative;
+  overflow: hidden;
 }
 
-.page-hero::after {
+.report-hero::after {
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 20% 20%, var(--header-radial), transparent 60%);
-  opacity: 0.4;
+  background: radial-gradient(circle at 10% 10%, rgba(255, 255, 255, 0.32), transparent 60%);
+  opacity: 0.35;
   pointer-events: none;
 }
 
-.hero-eyebrow {
+.report-hero__content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 640px;
+}
+
+.report-hero__badge {
   display: inline-flex;
   align-items: center;
-  padding: 4px 12px;
-  border-radius: var(--radius-pill);
-  background: rgba(255, 255, 255, 0.16);
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
   font-size: 0.75rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  margin-bottom: 18px;
 }
 
-.hero-title {
-  font-size: clamp(1.8rem, 2.8vw, 2.6rem);
+.report-hero__title {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 2.8rem);
   font-weight: 600;
-  margin-bottom: 12px;
 }
 
-.hero-description {
-  max-width: 680px;
-  color: rgba(255, 255, 255, 0.85);
-  margin-bottom: 28px;
+.report-hero__subtitle {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.86);
 }
 
-.hero-metrics {
+.report-hero__brand {
+  position: absolute;
+  inset: auto 24px -70px auto;
+  width: clamp(140px, 22vw, 220px);
+  opacity: 0.2;
+}
+
+.metrics-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 16px;
-  position: relative;
-  z-index: 1;
+  margin-top: 12px;
 }
 
 .metric-card {
   background: rgba(255, 255, 255, 0.16);
   border: 1px solid rgba(255, 255, 255, 0.28);
-  border-radius: var(--radius-md);
-  padding: 18px 20px;
-  backdrop-filter: blur(4px);
+  border-radius: 18px;
+  padding: 16px 18px;
+  backdrop-filter: blur(3px);
 }
 
 .metric-card__label {
   display: block;
-  font-size: 0.8rem;
-  letter-spacing: 0.06em;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.75);
-  margin-bottom: 10px;
+  color: rgba(255, 255, 255, 0.7);
+  margin-bottom: 6px;
 }
 
 .metric-card__value {
@@ -100,106 +114,105 @@ body {
   color: #ffffff;
 }
 
-.reports-shell {
-  display: flex;
-  flex-direction: column;
-  gap: 28px;
+.metrics-empty {
+  grid-column: 1 / -1;
+  padding: 18px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.14);
+  color: rgba(255, 255, 255, 0.82);
+  text-align: center;
 }
 
-.shell-grid {
+.report-panels {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   gap: 24px;
 }
 
-.filters-card,
-.chart-card,
-.results-card,
-.history-card {
-  background: var(--card-bg);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-soft);
+.filter-panel,
+.chart-panel,
+.report-results,
+.report-history {
+  background: var(--card-bg, #ffffff);
+  border-radius: 20px;
   padding: 28px;
+  box-shadow: 0 24px 60px -45px rgba(17, 25, 40, 0.35);
+  border: 1px solid rgba(17, 25, 40, 0.06);
 }
 
-.card-header {
+@media (min-width: 960px) {
+  .report-panels {
+    grid-template-columns: 340px minmax(0, 1fr);
+  }
+}
+
+.panel-heading {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin-bottom: 22px;
-}
-
-.card-eyebrow {
-  font-size: 0.75rem;
-  font-weight: 500;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--muted-color);
-}
-
-.card-title {
-  font-size: 1.45rem;
-  font-weight: 600;
-}
-
-.card-header__row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 12px;
-}
-
-.card-description {
-  color: var(--muted-color);
-  font-size: 0.95rem;
-}
-
-.filters-group {
+  gap: 6px;
   margin-bottom: 20px;
 }
 
-.field-label {
-  font-size: 0.85rem;
-  font-weight: 500;
-  color: var(--muted-color);
-  margin-bottom: 6px;
-  display: block;
+.panel-heading h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--text-color, #1f2937);
 }
 
-.chip-group {
+.panel-heading p {
+  margin: 0;
+  color: var(--muted-color, #6b7280);
+}
+
+.filters-form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.filters-form__group {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+  margin: 0;
+  padding: 0;
+  border: none;
 }
 
-.chip-option {
+.filters-form__group legend {
+  width: 100%;
+  font-weight: 600;
+  margin-bottom: 4px;
+  color: var(--text-color, #1f2937);
+}
+
+.chip {
   display: inline-flex;
   align-items: center;
   gap: 8px;
   padding: 8px 14px;
-  border-radius: var(--radius-pill);
-  background: var(--primary-surface);
-  color: var(--text-color);
-  border: 1px solid var(--primary-border-soft);
+  border-radius: 999px;
+  border: 1px solid var(--primary-border-soft, rgba(255, 111, 145, 0.18));
+  background: var(--primary-surface, rgba(255, 111, 145, 0.12));
   cursor: pointer;
-  transition: background var(--transition-speed) ease, border-color var(--transition-speed) ease;
+  transition: background 0.2s ease, transform 0.2s ease;
+  font-weight: 500;
 }
 
-.chip-option input {
-  accent-color: var(--primary-color);
+.chip input {
+  accent-color: var(--primary-color, #ff6f91);
 }
 
-.chip-option:hover {
-  background: var(--primary-surface-strong);
-  border-color: var(--primary-border-strong);
+.chip:hover {
+  background: var(--primary-surface-strong, rgba(255, 111, 145, 0.18));
+  transform: translateY(-1px);
 }
 
 .filters-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 16px;
-  margin-bottom: 22px;
 }
 
 .field {
@@ -209,69 +222,56 @@ body {
   font-size: 0.95rem;
 }
 
+.field span {
+  color: var(--muted-color, #6b7280);
+  font-weight: 500;
+}
+
 .field input,
 .field select {
-  width: 100%;
   padding: 10px 12px;
-  border-radius: 12px;
-  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  border: 1px solid var(--border-color, #e7e9f5);
   background: #ffffff;
-  color: var(--text-color);
-  font-family: inherit;
-  font-size: 0.95rem;
-  transition: border-color var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
+  font: inherit;
+  color: inherit;
 }
 
-.field input:focus,
-.field select:focus {
-  outline: none;
-  border-color: var(--primary-color);
-  box-shadow: 0 0 0 4px var(--primary-surface-strong);
-}
-
-.action-buttons {
+.filters-actions {
+  margin-top: 12px;
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
 }
 
-.action-btn {
-  border: 1px solid transparent;
-  border-radius: var(--radius-pill);
-  padding: 10px 22px;
-  background: rgba(15, 23, 42, 0.06);
-  color: var(--text-color);
-  font-weight: 500;
+.btn {
+  border: 1px solid var(--border-color, #e7e9f5);
+  background: #ffffff;
+  color: var(--text-color, #1f2937);
+  padding: 10px 18px;
+  border-radius: 12px;
+  font-weight: 600;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.action-btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 12px 24px -18px rgba(15, 23, 42, 0.5);
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px -15px rgba(17, 25, 40, 0.35);
 }
 
-.action-btn--primary {
-  background: var(--primary-color);
+.btn--primary {
+  background: var(--primary-color, #ff6f91);
+  border-color: transparent;
   color: #ffffff;
-  box-shadow: 0 14px 32px -22px var(--primary-shadow-strong);
 }
 
-.action-btn--primary:hover {
-  background: var(--primary-color);
-}
-
-.action-btn--ghost {
+.btn--ghost {
   background: transparent;
-  border-color: var(--primary-border-strong);
-  color: var(--primary-color);
-}
-
-.chart-card canvas {
-  width: 100%;
 }
 
 .table-wrapper {
+  position: relative;
   overflow-x: auto;
 }
 
@@ -282,206 +282,124 @@ body {
 }
 
 .data-table thead {
-  background: var(--primary-surface);
+  background: var(--primary-surface-extra, rgba(255, 111, 145, 0.08));
 }
 
 .data-table th,
 .data-table td {
+  padding: 12px;
   text-align: left;
-  padding: 12px 14px;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-color, #e7e9f5);
 }
 
 .data-table tbody tr:hover {
-  background: rgba(15, 23, 42, 0.04);
+  background: rgba(15, 180, 212, 0.06);
 }
 
-.results-counter {
-  font-size: 0.95rem;
-  color: var(--muted-color);
+.text-end {
+  text-align: right;
 }
 
 .empty-message {
-  margin-top: 16px;
-  color: var(--muted-color);
-  font-size: 0.95rem;
+  margin: 16px 0 0;
+  padding: 14px 18px;
+  border-radius: 12px;
+  background: rgba(17, 25, 40, 0.05);
+  color: var(--muted-color, #6b7280);
+  display: none;
 }
 
-.text-end {
-  text-align: right;
+.results-summary {
+  font-weight: 600;
+  color: var(--text-color, #1f2937);
 }
 
-.link-button {
-  border: none;
-  background: none;
-  color: var(--primary-color);
-  font-weight: 500;
+.report-history .btn-share {
+  padding: 6px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--primary-border-strong, rgba(255, 111, 145, 0.22));
+  background: var(--primary-surface, rgba(255, 111, 145, 0.12));
+  color: var(--primary-color, #ff6f91);
+  font-weight: 600;
   cursor: pointer;
-  text-decoration: underline;
-  padding: 0;
+}
+
+.report-history .btn-share:hover {
+  background: var(--primary-surface-strong, rgba(255, 111, 145, 0.18));
 }
 
 .modal {
-.metricas-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-}
-
-.metric-card {
-  background: #f8f9fa;
-  border: 1px solid #dee2e6;
-  border-radius: 6px;
-  padding: 0.75rem 1rem;
-  min-width: 160px;
-}
-
-.metric-card strong {
-  font-size: 1.3rem;
-  display: block;
-}
-
-.metric-title {
-  display: block;
-  font-size: 0.85rem;
-  color: #6c757d;
-  margin-bottom: 0.25rem;
-}
-
-.estado-resultados {
-  font-weight: 600;
-}
-
-.tabla-resultados {
-  overflow-x: auto;
-}
-
-.tabla-resultados table td,
-.tabla-resultados table th {
-  font-size: 14px;
-  vertical-align: middle;
-}
-
-.mensaje-vacio {
-  color: #6c757d;
-  font-size: 0.9rem;
-  margin-top: 0.5rem;
-}
-
-#sinDatos {
-  display: none;
-}
-
-.btn-share {
-  background: none;
-  border: none;
-  color: #0d6efd;
-  cursor: pointer;
-  padding: 0;
-  font-size: 0.9rem;
-  text-decoration: underline;
-}
-
-.text-end {
-  text-align: right;
-}
-
-#modalProgramar {
-  display: none;
   position: fixed;
   inset: 0;
-  background: rgba(23, 31, 52, 0.55);
-  backdrop-filter: blur(2px);
+  display: flex;
   align-items: center;
   justify-content: center;
   padding: 24px;
-  z-index: 200;
+  transition: opacity 0.3s ease;
+  z-index: 1000;
 }
 
-.modal-content {
-  background: var(--card-bg);
+.modal[aria-hidden="true"] {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.modal[aria-hidden="false"] {
+  opacity: 1;
+}
+
+.modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.modal__content {
+  position: relative;
+  z-index: 1;
+  width: min(420px, 100%);
+  background: var(--card-bg, #ffffff);
+  border-radius: 20px;
   padding: 28px;
-  border-radius: var(--radius-lg);
-  width: min(420px, 90vw);
-  box-shadow: var(--shadow-soft);
+  box-shadow: 0 25px 80px -40px rgba(15, 23, 42, 0.45);
   display: flex;
   flex-direction: column;
   gap: 18px;
 }
 
-.modal-header h3 {
-  font-size: 1.35rem;
-  margin-bottom: 6px;
-}
-
-.modal-header p {
-  color: var(--muted-color);
-  font-size: 0.95rem;
-}
-
-.modal-actions {
+.modal__header {
   display: flex;
-  justify-content: flex-end;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.modal__header h3 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.modal__header p {
+  margin: 0;
+  color: var(--muted-color, #6b7280);
+}
+
+.modal__actions {
+  display: flex;
   gap: 12px;
+  justify-content: flex-end;
 }
 
-@media (min-width: 960px) {
-  .shell-grid {
-    grid-template-columns: 380px minmax(0, 1fr);
-  }
-}
-
-@media (max-width: 720px) {
-  .page-hero {
+@media (max-width: 640px) {
+  .report-hero {
     padding: 32px 24px;
   }
 
-  .filters-card,
-  .chart-card,
-  .results-card,
-  .history-card {
-    padding: 22px;
-  }
-
-  .action-buttons {
+  .filters-actions {
     flex-direction: column;
-    align-items: stretch;
   }
 
-  .action-btn {
+  .btn {
     width: 100%;
     text-align: center;
-  }
-}
-
-@media (max-width: 480px) {
-  .page-hero {
-    padding: 26px 18px;
-  }
-
-  .hero-title {
-    font-size: 1.65rem;
-  }
-
-  .hero-description {
-    font-size: 0.95rem;
-  }
-
-  .filters-card,
-  .chart-card,
-  .results-card,
-  .history-card {
-    padding: 18px;
-  }
-
-  .filters-grid,
-  .metricas-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .field input,
-  .field select {
-    font-size: 0.9rem;
-    padding: 10px;
   }
 }


### PR DESCRIPTION
## Summary
- rebuild the reports page markup with a single, accessible layout and reorganized filters, results, and history sections
- refresh the reports stylesheet to match the new structure with responsive grids, buttons, and modal styling
- update the reporting script to align with the new DOM, improve metric empty states, and manage the scheduling modal accessibly

## Testing
- not run (frontend-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68cc5798225c832ca1daa1092b4a2ab5