### PR TITLE
Embed global search view in main dashboard content

### DIFF
--- a/pages/main_menu/global_search.html
+++ b/pages/main_menu/global_search.html
@@ -1,0 +1,35 @@
+<section class="search-page" id="globalSearchPage">
+    <header class="search-page-header">
+        <span class="search-eyebrow">Herramientas</span>
+        <h1 class="search-title">Buscador global</h1>
+        <p class="search-lead">Consulta productos, movimientos, usuarios y más desde un único lugar.</p>
+        <div class="search-field">
+            <i class="fas fa-search" aria-hidden="true"></i>
+            <input type="text" id="globalSearchInput" placeholder="Buscar productos, movimientos, usuarios..." autocomplete="off">
+        </div>
+    </header>
+
+    <section class="search-summary">
+        <article class="search-summary-card">
+            <div class="summary-label">Coincidencias encontradas</div>
+            <div class="summary-value" id="resultsCount">0</div>
+            <p class="summary-description">Actualiza en tiempo real mientras escribes.</p>
+        </article>
+        <article class="search-summary-card">
+            <div class="summary-label">Atajos destacados</div>
+            <ul class="summary-links" id="quickLinks">
+                <li><button data-query="stock bajo">Stock bajo</button></li>
+                <li><button data-query="ingreso">Registrar ingreso</button></li>
+                <li><button data-query="proveedores">Proveedores</button></li>
+            </ul>
+        </article>
+    </section>
+
+    <section class="search-results" id="searchResults">
+        <div class="search-placeholder">
+            <i class="fas fa-search" aria-hidden="true"></i>
+            <h2>Comienza a escribir para ver resultados</h2>
+            <p>Puedes buscar productos, movimientos, áreas o usuarios de tu empresa.</p>
+        </div>
+    </section>
+</section>

--- a/scripts/main_menu/global_search.js
+++ b/scripts/main_menu/global_search.js
@@ -1,0 +1,383 @@
+const searchPageRoot = document.getElementById('globalSearchPage');
+if (!searchPageRoot) {
+    if (typeof window.__GLOBAL_SEARCH_INITIAL_QUERY__ === 'string') {
+        delete window.__GLOBAL_SEARCH_INITIAL_QUERY__;
+    }
+    console.warn('Vista de buscador global no encontrada en el DOM.');
+    return;
+}
+
+const searchInput = searchPageRoot.querySelector('#globalSearchInput');
+const searchResultsContainer = searchPageRoot.querySelector('#searchResults');
+const resultsCount = searchPageRoot.querySelector('#resultsCount');
+const quickLinks = searchPageRoot.querySelector('#quickLinks');
+const summaryDescription = searchPageRoot.querySelector('.summary-description');
+
+const params = new URLSearchParams(window.location.search);
+const injectedQuery = typeof window.__GLOBAL_SEARCH_INITIAL_QUERY__ === 'string'
+    ? window.__GLOBAL_SEARCH_INITIAL_QUERY__
+    : '';
+
+if (typeof window.__GLOBAL_SEARCH_INITIAL_QUERY__ === 'string') {
+    delete window.__GLOBAL_SEARCH_INITIAL_QUERY__;
+}
+
+const initialQuery = (params.get('q') || injectedQuery || '').trim();
+
+if (searchInput) {
+    if (initialQuery) {
+        searchInput.value = initialQuery;
+    } else {
+        setTimeout(() => searchInput.focus(), 120);
+    }
+}
+
+function normalizeHex(hexColor) {
+    if (!hexColor) return null;
+    let hex = hexColor.trim();
+    if (!hex.startsWith('#')) return null;
+    hex = hex.slice(1);
+    if (hex.length === 3) {
+        hex = hex.split('').map(ch => ch + ch).join('');
+    }
+    if (hex.length !== 6) return null;
+    return hex.toLowerCase();
+}
+
+function getContrastingColor(hexColor) {
+    const hex = normalizeHex(hexColor);
+    if (!hex) return '#ffffff';
+    const r = parseInt(hex.slice(0, 2), 16);
+    const g = parseInt(hex.slice(2, 4), 16);
+    const b = parseInt(hex.slice(4, 6), 16);
+    const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+    return brightness > 128 ? '#000000' : '#ffffff';
+}
+
+function hexToRgb(hexColor) {
+    const hex = normalizeHex(hexColor);
+    if (!hex) return null;
+    return {
+        r: parseInt(hex.slice(0, 2), 16),
+        g: parseInt(hex.slice(2, 4), 16),
+        b: parseInt(hex.slice(4, 6), 16)
+    };
+}
+
+function updatePrimaryPalette(baseColor) {
+    const rgb = hexToRgb(baseColor);
+    if (!rgb) return;
+    const { r, g, b } = rgb;
+    const rootStyle = document.documentElement.style;
+    rootStyle.setProperty('--primary-color', baseColor);
+    rootStyle.setProperty('--primary-soft', `rgba(${r}, ${g}, ${b}, 0.16)`);
+    rootStyle.setProperty('--primary-border-soft', `rgba(${r}, ${g}, ${b}, 0.12)`);
+    rootStyle.setProperty('--primary-border-strong', `rgba(${r}, ${g}, ${b}, 0.22)`);
+    rootStyle.setProperty('--primary-border-heavy', `rgba(${r}, ${g}, ${b}, 0.32)`);
+    rootStyle.setProperty('--primary-surface-extra', `rgba(${r}, ${g}, ${b}, 0.08)`);
+    rootStyle.setProperty('--primary-surface', `rgba(${r}, ${g}, ${b}, 0.12)`);
+    rootStyle.setProperty('--primary-surface-strong', `rgba(${r}, ${g}, ${b}, 0.18)`);
+    rootStyle.setProperty('--primary-surface-heavy', `rgba(${r}, ${g}, ${b}, 0.24)`);
+    rootStyle.setProperty('--primary-outline', `rgba(${r}, ${g}, ${b}, 0.18)`);
+    rootStyle.setProperty('--primary-outline-strong', `rgba(${r}, ${g}, ${b}, 0.28)`);
+    rootStyle.setProperty('--primary-shadow-soft', `rgba(${r}, ${g}, ${b}, 0.35)`);
+    rootStyle.setProperty('--primary-shadow-strong', `rgba(${r}, ${g}, ${b}, 0.5)`);
+    rootStyle.setProperty('--primary-shadow-heavy', `rgba(${r}, ${g}, ${b}, 0.65)`);
+    rootStyle.setProperty('--header-gradient', baseColor);
+}
+
+function applySidebarColor(color) {
+    if (!color) return;
+    document.documentElement.style.setProperty('--sidebar-color', color);
+    document.documentElement.style.setProperty('--sidebar-text-color', getContrastingColor(color));
+}
+
+function applyTopbarColor(color) {
+    if (!color) return;
+    const textColor = getContrastingColor(color);
+    document.documentElement.style.setProperty('--topbar-color', color);
+    document.documentElement.style.setProperty('--topbar-text-color', textColor);
+    document.documentElement.style.setProperty('--header-text-color', textColor);
+    document.documentElement.style.setProperty('--header-muted-color', textColor);
+    updatePrimaryPalette(color);
+}
+
+let searchDataset = [];
+let datasetReady = false;
+let datasetError = null;
+let pendingQuery = initialQuery;
+
+function mostrarPlaceholder(titulo, descripcion = '', iconClass = 'fa-search') {
+    if (!searchResultsContainer) return;
+    searchResultsContainer.innerHTML = `
+        <div class="search-placeholder">
+            <i class="fas ${iconClass}"></i>
+            <h2>${titulo}</h2>
+            ${descripcion ? `<p>${descripcion}</p>` : ''}
+        </div>
+    `;
+}
+
+function normalizarTexto(texto) {
+    return texto
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '');
+}
+
+function filtrarResultados(termino) {
+    const terminoNormalizado = normalizarTexto(termino.trim());
+
+    if (!terminoNormalizado) {
+        return searchDataset;
+    }
+
+    return searchDataset.filter(item => {
+        const titulo = normalizarTexto(item.titulo || '');
+        const descripcion = normalizarTexto(item.descripcion || '');
+        const categoria = normalizarTexto(item.categoria || '');
+        return (
+            titulo.includes(terminoNormalizado) ||
+            descripcion.includes(terminoNormalizado) ||
+            categoria.includes(terminoNormalizado)
+        );
+    });
+}
+
+function crearGrupoHTML(categoria, elementos) {
+    const group = document.createElement('article');
+    group.className = 'search-group';
+
+    const header = document.createElement('header');
+    header.className = 'search-group-header';
+    header.innerHTML = `
+        <div class="group-info">
+            <span class="group-icon"><i class="fas fa-folder-open"></i></span>
+            <h2>${categoria}</h2>
+        </div>
+        <span class="group-count">${elementos.length}</span>
+    `;
+
+    const list = document.createElement('ul');
+    list.className = 'search-list';
+
+    elementos.forEach(item => {
+        const li = document.createElement('li');
+        li.className = 'search-item';
+        li.innerHTML = `
+            <div class="item-content">
+                <h3>${item.titulo}</h3>
+                <p>${item.descripcion}</p>
+            </div>
+            <a class="item-action" href="${item.url}">${item.accion}</a>
+        `;
+        list.appendChild(li);
+    });
+
+    group.appendChild(header);
+    group.appendChild(list);
+    return group;
+}
+
+function renderResultados(termino) {
+    if (!searchResultsContainer || !resultsCount) return;
+    pendingQuery = termino;
+
+    if (!datasetReady) {
+        mostrarPlaceholder('Cargando datos de tu empresa...', 'Estamos preparando tus registros más recientes.', 'fa-spinner fa-spin');
+        resultsCount.textContent = '0';
+        return;
+    }
+
+    if (datasetError) {
+        mostrarPlaceholder('No pudimos cargar la búsqueda', datasetError, 'fa-triangle-exclamation');
+        resultsCount.textContent = '0';
+        return;
+    }
+
+    const consulta = termino.trim();
+    const totalDisponible = searchDataset.length;
+    const resultados = filtrarResultados(consulta);
+
+    if (consulta) {
+        resultsCount.textContent = resultados.length.toString();
+    } else {
+        resultsCount.textContent = totalDisponible.toString();
+    }
+
+    if (!consulta) {
+        mostrarPlaceholder('Comienza a escribir para ver resultados', 'Puedes buscar productos, movimientos, áreas o usuarios de tu equipo.');
+        return;
+    }
+
+    if (resultados.length === 0) {
+        mostrarPlaceholder('Sin coincidencias', 'Prueba con otro término o revisa las categorías disponibles.');
+        return;
+    }
+
+    const agrupados = resultados.reduce((acc, item) => {
+        if (!acc[item.categoria]) {
+            acc[item.categoria] = [];
+        }
+        acc[item.categoria].push(item);
+        return acc;
+    }, {});
+
+    searchResultsContainer.innerHTML = '';
+
+    Object.keys(agrupados)
+        .sort((a, b) => a.localeCompare(b, 'es'))
+        .forEach(categoria => {
+            const grupo = crearGrupoHTML(categoria, agrupados[categoria]);
+            searchResultsContainer.appendChild(grupo);
+        });
+}
+
+async function cargarConfiguracionVisual(idEmpresa) {
+    try {
+        const response = await fetch('/scripts/php/get_configuracion_empresa.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id_empresa: Number(idEmpresa) })
+        });
+
+        if (!response.ok) {
+            throw new Error('Error al obtener la configuración visual');
+        }
+
+        const { success, config } = await response.json();
+        if (!success || !config) return;
+
+        if (config.color_sidebar) {
+            applySidebarColor(config.color_sidebar);
+        }
+
+        if (config.color_topbar) {
+            applyTopbarColor(config.color_topbar);
+        }
+    } catch (error) {
+        console.error('No se pudo cargar la configuración visual:', error);
+    }
+}
+
+async function cargarDatosBusqueda(idEmpresa) {
+    if (summaryDescription) {
+        summaryDescription.textContent = 'Sincronizando información con la base de datos...';
+    }
+
+    mostrarPlaceholder('Cargando datos de tu empresa...', 'Estamos preparando tus registros más recientes.', 'fa-spinner fa-spin');
+
+    try {
+        const response = await fetch(`/scripts/php/get_global_search.php?id_empresa=${encodeURIComponent(idEmpresa)}`, {
+            credentials: 'include'
+        });
+
+        if (!response.ok) {
+            throw new Error('Error al solicitar resultados de búsqueda.');
+        }
+
+        const data = await response.json();
+
+        if (!data.success) {
+            datasetReady = true;
+            datasetError = data.message || 'No se pudo obtener información de la base de datos.';
+            renderResultados(pendingQuery);
+            return;
+        }
+
+        searchDataset = Array.isArray(data.results) ? data.results : [];
+        datasetReady = true;
+        datasetError = null;
+
+        if (summaryDescription) {
+            if (searchDataset.length > 0) {
+                summaryDescription.textContent = `Listo. Tienes ${searchDataset.length} elementos indexados para buscar.`;
+            } else {
+                summaryDescription.textContent = 'Tu empresa aún no tiene registros para mostrar. Agrega productos, movimientos o usuarios.';
+            }
+        }
+
+        renderResultados(pendingQuery);
+    } catch (error) {
+        console.error('Error cargando los datos de búsqueda:', error);
+        datasetReady = true;
+        datasetError = 'Ocurrió un problema al conectarnos con la base de datos. Intenta nuevamente más tarde.';
+        if (summaryDescription) {
+            summaryDescription.textContent = 'No fue posible conectar con la base de datos. Intenta nuevamente en unos minutos.';
+        }
+        renderResultados(pendingQuery);
+    }
+}
+
+async function initializeSearchPage() {
+    const userId = localStorage.getItem('usuario_id');
+    if (!userId) {
+        datasetReady = true;
+        datasetError = 'Tu sesión expiró. Por favor inicia sesión nuevamente.';
+        renderResultados('');
+        setTimeout(() => {
+            window.location.href = '../../pages/regis_login/login/login.html';
+        }, 2000);
+        return;
+    }
+
+    let empresaId = localStorage.getItem('id_empresa');
+
+    try {
+        const response = await fetch('/scripts/php/check_empresa.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ usuario_id: userId })
+        });
+
+        const data = await response.json();
+        if (data.success && data.empresa_id) {
+            empresaId = data.empresa_id;
+            localStorage.setItem('id_empresa', data.empresa_id);
+        }
+    } catch (error) {
+        console.warn('No se pudo verificar la empresa del usuario:', error);
+    }
+
+    if (!empresaId) {
+        datasetReady = true;
+        datasetError = 'No encontramos una empresa asociada a tu usuario. Solicita acceso al administrador.';
+        renderResultados('');
+        return;
+    }
+
+    await Promise.all([
+        cargarConfiguracionVisual(empresaId),
+        cargarDatosBusqueda(empresaId)
+    ]);
+}
+
+if (quickLinks) {
+    quickLinks.addEventListener('click', event => {
+        const button = event.target.closest('button[data-query]');
+        if (!button) return;
+        const query = button.getAttribute('data-query');
+        if (searchInput) {
+            searchInput.value = query;
+            searchInput.focus();
+            searchInput.setSelectionRange(searchInput.value.length, searchInput.value.length);
+        }
+        renderResultados(query);
+    });
+}
+
+if (searchInput) {
+    searchInput.addEventListener('input', event => {
+        renderResultados(event.target.value);
+    });
+
+    searchInput.addEventListener('keydown', event => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            renderResultados(event.target.value);
+        }
+    });
+}
+
+renderResultados(initialQuery);
+initializeSearchPage();

--- a/scripts/php/get_global_search.php
+++ b/scripts/php/get_global_search.php
@@ -1,0 +1,252 @@
+<?php
+session_start();
+header('Content-Type: application/json; charset=utf-8');
+
+$servername = "localhost";
+$username   = "u296155119_Admin";
+$password   = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+$conn = new mysqli($servername, $username, $password, $database);
+
+if ($conn->connect_error) {
+    echo json_encode([
+        'success' => false,
+        'message' => 'Error de conexión a la base de datos.'
+    ]);
+    exit;
+}
+
+$conn->set_charset('utf8mb4');
+
+if (!isset($_SESSION['usuario_id'])) {
+    echo json_encode([
+        'success' => false,
+        'message' => 'Sesión no válida. Inicia sesión nuevamente.'
+    ]);
+    $conn->close();
+    exit;
+}
+
+$userId = (int) $_SESSION['usuario_id'];
+$idEmpresa = isset($_GET['id_empresa']) ? (int) $_GET['id_empresa'] : 0;
+
+if ($idEmpresa <= 0) {
+    $empresaStmt = $conn->prepare(
+        "SELECT e.id_empresa
+         FROM empresa e
+         LEFT JOIN usuario_empresa ue ON ue.id_empresa = e.id_empresa
+         WHERE e.usuario_creador = ? OR ue.id_usuario = ?
+         ORDER BY e.fecha_registro DESC
+         LIMIT 1"
+    );
+
+    if ($empresaStmt) {
+        $empresaStmt->bind_param('ii', $userId, $userId);
+        $empresaStmt->execute();
+        $empresaStmt->bind_result($empresaId);
+        if ($empresaStmt->fetch()) {
+            $idEmpresa = (int) $empresaId;
+        }
+        $empresaStmt->close();
+    }
+}
+
+if ($idEmpresa <= 0) {
+    echo json_encode([
+        'success' => false,
+        'message' => 'No se encontró una empresa asociada a tu usuario.'
+    ]);
+    $conn->close();
+    exit;
+}
+
+function sanitizeText(?string $value): string {
+    return htmlspecialchars($value ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+
+function formatDateTime(?string $value): string {
+    if (!$value) {
+        return '';
+    }
+
+    try {
+        $date = new DateTime($value);
+        return $date->format('d/m/Y H:i');
+    } catch (Exception $e) {
+        return $value;
+    }
+}
+
+$results = [];
+
+$productosSql = "SELECT p.id, p.nombre, p.descripcion, p.stock, p.last_movimiento, p.last_tipo, z.nombre AS zona_nombre
+                 FROM productos p
+                 LEFT JOIN zonas z ON z.id = p.zona_id
+                 WHERE p.empresa_id = ?
+                 ORDER BY p.nombre ASC";
+
+if ($productosStmt = $conn->prepare($productosSql)) {
+    $productosStmt->bind_param('i', $idEmpresa);
+    $productosStmt->execute();
+    $productosResult = $productosStmt->get_result();
+
+    while ($row = $productosResult->fetch_assoc()) {
+        $descripcionPartes = [];
+        $descripcionPartes[] = 'Stock: ' . (int) $row['stock'] . ' unidades';
+        if (!empty($row['zona_nombre'])) {
+            $descripcionPartes[] = 'Zona ' . sanitizeText($row['zona_nombre']);
+        }
+        if (!empty($row['last_movimiento'])) {
+            $descripcionPartes[] = 'Último movimiento ' . formatDateTime($row['last_movimiento']);
+        }
+
+        $descripcion = implode(' · ', array_filter($descripcionPartes));
+        if (!$descripcion && !empty($row['descripcion'])) {
+            $descripcion = sanitizeText($row['descripcion']);
+        }
+
+        $results[] = [
+            'categoria' => 'Productos',
+            'titulo' => sanitizeText($row['nombre']),
+            'descripcion' => $descripcion,
+            'accion' => 'Ver en inventario',
+            'url' => '../gest_inve/inventario_basico.html'
+        ];
+    }
+
+    $productosStmt->close();
+}
+
+$movimientosSql = "SELECT m.id, m.tipo, m.cantidad, m.fecha_movimiento, p.nombre AS producto_nombre
+                   FROM movimientos m
+                   LEFT JOIN productos p ON p.id = m.producto_id
+                   WHERE m.empresa_id = ?
+                   ORDER BY m.fecha_movimiento DESC
+                   LIMIT 50";
+
+if ($movimientosStmt = $conn->prepare($movimientosSql)) {
+    $movimientosStmt->bind_param('i', $idEmpresa);
+    $movimientosStmt->execute();
+    $movimientosResult = $movimientosStmt->get_result();
+
+    while ($row = $movimientosResult->fetch_assoc()) {
+        $titulo = ucfirst($row['tipo'] ?? 'movimiento') . ' #' . str_pad((string) $row['id'], 4, '0', STR_PAD_LEFT);
+        $descripcionPartes = [];
+
+        if (!empty($row['producto_nombre'])) {
+            $descripcionPartes[] = 'Producto: ' . sanitizeText($row['producto_nombre']);
+        }
+
+        $descripcionPartes[] = 'Cantidad: ' . (int) $row['cantidad'];
+
+        if (!empty($row['fecha_movimiento'])) {
+            $descripcionPartes[] = formatDateTime($row['fecha_movimiento']);
+        }
+
+        $results[] = [
+            'categoria' => 'Movimientos',
+            'titulo' => sanitizeText($titulo),
+            'descripcion' => implode(' · ', array_filter($descripcionPartes)),
+            'accion' => 'Revisar movimiento',
+            'url' => '../control_log/log.html'
+        ];
+    }
+
+    $movimientosStmt->close();
+}
+
+$usuariosSql = "SELECT DISTINCT u.id_usuario, u.nombre, u.apellido, u.rol, u.correo
+                FROM usuario u
+                LEFT JOIN usuario_empresa ue ON ue.id_usuario = u.id_usuario
+                LEFT JOIN empresa e ON e.usuario_creador = u.id_usuario
+                WHERE ue.id_empresa = ? OR e.id_empresa = ?
+                ORDER BY u.nombre ASC, u.apellido ASC";
+
+if ($usuariosStmt = $conn->prepare($usuariosSql)) {
+    $usuariosStmt->bind_param('ii', $idEmpresa, $idEmpresa);
+    $usuariosStmt->execute();
+    $usuariosResult = $usuariosStmt->get_result();
+
+    while ($row = $usuariosResult->fetch_assoc()) {
+        $nombreCompleto = trim(($row['nombre'] ?? '') . ' ' . ($row['apellido'] ?? ''));
+        $descripcionPartes = [];
+        if (!empty($row['rol'])) {
+            $descripcionPartes[] = 'Rol: ' . sanitizeText($row['rol']);
+        }
+        if (!empty($row['correo'])) {
+            $descripcionPartes[] = sanitizeText($row['correo']);
+        }
+
+        $results[] = [
+            'categoria' => 'Usuarios',
+            'titulo' => sanitizeText($nombreCompleto ?: 'Usuario sin nombre'),
+            'descripcion' => implode(' · ', $descripcionPartes),
+            'accion' => 'Gestionar usuario',
+            'url' => '../admin_usuar/administracion_usuarios.html'
+        ];
+    }
+
+    $usuariosStmt->close();
+}
+
+$areasSql = "SELECT nombre, descripcion, volumen FROM areas WHERE id_empresa = ? ORDER BY nombre ASC";
+if ($areasStmt = $conn->prepare($areasSql)) {
+    $areasStmt->bind_param('i', $idEmpresa);
+    $areasStmt->execute();
+    $areasResult = $areasStmt->get_result();
+
+    while ($row = $areasResult->fetch_assoc()) {
+        $descripcionPartes = [];
+        if (!empty($row['descripcion'])) {
+            $descripcionPartes[] = sanitizeText($row['descripcion']);
+        }
+        if (!empty($row['volumen'])) {
+            $descripcionPartes[] = 'Volumen: ' . sanitizeText($row['volumen']);
+        }
+
+        $results[] = [
+            'categoria' => 'Áreas',
+            'titulo' => sanitizeText($row['nombre']),
+            'descripcion' => implode(' · ', array_filter($descripcionPartes)),
+            'accion' => 'Gestionar áreas',
+            'url' => '../area_almac_v2/gestion_areas_zonas.html'
+        ];
+    }
+
+    $areasStmt->close();
+}
+
+$zonasSql = "SELECT nombre, descripcion, tipo_almacenamiento FROM zonas WHERE id_empresa = ? ORDER BY nombre ASC";
+if ($zonasStmt = $conn->prepare($zonasSql)) {
+    $zonasStmt->bind_param('i', $idEmpresa);
+    $zonasStmt->execute();
+    $zonasResult = $zonasStmt->get_result();
+
+    while ($row = $zonasResult->fetch_assoc()) {
+        $descripcionPartes = [];
+        if (!empty($row['descripcion'])) {
+            $descripcionPartes[] = sanitizeText($row['descripcion']);
+        }
+        if (!empty($row['tipo_almacenamiento'])) {
+            $descripcionPartes[] = 'Tipo: ' . sanitizeText($row['tipo_almacenamiento']);
+        }
+
+        $results[] = [
+            'categoria' => 'Zonas',
+            'titulo' => sanitizeText($row['nombre']),
+            'descripcion' => implode(' · ', array_filter($descripcionPartes)),
+            'accion' => 'Gestionar zonas',
+            'url' => '../area_almac_v2/gestion_areas_zonas.html'
+        ];
+    }
+
+    $zonasStmt->close();
+}
+
+$conn->close();
+
+echo json_encode([
+    'success' => true,
+    'results' => $results
+], JSON_UNESCAPED_UNICODE);

--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -191,6 +191,259 @@ img {
     font-size: 0.95rem;
 }
 
+/* Search page */
+.search-page {
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+    color: var(--text-color);
+}
+
+.search-page-header {
+    background: var(--card-bg);
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--border-color);
+    box-shadow: var(--shadow-soft);
+    padding: 1.8rem 2rem;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.search-eyebrow {
+    text-transform: uppercase;
+    font-size: 0.78rem;
+    letter-spacing: 0.16em;
+    font-weight: 600;
+    color: var(--muted-color);
+}
+
+.search-title {
+    font-size: clamp(1.65rem, 2.2vw, 2.05rem);
+    font-weight: 600;
+    color: var(--text-color);
+}
+
+.search-lead {
+    color: var(--muted-color);
+    max-width: 720px;
+    font-size: 0.98rem;
+    line-height: 1.7;
+}
+
+.search-field {
+    position: relative;
+    display: flex;
+    align-items: center;
+    margin-top: 0.25rem;
+}
+
+.search-field i {
+    position: absolute;
+    left: 1.2rem;
+    color: var(--muted-color);
+    font-size: 1.05rem;
+}
+
+.search-field input {
+    width: 100%;
+    padding: 0.95rem 1.4rem 0.95rem 3rem;
+    border-radius: var(--radius-pill);
+    border: 1px solid var(--border-color);
+    font-size: 1rem;
+    color: var(--text-color);
+    background: #ffffff;
+    transition: border-color var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
+}
+
+.search-field input:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(15, 180, 212, 0.18);
+}
+
+.search-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.search-summary-card {
+    background: var(--card-bg);
+    border-radius: var(--radius-lg);
+    padding: 1.8rem;
+    box-shadow: var(--shadow-soft);
+    border: 1px solid var(--border-color);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.summary-label {
+    font-size: 0.88rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--muted-color);
+    font-weight: 600;
+}
+
+.summary-value {
+    font-size: clamp(2.4rem, 3vw, 2.9rem);
+    font-weight: 700;
+    color: var(--primary-color);
+}
+
+.summary-description {
+    margin: 0;
+    color: var(--muted-color);
+    font-size: 0.95rem;
+}
+
+.summary-links {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin: 0;
+    padding: 0;
+}
+
+.summary-links button {
+    border: none;
+    border-radius: var(--radius-pill);
+    padding: 0.6rem 1.35rem;
+    background: var(--primary-soft);
+    color: var(--primary-color);
+    font-weight: 500;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.summary-links button:hover {
+    background: rgba(15, 180, 212, 0.22);
+    transform: translateY(-2px);
+    box-shadow: 0 18px 30px -24px rgba(23, 31, 52, 0.3);
+}
+
+.search-results {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.search-placeholder {
+    padding: 3rem 1.5rem;
+    background: var(--card-bg);
+    border-radius: var(--radius-lg);
+    border: 1px dashed var(--border-color);
+    text-align: center;
+    color: var(--muted-color);
+    display: grid;
+    gap: 1rem;
+    justify-items: center;
+}
+
+.search-placeholder i {
+    font-size: 2.2rem;
+    color: var(--primary-color);
+}
+
+.search-group {
+    background: var(--card-bg);
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--border-color);
+    box-shadow: var(--shadow-soft);
+    overflow: hidden;
+}
+
+.search-group-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.35rem 1.6rem;
+    background: var(--primary-soft);
+}
+
+.group-info {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.group-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: #ffffff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--primary-color);
+}
+
+.search-group-header h2 {
+    font-size: 1.12rem;
+    font-weight: 600;
+    color: var(--text-color);
+}
+
+.group-count {
+    font-weight: 600;
+    color: var(--primary-color);
+    background: rgba(15, 180, 212, 0.16);
+    border-radius: var(--radius-pill);
+    padding: 0.4rem 0.95rem;
+}
+
+.search-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.search-item {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1.45rem 1.6rem;
+    border-top: 1px solid var(--border-color);
+}
+
+.search-item:first-child {
+    border-top: none;
+}
+
+.item-content h3 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin-bottom: 0.35rem;
+    color: var(--text-color);
+}
+
+.item-content p {
+    margin: 0;
+    color: var(--muted-color);
+    font-size: 0.95rem;
+}
+
+.item-action {
+    align-self: center;
+    padding: 0.7rem 1.55rem;
+    border-radius: var(--radius-pill);
+    background: var(--primary-color);
+    color: #ffffff;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.item-action:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 35px -24px rgba(23, 31, 52, 0.35);
+}
+
 .notification-bell,
 .alert-settings {
     position: relative;


### PR DESCRIPTION
## Summary
- convert the global search layout into a content fragment with its own header, search field and quick links ready to render inside the dashboard
- load that fragment dynamically from the topbar search, wiring a placeholder, query hand-off and script bootstrap so the results appear in the main content area without altering the sidebar data
- adapt the global search script and styles for the embedded experience, improving readability and ensuring quick actions refocus the new inline search field

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc518a5798832ca49601544d8932a3