### PR TITLE
Align company sector dropdown styling

### DIFF
--- a/pages/account_suscrip/account_suscrip.html
+++ b/pages/account_suscrip/account_suscrip.html
@@ -401,7 +401,12 @@
             </div>
             <div class="mb-2">
               <label for="inputSectorEmpresa" class="form-label">Sector</label>
-              <select id="ImputSectorEmpresa" name="sector_empresa" required>
+              <select
+                id="inputSectorEmpresa"
+                class="form-select"
+                name="sector_empresa"
+                required
+              >
                 <option value="Industrial">Industrial</option>
                 <option value="Comercial">Comercial</option>
                 <option value="Servicios">Servicios</option>
@@ -409,7 +414,7 @@
                 <option value="Tecnológico">Tecnológico</option>
                 <option value="Financiero">Financiero</option>
                 <option value="Construcción">Construcción</option>
-            </select>
+              </select>
             </div>
             <div class="mb-2">
               <label for="inputLogoEmpresaFile" class="form-label">Logo de empresa</label>


### PR DESCRIPTION
## Summary
- add the Bootstrap `form-select` styling to the sector dropdown in the company modal so it matches the surrounding form

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cda9d0b038832c99a4aa2facf97079