### PR TITLE
Fix sector select id on account page

### DIFF
--- a/pages/account_suscrip/account_suscrip.html
+++ b/pages/account_suscrip/account_suscrip.html
@@ -401,7 +401,7 @@
             </div>
             <div class="mb-2">
               <label for="inputSectorEmpresa" class="form-label">Sector</label>
-              <select id="ImputSectorEmpresa" name="sector_empresa" required>
+              <select id="inputSectorEmpresa" name="sector_empresa" required>
                 <option value="Industrial">Industrial</option>
                 <option value="Comercial">Comercial</option>
                 <option value="Servicios">Servicios</option>


### PR DESCRIPTION
## Summary
- correct the id of the sector select element on the account subscription page so it matches the JavaScript logic

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cda9d0b038832c99a4aa2facf97079