### PR TITLE
Improve search navigation and readability

### DIFF
--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -194,12 +194,14 @@ img {
 /* Search page */
 .search-page-body {
     background: var(--page-bg);
+    color: var(--text-color);
 }
 
 .search-page {
     display: flex;
     flex-direction: column;
     gap: 2rem;
+    color: var(--text-color);
 }
 
 .search-summary {
@@ -209,21 +211,21 @@ img {
 }
 
 .search-summary-card {
-    background: var(--primary-surface);
+    background: #ffffff;
     border-radius: var(--radius-lg);
     padding: 1.6rem;
-    box-shadow: 0 28px 60px -48px rgba(15, 40, 65, 0.65);
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 28px 60px -48px rgba(15, 40, 65, 0.18);
+    border: 1px solid rgba(15, 23, 42, 0.08);
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
 }
 
 .summary-label {
-    font-size: 0.85rem;
+    font-size: 0.95rem;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: rgba(255, 255, 255, 0.65);
+    color: #0f172a;
     font-weight: 600;
 }
 
@@ -231,12 +233,14 @@ img {
     font-size: clamp(2.4rem, 3vw, 2.9rem);
     font-weight: 700;
     color: var(--accent-color);
-    text-shadow: 0 18px 42px rgba(0, 0, 0, 0.35);
+    text-shadow: none;
 }
 
 .summary-description {
     margin: 0;
-    color: rgba(255, 255, 255, 0.72);
+    font-size: 1.08rem;
+    line-height: 1.75;
+    color: #0f172a;
 }
 
 .summary-links {
@@ -249,20 +253,21 @@ img {
 }
 
 .summary-links button {
-    border: none;
+    border: 1px solid rgba(15, 180, 212, 0.25);
     border-radius: var(--radius-pill);
-    padding: 0.55rem 1.2rem;
-    background: rgba(255, 255, 255, 0.12);
-    color: #fff;
-    font-weight: 500;
+    padding: 0.6rem 1.3rem;
+    background: rgba(15, 180, 212, 0.12);
+    color: #0f172a;
+    font-weight: 600;
     cursor: pointer;
-    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, border-color 0.2s ease;
 }
 
 .summary-links button:hover {
-    background: rgba(255, 255, 255, 0.2);
+    background: rgba(15, 180, 212, 0.18);
+    border-color: rgba(15, 180, 212, 0.45);
     transform: translateY(-2px);
-    box-shadow: 0 18px 30px -24px rgba(0, 0, 0, 0.45);
+    box-shadow: 0 18px 30px -24px rgba(15, 40, 65, 0.25);
 }
 
 .search-results {
@@ -273,26 +278,70 @@ img {
 
 .search-placeholder {
     padding: 3.5rem 1.5rem;
-    background: rgba(255, 255, 255, 0.05);
+    background: #ffffff;
     border-radius: var(--radius-lg);
-    border: 1px dashed rgba(255, 255, 255, 0.2);
+    border: 1px dashed rgba(15, 23, 42, 0.16);
     text-align: center;
-    color: rgba(255, 255, 255, 0.7);
+    color: rgba(15, 23, 42, 0.75);
     display: grid;
-    gap: 1rem;
+    gap: 1.2rem;
     justify-items: center;
 }
 
 .search-placeholder i {
-    font-size: 2rem;
-    color: rgba(255, 255, 255, 0.5);
+    font-size: 2.4rem;
+    color: var(--accent-color);
+}
+
+.search-placeholder h2 {
+    font-size: clamp(1.75rem, 3.4vw, 2.2rem);
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.search-placeholder p {
+    max-width: 640px;
+    margin: 0 auto;
+    font-size: 1.08rem;
+    line-height: 1.75;
+    color: #0f172a;
+}
+
+.search-loading-state,
+.search-error-state {
+    display: grid;
+    gap: 0.85rem;
+    justify-items: center;
+    text-align: center;
+    padding: 3rem 1.5rem;
+    border-radius: var(--radius-lg);
+    background: #ffffff;
+    color: var(--text-color);
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    line-height: 1.6;
+}
+
+.search-loading-state i,
+.search-error-state i {
+    font-size: 2.2rem;
+    color: var(--accent-color);
+}
+
+.search-error-state i {
+    color: #b91c1c;
+}
+
+.search-error-state {
+    background: #fff5f5;
+    color: #b91c1c;
+    border-color: rgba(185, 28, 28, 0.25);
 }
 
 .search-group {
-    background: rgba(255, 255, 255, 0.08);
+    background: #ffffff;
     border-radius: var(--radius-lg);
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    box-shadow: 0 28px 55px -48px rgba(15, 40, 65, 0.5);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    box-shadow: 0 28px 55px -48px rgba(15, 40, 65, 0.18);
     overflow: hidden;
 }
 
@@ -301,7 +350,8 @@ img {
     align-items: center;
     justify-content: space-between;
     padding: 1.2rem 1.6rem;
-    background: rgba(0, 0, 0, 0.15);
+    background: rgba(15, 180, 212, 0.1);
+    border-bottom: 1px solid rgba(15, 23, 42, 0.06);
 }
 
 .group-info {
@@ -314,25 +364,26 @@ img {
     width: 40px;
     height: 40px;
     border-radius: 50%;
-    background: rgba(255, 255, 255, 0.15);
+    background: rgba(15, 180, 212, 0.18);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    color: #fff;
+    color: #0f172a;
 }
 
 .search-group-header h2 {
-    font-size: 1.05rem;
+    font-size: 1.2rem;
     font-weight: 600;
-    color: #fff;
+    color: #0f172a;
 }
 
 .group-count {
     font-weight: 600;
-    color: rgba(255, 255, 255, 0.75);
-    background: rgba(255, 255, 255, 0.1);
+    color: #0f172a;
+    background: rgba(15, 180, 212, 0.18);
     border-radius: var(--radius-pill);
-    padding: 0.35rem 0.85rem;
+    padding: 0.35rem 0.95rem;
+    font-size: 0.95rem;
 }
 
 .search-list {
@@ -349,7 +400,7 @@ img {
     justify-content: space-between;
     gap: 1rem;
     padding: 1.4rem 1.6rem;
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid rgba(15, 23, 42, 0.06);
 }
 
 .search-item:first-child {
@@ -357,14 +408,17 @@ img {
 }
 
 .item-content h3 {
-    font-size: 1rem;
+    font-size: 1.15rem;
     font-weight: 600;
-    margin-bottom: 0.35rem;
+    margin-bottom: 0.4rem;
+    color: #0f172a;
 }
 
 .item-content p {
     margin: 0;
-    color: rgba(255, 255, 255, 0.7);
+    font-size: 1.05rem;
+    line-height: 1.75;
+    color: #0f172a;
 }
 
 .item-action {


### PR DESCRIPTION
## Summary
- add navigation helpers so sidebar links, deep links, and custom events load pages inside the main panel without affecting the sidebar info
- update the global search results to dispatch in-app navigation events and fall back to loading the selected view inside the dashboard when opened directly
- tweak global search typography for stronger contrast and larger body text so cards, placeholders, and results are easier to read

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc69b46d78832ca074c9e866aa58cd