### PR TITLE
Convert mobile search bar to expandable icon

### DIFF
--- a/pages/main_menu/main_menu.html
+++ b/pages/main_menu/main_menu.html
@@ -54,9 +54,17 @@
         </button>
         <div class="topbar-title">Panel de Control Principal</div>
         <div class="topbar-actions">
-            <div class="search-bar">
-                <i class="fas fa-search"></i>
-                <input type="text" placeholder="Buscar productos, órdenes...">
+            <div class="search-wrapper">
+                <button class="search-toggle" id="searchToggle" type="button" aria-label="Abrir buscador" aria-expanded="false">
+                    <i class="fas fa-search"></i>
+                </button>
+                <div class="search-bar" id="topbarSearch">
+                    <i class="fas fa-search"></i>
+                    <input type="text" placeholder="Buscar productos, órdenes..." aria-label="Buscar">
+                    <button class="search-close" id="searchClose" type="button" aria-label="Cerrar buscador">
+                        <i class="fas fa-times"></i>
+                    </button>
+                </div>
             </div>
             <div class="notification-bell">
                 <i class="fas fa-bell"></i>

--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -11,6 +11,53 @@ const alertMovCriticos = document.getElementById('alertMovCriticos');
 const alertFallosInventario = document.getElementById('alertFallosInventario');
 const saveAlertSettings = document.getElementById('saveAlertSettings');
 const cancelAlertSettings = document.getElementById('cancelAlertSettings');
+const searchWrapper = document.querySelector('.search-wrapper');
+const searchToggle = document.getElementById('searchToggle');
+const searchClose = document.getElementById('searchClose');
+const searchInput = document.querySelector('#topbarSearch input');
+
+function closeSearchOverlay() {
+    if (!searchWrapper) return;
+    searchWrapper.classList.remove('active');
+    body.classList.remove('search-open');
+    if (searchToggle) {
+        searchToggle.setAttribute('aria-expanded', 'false');
+    }
+}
+
+if (searchToggle && searchWrapper) {
+    searchToggle.addEventListener('click', () => {
+        const isActive = searchWrapper.classList.toggle('active');
+        body.classList.toggle('search-open', isActive);
+        searchToggle.setAttribute('aria-expanded', String(isActive));
+        if (isActive && searchInput) {
+            setTimeout(() => searchInput.focus(), 60);
+        }
+    });
+}
+
+if (searchClose) {
+    searchClose.addEventListener('click', closeSearchOverlay);
+}
+
+document.addEventListener('click', event => {
+    if (!searchWrapper || !searchWrapper.classList.contains('active')) return;
+    if (!searchWrapper.contains(event.target)) {
+        closeSearchOverlay();
+    }
+});
+
+document.addEventListener('keydown', event => {
+    if (event.key === 'Escape') {
+        closeSearchOverlay();
+    }
+});
+
+window.addEventListener('resize', () => {
+    if (window.innerWidth > 768) {
+        closeSearchOverlay();
+    }
+});
 
 let navegadorTimeZone = null;
 

--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -24,7 +24,8 @@ body::before {
     z-index: 60;
 }
 
-body.sidebar-open::before {
+body.sidebar-open::before,
+body.search-open::before {
     opacity: 1;
 }
 
@@ -160,14 +161,22 @@ img {
     gap: 18px;
 }
 
+.search-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    position: relative;
+}
+
 .search-bar {
     position: relative;
     width: 280px;
+    transition: opacity var(--transition-speed) ease, transform var(--transition-speed) ease;
 }
 
 .search-bar input {
     width: 100%;
-    padding: 12px 18px 12px 46px;
+    padding: 12px 44px 12px 46px;
     border: 1px solid rgba(255, 255, 255, 0.45);
     border-radius: var(--radius-pill);
     font-size: 0.95rem;
@@ -191,8 +200,28 @@ img {
     font-size: 0.95rem;
 }
 
+.search-close {
+    position: absolute;
+    right: 16px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    color: rgba(39, 64, 96, 0.55);
+    font-size: 1rem;
+    cursor: pointer;
+    display: none;
+    padding: 0;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    align-items: center;
+    justify-content: center;
+}
+
 .notification-bell,
-.alert-settings {
+.alert-settings,
+.search-toggle {
     position: relative;
     cursor: pointer;
     color: var(--topbar-text-color);
@@ -208,8 +237,13 @@ img {
     transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
+.search-toggle {
+    display: none;
+}
+
 .notification-bell:hover,
-.alert-settings:hover {
+.alert-settings:hover,
+.search-toggle:hover {
     transform: translateY(-2px);
     background: rgba(255, 255, 255, 0.3);
     box-shadow: 0 12px 32px -20px rgba(15, 50, 87, 0.35);
@@ -271,6 +305,10 @@ img {
     cursor: pointer;
     font-size: 1rem;
     color: var(--topbar-text-color);
+}
+
+.topbar .dropdown-toggle::after {
+    display: none;
 }
 
 .dropdown-menu {
@@ -934,9 +972,40 @@ img {
         min-height: calc(100vh - 64px);
     }
 
+    .search-wrapper {
+        min-width: 0;
+    }
+
+    .search-toggle {
+        display: inline-flex;
+    }
+
     .search-bar {
-        width: 220px;
+        width: min(320px, 88vw);
         display: none;
+        position: absolute;
+        top: calc(100% + 12px);
+        right: 0;
+        background: rgba(255, 255, 255, 0.97);
+        border-radius: var(--radius-lg);
+        padding: 12px 16px 12px 46px;
+        box-shadow: 0 22px 45px -28px rgba(15, 40, 65, 0.45);
+        border: 1px solid rgba(39, 64, 96, 0.12);
+        z-index: 120;
+    }
+
+    .search-wrapper.active .search-bar {
+        display: block;
+    }
+
+    .search-wrapper.active .search-close {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .search-close {
+        color: rgba(15, 40, 65, 0.55);
     }
 
     .dashboard-grid {
@@ -952,13 +1021,21 @@ img {
     .topbar {
         padding: 8px 14px;
         padding-left: 14px;
-        height: 60px;
+        height: auto;
         gap: 8px;
+        flex-wrap: wrap;
+        align-items: flex-start;
+        row-gap: 12px;
+    }
+
+    .menu-toggle {
+        order: 0;
     }
 
     .topbar-title {
+        order: 1;
+        flex: 1 1 auto;
         font-size: 1rem;
-        flex: 1;
         min-width: 0;
         white-space: nowrap;
         overflow: hidden;
@@ -966,41 +1043,41 @@ img {
     }
 
     .topbar-actions {
-        flex: 1;
+        order: 2;
+        flex: 1 1 100%;
+        display: flex;
+        align-items: center;
         justify-content: flex-end;
-        gap: 8px;
+        gap: 10px;
         min-width: 0;
         flex-wrap: wrap;
-        height: auto;
-        padding: 12px 16px;
-        gap: 12px;
-    }
-
-    .topbar-title {
-        font-size: 1.05rem;
-    }
-
-    .topbar-actions {
-        width: 100%;
-        justify-content: space-between;
-        gap: 10px;
+        padding: 0;
     }
 
     .notification-bell,
     .alert-settings,
-    .menu-toggle {
+    .menu-toggle,
+    .search-toggle {
         width: 32px;
         height: 32px;
         font-size: 0.95rem;
     }
 
     .user-profile {
-        gap: 6px;
+        order: 1;
+        flex: 1 1 100%;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+        padding: 8px 12px;
+        border-radius: 14px;
+        background: rgba(255, 255, 255, 0.18);
     }
 
     .user-profile img {
-        width: 32px;
-        height: 32px;
+        width: 38px;
+        height: 38px;
     }
 
     .user-info {
@@ -1020,22 +1097,18 @@ img {
         font-size: 0.85rem;
         width: 36px;
         height: 36px;
-    }
-
-    .user-profile {
-        width: 100%;
-        justify-content: space-between;
-    }
-
-    .user-profile img {
-        width: 38px;
-        height: 38px;
+        margin-left: auto;
     }
 
     .content {
         padding: 20px 16px;
-        margin-top: 60px;
-        min-height: calc(100vh - 60px);
+        margin-top: calc(60px + 64px);
+        min-height: calc(100vh - (60px + 64px));
+    }
+
+    .search-bar {
+        width: calc(100vw - 36px);
+        right: -14px;
     }
 
     .page-header {


### PR DESCRIPTION
## Summary
- restructure the topbar layout for small screens so icons and user data stack cleanly
- convert the search field into an expandable icon on phones so the header elements stay aligned
- adjust mobile spacings to keep the main content clear of the fixed header
- hide the Bootstrap-generated dropdown caret to avoid a duplicated arrow in embedded pages

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cc598fefdc832ca5180fdeba21c85c