### PR TITLE
Improve global search layout width usage

### DIFF
--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -210,6 +210,25 @@ img {
     gap: 1.5rem;
 }
 
+@media (min-width: 1200px) {
+    .search-page {
+        display: grid;
+        grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
+        align-items: flex-start;
+        gap: 2rem;
+    }
+
+    .search-summary {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+    }
+
+    .search-results {
+        grid-column: 2;
+    }
+}
+
 .search-summary-card {
     background: #ffffff;
     border-radius: var(--radius-lg);


### PR DESCRIPTION
## Summary
- reorganized the global search layout so the summary cards and results share the viewport on large screens
- switch the summary container to a vertical stack on desktops to avoid wasted space and keep cards full width

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ccb1fad68c832cb0cbbbcdb2a8bade