### PR TITLE
Add dashboard movement modals and inventory transfer workflows

### DIFF
--- a/pages/gest_inve/inventario_basico.html
+++ b/pages/gest_inve/inventario_basico.html
@@ -234,6 +234,18 @@
             </span>
             <span class="btn-icon__label">Egreso</span>
           </button>
+          <button id="btnTransferencia" class="btn-icon btn-icon--primary" type="button" title="Transferir producto">
+            <span class="btn-icon__circle" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                <path d="M5 8l-3 3 3 3"></path>
+                <path d="M19 8l3 3-3 3"></path>
+                <path d="M3 11h18"></path>
+                <path d="M8 5h8"></path>
+                <path d="M8 19h8"></path>
+              </svg>
+            </span>
+            <span class="btn-icon__label">Transferir</span>
+          </button>
           <button id="btnRecargarResumen" class="btn-icon" type="button" title="Recargar datos">
             <span class="btn-icon__circle" aria-hidden="true">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
@@ -294,6 +306,54 @@
           <button id="movGuardar" class="btn btn-primary flex-fill" type="button">Guardar movimiento</button>
           <button class="btn btn-outline-secondary flex-fill" type="button" data-bs-dismiss="modal">Cancelar</button>
         </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal fade" id="transferModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content shadow-lg">
+        <form id="transferForm">
+          <div class="modal-header border-0">
+            <div>
+              <span class="modal-eyebrow">Transferencia</span>
+              <h5 class="modal-title fw-bold">Mover producto a otra zona</h5>
+            </div>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+          </div>
+          <div class="modal-body">
+            <div class="mb-3">
+              <label class="form-label" for="transferProducto">Producto</label>
+              <select id="transferProducto" class="form-select" required></select>
+            </div>
+            <div class="row g-3 align-items-end">
+              <div class="col-sm-6">
+                <label class="form-label" for="transferCantidad">Unidades a transferir</label>
+                <input type="number" id="transferCantidad" class="form-control" min="1" placeholder="0" required />
+              </div>
+              <div class="col-sm-6">
+                <label class="form-label" for="transferStockDisponible">Stock disponible</label>
+                <input type="text" id="transferStockDisponible" class="form-control" value="0" disabled />
+              </div>
+            </div>
+            <div class="mt-3">
+              <span class="form-label d-block">Ubicación actual</span>
+              <div class="d-flex gap-2 flex-wrap">
+                <span class="badge text-bg-secondary" id="transferOrigenArea">—</span>
+                <span class="badge text-bg-secondary" id="transferOrigenZona">—</span>
+              </div>
+            </div>
+            <div class="mt-3">
+              <label class="form-label" for="transferZonaDestino">Zona destino</label>
+              <select id="transferZonaDestino" class="form-select" required></select>
+              <div class="form-text" id="transferZonaInfo">Selecciona la zona a la que deseas mover el producto.</div>
+            </div>
+          </div>
+          <div class="modal-footer border-0 d-flex flex-column flex-sm-row gap-2">
+            <button id="transferGuardar" class="btn btn-primary flex-fill" type="submit">Guardar transferencia</button>
+            <button class="btn btn-outline-secondary flex-fill" type="button" data-bs-dismiss="modal">Cancelar</button>
+          </div>
+        </form>
       </div>
     </div>
   </div>

--- a/pages/main_menu/main_menu.html
+++ b/pages/main_menu/main_menu.html
@@ -95,17 +95,17 @@
                     <div class="header-stats">
                         <article class="stat-card">
                             <span class="stat-label">Alertas activas</span>
-                            <span class="stat-value">4</span>
+                            <span class="stat-value" id="activeAlertsValue">4</span>
                             <span class="stat-trend negative"><i class="fas fa-arrow-up"></i> +12%</span>
                         </article>
                         <article class="stat-card">
                             <span class="stat-label">Movimientos hoy</span>
-                            <span class="stat-value">128</span>
+                            <span class="stat-value" id="movimientosHoyValue">128</span>
                             <span class="stat-trend positive"><i class="fas fa-arrow-up"></i> +8%</span>
                         </article>
                         <article class="stat-card">
                             <span class="stat-label">Zonas críticas</span>
-                            <span class="stat-value">2</span>
+                            <span class="stat-value" id="zonasCriticasValue">2</span>
                             <span class="stat-trend neutral"><i class="fas fa-minus"></i> Sin cambios</span>
                         </article>
                     </div>
@@ -119,10 +119,10 @@
                             <button class="btn btn-danger" id="egresoFlashBtn">
                                 <i class="fas fa-bolt"></i> Egreso Flash
                             </button>
-                            <button class="btn btn-primary">
+                            <button class="btn btn-primary" id="registrarEntradaBtn">
                                 <i class="fas fa-sign-in-alt"></i> Registrar Entrada
                             </button>
-                            <button class="btn btn-primary">
+                            <button class="btn btn-primary" id="registrarSalidaBtn">
                                 <i class="fas fa-sign-out-alt"></i> Registrar Salida
                             </button>
                         </div>
@@ -143,56 +143,7 @@
                         <button class="card-action-btn"><i class="fas fa-ellipsis-v"></i></button>
                     </div>
                 </div>
-                <ul class="stock-alert-list">
-                    <li class="stock-alert-item">
-                        <div class="stock-alert-info">
-                            <div class="stock-alert-icon">
-                                <i class="fas fa-box-open"></i>
-                            </div>
-                            <div>
-                                <div class="stock-alert-name">Baterías AA</div>
-                                <div class="stock-alert-detail">Zona A1 - Estante 3</div>
-                            </div>
-                        </div>
-                        <div class="stock-alert-stock">5 unidades</div>
-                    </li>
-                    <li class="stock-alert-item">
-                        <div class="stock-alert-info">
-                            <div class="stock-alert-icon">
-                                <i class="fas fa-box-open"></i>
-                            </div>
-                            <div>
-                                <div class="stock-alert-name">Mouse Inalámbrico</div>
-                                <div class="stock-alert-detail">Zona B2 - Estante 1</div>
-                            </div>
-                        </div>
-                        <div class="stock-alert-stock">3 unidades</div>
-                    </li>
-                    <li class="stock-alert-item">
-                        <div class="stock-alert-info">
-                            <div class="stock-alert-icon">
-                                <i class="fas fa-box-open"></i>
-                            </div>
-                            <div>
-                                <div class="stock-alert-name">Teclados</div>
-                                <div class="stock-alert-detail">Zona C3 - Estante 2</div>
-                            </div>
-                        </div>
-                        <div class="stock-alert-stock">2 unidades</div>
-                    </li>
-                    <li class="stock-alert-item">
-                        <div class="stock-alert-info">
-                            <div class="stock-alert-icon">
-                                <i class="fas fa-box-open"></i>
-                            </div>
-                            <div>
-                                <div class="stock-alert-name">Monitor 24"</div>
-                                <div class="stock-alert-detail">Zona D4 - Estante 5</div>
-                            </div>
-                        </div>
-                        <div class="stock-alert-stock">1 unidad</div>
-                    </li>
-                </ul>
+                <ul class="stock-alert-list"></ul>
             </div>
             
             <!-- Recent Activity Card -->
@@ -206,53 +157,7 @@
                         <button class="card-action-btn"><i class="fas fa-sync-alt"></i></button>
                     </div>
                 </div>
-                <ul class="activity-list">
-                    <li class="activity-item">
-                        <div class="activity-icon">
-                            <i class="fas fa-arrow-down"></i>
-                        </div>
-                        <div class="activity-details">
-                            <div class="activity-description">Ingreso de 50 unidades de Baterías AA</div>
-                            <div class="activity-time">Hace 15 minutos</div>
-                        </div>
-                    </li>
-                    <li class="activity-item">
-                        <div class="activity-icon">
-                            <i class="fas fa-arrow-up"></i>
-                        </div>
-                        <div class="activity-details">
-                            <div class="activity-description">Egreso de 2 unidades de Teclados</div>
-                            <div class="activity-time">Hace 1 hora</div>
-                        </div>
-                    </li>
-                    <li class="activity-item">
-                        <div class="activity-icon">
-                            <i class="fas fa-exchange-alt"></i>
-                        </div>
-                        <div class="activity-details">
-                            <div class="activity-description">Transferencia de 10 Monitores a Zona D4</div>
-                            <div class="activity-time">Hace 3 horas</div>
-                        </div>
-                    </li>
-                    <li class="activity-item">
-                        <div class="activity-icon">
-                            <i class="fas fa-arrow-down"></i>
-                        </div>
-                        <div class="activity-details">
-                            <div class="activity-description">Ingreso de 25 Mouse Inalámbricos</div>
-                            <div class="activity-time">Hace 5 horas</div>
-                        </div>
-                    </li>
-                    <li class="activity-item">
-                        <div class="activity-icon">
-                            <i class="fas fa-user-check"></i>
-                        </div>
-                        <div class="activity-details">
-                            <div class="activity-description">Usuario María García inició sesión</div>
-                            <div class="activity-time">Hace 6 horas</div>
-                        </div>
-                    </li>
-                </ul>
+                <ul class="activity-list"></ul>
             </div>
             
             <!-- Space Optimization Card -->
@@ -405,6 +310,50 @@
     </div>
   </div>
 </div>
+
+    <div class="dashboard-modal" id="movementModal" role="dialog" aria-modal="true" aria-hidden="true">
+        <div class="dashboard-modal__backdrop" id="movementBackdrop"></div>
+        <div class="dashboard-modal__dialog" role="document">
+            <header class="dashboard-modal__header">
+                <div>
+                    <span class="dashboard-modal__eyebrow" id="movementModalEyebrow">Movimiento</span>
+                    <h2 class="dashboard-modal__title" id="movementModalTitle">Registrar movimiento</h2>
+                </div>
+                <button type="button" class="dashboard-modal__close" id="movementCloseBtn" aria-label="Cerrar ventana">
+                    <i class="fas fa-times"></i>
+                </button>
+            </header>
+            <form class="movement-form" id="movementForm">
+                <div class="movement-form__group">
+                    <label for="movementProduct" class="movement-form__label">Producto</label>
+                    <select id="movementProduct" class="movement-form__select" required></select>
+                </div>
+                <div class="movement-form__group movement-form__group--inline">
+                    <div class="movement-form__field">
+                        <label for="movementUnits" class="movement-form__label">Unidades</label>
+                        <input type="number" id="movementUnits" class="movement-form__input" min="1" step="1" placeholder="0" required>
+                    </div>
+                    <div class="movement-form__field movement-form__field--summary">
+                        <span class="movement-form__summary-label">Stock actual</span>
+                        <span class="movement-form__summary-value" id="movementStockSummary">0</span>
+                    </div>
+                </div>
+                <div class="movement-form__group movement-form__group--area" id="movementAreaGroup">
+                    <label for="movementArea" class="movement-form__label">Área destino</label>
+                    <select id="movementArea" class="movement-form__select"></select>
+                </div>
+                <div class="movement-form__group movement-form__group--area" id="movementZoneGroup">
+                    <label for="movementZone" class="movement-form__label">Zona destino</label>
+                    <select id="movementZone" class="movement-form__select"></select>
+                    <p class="movement-form__help" id="movementZoneHelp">Selecciona una zona dentro del área elegida.</p>
+                </div>
+                <footer class="movement-form__actions">
+                    <button type="submit" class="movement-form__btn movement-form__btn--primary" id="movementSubmit">Guardar</button>
+                    <button type="button" class="movement-form__btn movement-form__btn--ghost" id="movementCancel">Cancelar</button>
+                </footer>
+            </form>
+        </div>
+    </div>
 
     <script src="../../scripts/theme.js"></script>
     <script src="../../scripts/main_menu/main_menu.js"></script>

--- a/scripts/gest_inve/inventario_basico.js
+++ b/scripts/gest_inve/inventario_basico.js
@@ -168,6 +168,7 @@ prodCategoria?.addEventListener('change', () => {
   const btnScanQR = document.getElementById('btnScanQR');
   const btnIngreso = document.getElementById('btnIngreso');
   const btnEgreso  = document.getElementById('btnEgreso');
+  const btnTransferencia = document.getElementById('btnTransferencia');
   const movimientoModalElement = document.getElementById('movimientoModal');
   const movModal   = movimientoModalElement ? new bootstrap.Modal(movimientoModalElement) : null;
   const movTitle   = document.getElementById('movimientoTitle');
@@ -175,6 +176,16 @@ prodCategoria?.addEventListener('change', () => {
   const movCant    = document.getElementById('movCantidad');
   const movGuardar = document.getElementById('movGuardar');
   let movTipo      = '';
+  const transferModalElement = document.getElementById('transferModal');
+  const transferModal = transferModalElement ? new bootstrap.Modal(transferModalElement) : null;
+  const transferForm = document.getElementById('transferForm');
+  const transferProductoSelect = document.getElementById('transferProducto');
+  const transferCantidadInput = document.getElementById('transferCantidad');
+  const transferStockDisponible = document.getElementById('transferStockDisponible');
+  const transferZonaDestinoSelect = document.getElementById('transferZonaDestino');
+  const transferZonaInfo = document.getElementById('transferZonaInfo');
+  const transferOrigenArea = document.getElementById('transferOrigenArea');
+  const transferOrigenZona = document.getElementById('transferOrigenZona');
   const qrReader   = document.getElementById('qrReader');
   let qrScanner;
   const scanModalElement = document.getElementById('scanModal');
@@ -250,6 +261,181 @@ function poblarSelectProductos() {
     movProdSel.appendChild(opt);
   });
 }
+
+function poblarSelectTransferencia() {
+  if (!transferProductoSelect) return;
+  transferProductoSelect.innerHTML = '';
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = 'Seleccione producto';
+  placeholder.disabled = true;
+  placeholder.selected = true;
+  transferProductoSelect.appendChild(placeholder);
+  productos.forEach(p => {
+    const opt = document.createElement('option');
+    opt.value = p.id;
+    const stockNumero = parseInt(p.stock, 10);
+    const stockLabel = Number.isFinite(stockNumero) ? stockNumero : p.stock;
+    opt.textContent = `${p.nombre} (Stock: ${stockLabel ?? 0})`;
+    transferProductoSelect.appendChild(opt);
+  });
+}
+
+function poblarZonasDestinoSelect(seleccion = null) {
+  if (!transferZonaDestinoSelect) return;
+  transferZonaDestinoSelect.innerHTML = '';
+  if (!zonas.length) {
+    const opt = document.createElement('option');
+    opt.value = '';
+    opt.textContent = 'No hay zonas registradas';
+    opt.disabled = true;
+    opt.selected = true;
+    transferZonaDestinoSelect.appendChild(opt);
+    transferZonaDestinoSelect.disabled = true;
+    if (transferZonaInfo) {
+      transferZonaInfo.textContent = 'Registra áreas y zonas para habilitar transferencias.';
+    }
+    return;
+  }
+
+  transferZonaDestinoSelect.disabled = false;
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = 'Selecciona zona destino';
+  placeholder.disabled = true;
+  if (!seleccion) {
+    placeholder.selected = true;
+  }
+  transferZonaDestinoSelect.appendChild(placeholder);
+
+  zonas.forEach(z => {
+    const zonaId = parseInt(z.id, 10);
+    const areaNombre = z.area_nombre || z.nombre_area || z.area || 'Área sin nombre';
+    const zonaNombre = z.nombre || z.zona_nombre || z.nombre_zona || 'Zona sin nombre';
+    const opt = document.createElement('option');
+    opt.value = zonaId;
+    opt.textContent = `${areaNombre} · ${zonaNombre}`;
+    opt.dataset.area = areaNombre;
+    opt.dataset.zona = zonaNombre;
+    if (seleccion && zonaId === seleccion) {
+      opt.selected = true;
+    }
+    transferZonaDestinoSelect.appendChild(opt);
+  });
+
+  if (transferZonaInfo) {
+    transferZonaInfo.textContent = 'Selecciona la zona a la que deseas mover el producto.';
+  }
+}
+
+function resetTransferModal() {
+  if (transferProductoSelect) {
+    transferProductoSelect.selectedIndex = 0;
+  }
+  if (transferCantidadInput) {
+    transferCantidadInput.value = '';
+    transferCantidadInput.removeAttribute('max');
+  }
+  if (transferStockDisponible) {
+    transferStockDisponible.value = '0';
+  }
+  if (transferOrigenArea) {
+    transferOrigenArea.textContent = '—';
+  }
+  if (transferOrigenZona) {
+    transferOrigenZona.textContent = '—';
+  }
+  if (transferZonaDestinoSelect && transferZonaDestinoSelect.options.length) {
+    transferZonaDestinoSelect.selectedIndex = 0;
+  }
+  if (transferZonaInfo) {
+    transferZonaInfo.textContent = 'Selecciona la zona a la que deseas mover el producto.';
+  }
+}
+
+transferProductoSelect?.addEventListener('change', () => {
+  const prodId = parseInt(transferProductoSelect.value, 10);
+  const producto = productos.find(p => parseInt(p.id, 10) === prodId);
+  const stock = producto ? parseInt(producto.stock, 10) || 0 : 0;
+  if (transferStockDisponible) {
+    transferStockDisponible.value = `${stock} ${stock === 1 ? 'unidad' : 'unidades'}`;
+  }
+  if (transferCantidadInput) {
+    transferCantidadInput.value = '';
+    if (stock > 0) {
+      transferCantidadInput.max = String(stock);
+    } else {
+      transferCantidadInput.removeAttribute('max');
+    }
+  }
+  if (transferOrigenArea) {
+    transferOrigenArea.textContent = producto?.area_nombre || 'Sin área';
+  }
+  if (transferOrigenZona) {
+    transferOrigenZona.textContent = producto?.zona_nombre || 'Sin zona';
+  }
+});
+
+transferZonaDestinoSelect?.addEventListener('change', () => {
+  if (!transferZonaInfo) return;
+  const selected = transferZonaDestinoSelect.selectedOptions[0];
+  if (!selected) {
+    transferZonaInfo.textContent = 'Selecciona la zona a la que deseas mover el producto.';
+    return;
+  }
+  const areaDestino = selected.dataset.area;
+  transferZonaInfo.textContent = areaDestino ? `Área destino: ${areaDestino}` : 'Selecciona la zona a la que deseas mover el producto.';
+});
+
+transferModalElement?.addEventListener('hidden.bs.modal', () => {
+  resetTransferModal();
+});
+
+transferForm?.addEventListener('submit', evento => {
+  evento.preventDefault();
+  if (!transferProductoSelect || !transferZonaDestinoSelect) {
+    return;
+  }
+  const prodId = parseInt(transferProductoSelect.value, 10);
+  const zonaId = parseInt(transferZonaDestinoSelect.value, 10);
+  const cantidad = parseInt(transferCantidadInput?.value ?? '0', 10);
+  if (!prodId || !zonaId) {
+    showToast('Selecciona un producto y la zona destino.', 'error');
+    return;
+  }
+  if (!Number.isFinite(cantidad) || cantidad <= 0) {
+    showToast('Ingresa la cantidad de unidades a transferir.', 'error');
+    return;
+  }
+  const producto = productos.find(p => parseInt(p.id, 10) === prodId);
+  if (!producto) {
+    showToast('No se encontró el producto seleccionado.', 'error');
+    return;
+  }
+  const stockDisponible = parseInt(producto.stock, 10) || 0;
+  if (cantidad > stockDisponible) {
+    showToast('La cantidad supera el stock disponible del producto.', 'error');
+    return;
+  }
+  const zonaDestino = zonas.find(z => parseInt(z.id, 10) === zonaId);
+  const areaDestino = zonaDestino?.area_nombre || zonaDestino?.nombre_area || zonaDestino?.area || producto.area_nombre || '';
+  const zonaDestinoNombre = zonaDestino?.nombre || zonaDestino?.zona_nombre || zonaDestino?.nombre_zona || '';
+  producto.area_nombre = areaDestino;
+  if (zonaDestinoNombre) {
+    producto.zona_nombre = zonaDestinoNombre;
+  }
+  showToast('Transferencia registrada correctamente.', 'success');
+  transferModal?.hide();
+  renderResumen();
+  document.dispatchEvent(new CustomEvent('movimientoRegistrado', {
+    detail: {
+      tipo: 'transferencia',
+      productoId: prodId,
+      cantidad,
+      destino: { area: areaDestino, zona: zonaDestinoNombre }
+    }
+  }));
+});
 
 btnScanQR?.addEventListener('click', async () => {
   if (!navigator.mediaDevices || !window.isSecureContext) {
@@ -359,6 +545,21 @@ scanModalElement?.addEventListener('shown.bs.modal', async () => {
     movModal.show();
   });
 
+  btnTransferencia?.addEventListener('click', () => {
+    if (!transferModal || !transferProductoSelect) {
+      showToast('El formulario de transferencias no está disponible.', 'error');
+      return;
+    }
+    if (!productos.length) {
+      showToast('No hay productos registrados para transferir.', 'info');
+      return;
+    }
+    poblarSelectTransferencia();
+    poblarZonasDestinoSelect();
+    resetTransferModal();
+    transferModal.show();
+  });
+
 
 
 
@@ -429,6 +630,7 @@ async function cargarZonas() {
   const datos = await fetchAPI(`${API.zonas}?empresa_id=${EMP_ID}`);
    datos.forEach(z => zonas.push(z));
   actualizarSelectZonas();
+  poblarZonasDestinoSelect();
  }
 
 movGuardar?.addEventListener('click', async () => {
@@ -474,6 +676,7 @@ movGuardar?.addEventListener('click', async () => {
       productos.push(p);
     });
     actualizarIndicadores();
+    poblarSelectTransferencia();
   }
 
   function renderResumen() {

--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -25,6 +25,583 @@ try {
     console.warn('No se pudo obtener la zona horaria del navegador.', error);
 }
 
+const DASHBOARD_STORAGE_KEY = 'optistockDashboardState';
+
+const defaultDashboardState = {
+    products: [
+        { id: 'p-001', nombre: 'Baterías AA', stock: 5, minimo: 8, area: 'Almacén Central', zona: 'Zona A1' },
+        { id: 'p-002', nombre: 'Mouse Inalámbrico', stock: 3, minimo: 6, area: 'Almacén Central', zona: 'Zona B2' },
+        { id: 'p-003', nombre: 'Teclados', stock: 2, minimo: 5, area: 'Sucursal Norte', zona: 'Zona C3' },
+        { id: 'p-004', nombre: 'Monitor 24"', stock: 1, minimo: 4, area: 'Depósito Externo', zona: 'Zona D4' }
+    ],
+    activity: [
+        {
+            id: 'mov-01',
+            tipo: 'entrada',
+            productoId: 'p-001',
+            producto: 'Baterías AA',
+            unidades: 50,
+            area: 'Almacén Central',
+            zona: 'Zona A1',
+            descripcion: 'Ingreso de 50 unidades de Baterías AA',
+            timestamp: Date.now() - 15 * 60 * 1000
+        },
+        {
+            id: 'mov-02',
+            tipo: 'salida',
+            productoId: 'p-003',
+            producto: 'Teclados',
+            unidades: 2,
+            area: 'Sucursal Norte',
+            zona: 'Zona C3',
+            descripcion: 'Egreso de 2 unidades de Teclados',
+            timestamp: Date.now() - 60 * 60 * 1000
+        },
+        {
+            id: 'mov-03',
+            tipo: 'transferencia',
+            productoId: 'p-004',
+            producto: 'Monitor 24"',
+            unidades: 10,
+            area: 'Depósito Externo',
+            zona: 'Zona D4',
+            descripcion: 'Transferencia de 10 Monitores a Zona D4',
+            timestamp: Date.now() - 3 * 60 * 60 * 1000
+        },
+        {
+            id: 'mov-04',
+            tipo: 'entrada',
+            productoId: 'p-002',
+            producto: 'Mouse Inalámbrico',
+            unidades: 25,
+            area: 'Almacén Central',
+            zona: 'Zona B2',
+            descripcion: 'Ingreso de 25 Mouse Inalámbricos',
+            timestamp: Date.now() - 5 * 60 * 60 * 1000
+        }
+    ]
+};
+
+function normalizeDashboardState(state) {
+    const clone = { products: [], activity: [] };
+    if (state && Array.isArray(state.products)) {
+        state.products.forEach(item => {
+            if (!item || !item.id) return;
+            const producto = {
+                id: String(item.id),
+                nombre: item.nombre || 'Producto sin nombre',
+                stock: Number.isFinite(item.stock) ? item.stock : 0,
+                minimo: Number.isFinite(item.minimo) ? item.minimo : 0,
+                area: item.area || '',
+                zona: item.zona || ''
+            };
+            clone.products.push(producto);
+        });
+    }
+
+    if (state && Array.isArray(state.activity)) {
+        state.activity.forEach(item => {
+            if (!item || !item.id) return;
+            clone.activity.push({
+                id: String(item.id),
+                tipo: item.tipo === 'salida' ? 'salida' : item.tipo === 'transferencia' ? 'transferencia' : 'entrada',
+                productoId: String(item.productoId || ''),
+                producto: item.producto || 'Producto',
+                unidades: Number.isFinite(item.unidades) ? item.unidades : 0,
+                area: item.area || '',
+                zona: item.zona || '',
+                descripcion: item.descripcion || '',
+                timestamp: Number.isFinite(item.timestamp) ? item.timestamp : Date.now()
+            });
+        });
+    }
+
+    if (!clone.products.length) {
+        clone.products = defaultDashboardState.products.map(p => ({ ...p }));
+    }
+    if (!clone.activity.length) {
+        clone.activity = defaultDashboardState.activity.map(a => ({ ...a }));
+    }
+    return clone;
+}
+
+function readDashboardState() {
+    let stored = null;
+    try {
+        const rawLocal = localStorage.getItem(DASHBOARD_STORAGE_KEY);
+        if (rawLocal) {
+            stored = JSON.parse(rawLocal);
+        }
+    } catch (error) {
+        console.warn('No se pudo leer el estado del dashboard desde localStorage', error);
+    }
+
+    if (!stored) {
+        try {
+            const rawSession = sessionStorage.getItem(DASHBOARD_STORAGE_KEY);
+            if (rawSession) {
+                stored = JSON.parse(rawSession);
+            }
+        } catch (error) {
+            console.warn('No se pudo leer el estado del dashboard desde sessionStorage', error);
+        }
+    }
+
+    if (!stored) {
+        stored = defaultDashboardState;
+    }
+
+    return normalizeDashboardState(stored);
+}
+
+let dashboardState = readDashboardState();
+
+const warehouseLayout = {
+    'Almacén Central': ['Zona A1', 'Zona A2', 'Zona B1', 'Zona B2'],
+    'Sucursal Norte': ['Zona C1', 'Zona C2', 'Zona C3'],
+    'Sucursal Sur': ['Zona S1', 'Zona S2'],
+    'Depósito Externo': ['Zona D4', 'Zona D5']
+};
+
+const stockAlertList = document.querySelector('#stockAlertsCard .stock-alert-list');
+const recentActivityList = document.querySelector('#recentActivityCard .activity-list');
+const activeAlertsValue = document.getElementById('activeAlertsValue');
+const movimientosHoyValue = document.getElementById('movimientosHoyValue');
+const zonasCriticasValue = document.getElementById('zonasCriticasValue');
+
+const registrarEntradaBtn = document.getElementById('registrarEntradaBtn');
+const registrarSalidaBtn = document.getElementById('registrarSalidaBtn');
+const movementModalEl = document.getElementById('movementModal');
+const movementBackdrop = document.getElementById('movementBackdrop');
+const movementModalTitle = document.getElementById('movementModalTitle');
+const movementModalEyebrow = document.getElementById('movementModalEyebrow');
+const movementForm = document.getElementById('movementForm');
+const movementProductSelect = document.getElementById('movementProduct');
+const movementUnitsInput = document.getElementById('movementUnits');
+const movementAreaGroup = document.getElementById('movementAreaGroup');
+const movementZoneGroup = document.getElementById('movementZoneGroup');
+const movementAreaSelect = document.getElementById('movementArea');
+const movementZoneSelect = document.getElementById('movementZone');
+const movementZoneHelp = document.getElementById('movementZoneHelp');
+const movementStockSummary = document.getElementById('movementStockSummary');
+const movementCloseBtn = document.getElementById('movementCloseBtn');
+const movementCancelBtn = document.getElementById('movementCancel');
+
+let movementMode = 'entrada';
+
+function persistDashboardState() {
+    try {
+        localStorage.setItem(DASHBOARD_STORAGE_KEY, JSON.stringify(dashboardState));
+    } catch (error) {
+        console.warn('No se pudo guardar el estado del dashboard en localStorage', error);
+    }
+    try {
+        sessionStorage.setItem(DASHBOARD_STORAGE_KEY, JSON.stringify(dashboardState));
+    } catch (error) {
+        console.warn('No se pudo guardar el estado del dashboard en sessionStorage', error);
+    }
+}
+
+function getAvailableAreas() {
+    const areas = new Set(Object.keys(warehouseLayout));
+    dashboardState.products.forEach(producto => {
+        if (producto.area) {
+            areas.add(producto.area);
+        }
+    });
+    return Array.from(areas).sort((a, b) => a.localeCompare(b, 'es'));
+}
+
+function getZonesForArea(area) {
+    const zonas = new Set();
+    if (warehouseLayout[area]) {
+        warehouseLayout[area].forEach(z => zonas.add(z));
+    }
+    dashboardState.products.forEach(producto => {
+        if (producto.area === area && producto.zona) {
+            zonas.add(producto.zona);
+        }
+    });
+    return Array.from(zonas).sort((a, b) => a.localeCompare(b, 'es'));
+}
+
+function populateAreaSelect(selectedArea = '') {
+    if (!movementAreaSelect) return;
+    movementAreaSelect.innerHTML = '';
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = 'Seleccione área';
+    placeholder.disabled = true;
+    if (!selectedArea) {
+        placeholder.selected = true;
+    }
+    movementAreaSelect.appendChild(placeholder);
+    getAvailableAreas().forEach(area => {
+        const opt = document.createElement('option');
+        opt.value = area;
+        opt.textContent = area;
+        if (area === selectedArea) {
+            opt.selected = true;
+        }
+        movementAreaSelect.appendChild(opt);
+    });
+}
+
+function populateZoneSelect(area = '', selectedZone = '') {
+    if (!movementZoneSelect) return;
+    movementZoneSelect.innerHTML = '';
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = area ? 'Seleccione zona' : 'Seleccione un área primero';
+    placeholder.disabled = true;
+    if (!selectedZone) {
+        placeholder.selected = true;
+    }
+    movementZoneSelect.appendChild(placeholder);
+
+    movementZoneSelect.disabled = !area;
+    if (movementZoneHelp) {
+        movementZoneHelp.style.display = area ? '' : 'none';
+    }
+
+    if (!area) {
+        return;
+    }
+
+    const zonasDisponibles = getZonesForArea(area);
+    if (!zonasDisponibles.length) {
+        movementZoneSelect.disabled = true;
+        return;
+    }
+
+    zonasDisponibles.forEach(zona => {
+        const opt = document.createElement('option');
+        opt.value = zona;
+        opt.textContent = zona;
+        if (zona === selectedZone) {
+            opt.selected = true;
+        }
+        movementZoneSelect.appendChild(opt);
+    });
+}
+
+function populateProductSelect(selectedId = '') {
+    if (!movementProductSelect) return;
+    movementProductSelect.innerHTML = '';
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = 'Seleccione producto';
+    placeholder.disabled = true;
+    if (!selectedId) {
+        placeholder.selected = true;
+    }
+    movementProductSelect.appendChild(placeholder);
+    dashboardState.products.forEach(producto => {
+        const opt = document.createElement('option');
+        opt.value = producto.id;
+        opt.textContent = `${producto.nombre} (Stock: ${producto.stock})`;
+        if (producto.id === selectedId) {
+            opt.selected = true;
+        }
+        movementProductSelect.appendChild(opt);
+    });
+}
+
+function updateStockSummary(productId) {
+    if (!movementStockSummary) return;
+    const producto = dashboardState.products.find(p => p.id === productId);
+    movementStockSummary.textContent = producto ? producto.stock : '0';
+}
+
+function toggleMovementFields() {
+    if (!movementAreaGroup || !movementZoneGroup) return;
+    const isEntrada = movementMode === 'entrada';
+    const method = isEntrada ? 'remove' : 'add';
+    movementAreaGroup.classList[method]('is-hidden');
+    movementZoneGroup.classList[method]('is-hidden');
+    if (movementAreaSelect) {
+        movementAreaSelect.required = isEntrada;
+    }
+    if (movementZoneSelect) {
+        movementZoneSelect.required = isEntrada;
+    }
+    if (movementZoneHelp) {
+        movementZoneHelp.style.display = isEntrada ? '' : 'none';
+    }
+}
+
+function openMovementModal(type = 'entrada') {
+    if (!movementModalEl || !movementForm) return;
+    if (!dashboardState.products.length) {
+        notifyDashboard('Agrega productos al inventario antes de registrar movimientos.');
+        return;
+    }
+    movementMode = type;
+    movementForm.dataset.mode = type;
+    const isEntrada = type === 'entrada';
+    if (movementModalTitle) {
+        movementModalTitle.textContent = isEntrada ? 'Registrar entrada' : 'Registrar salida';
+    }
+    if (movementModalEyebrow) {
+        movementModalEyebrow.textContent = isEntrada ? 'Entrada' : 'Salida';
+    }
+    populateProductSelect();
+    if (movementUnitsInput) {
+        movementUnitsInput.value = '';
+    }
+    if (movementAreaSelect) {
+        populateAreaSelect();
+    }
+    if (movementZoneSelect) {
+        populateZoneSelect('');
+    }
+    updateStockSummary('');
+    toggleMovementFields();
+    movementModalEl.classList.add('is-open');
+    movementModalEl.setAttribute('aria-hidden', 'false');
+    document.body.style.overflow = 'hidden';
+}
+
+function closeMovementModal() {
+    if (!movementModalEl) return;
+    movementModalEl.classList.remove('is-open');
+    movementModalEl.setAttribute('aria-hidden', 'true');
+    document.body.style.overflow = '';
+}
+
+function notifyDashboard(message) {
+    if (typeof window.toastInfo === 'function') {
+        window.toastInfo(message);
+        return;
+    }
+    if (typeof window.toastOk === 'function') {
+        window.toastOk(message);
+        return;
+    }
+    alert(message);
+}
+
+function formatMovementDescription(item) {
+    if (!item) return '';
+    const unidades = item.unidades || 0;
+    const unidadesLabel = `${unidades} ${unidades === 1 ? 'unidad' : 'unidades'}`;
+    if (item.descripcion) {
+        return item.descripcion;
+    }
+    if (item.tipo === 'salida') {
+        return `Egreso de ${unidadesLabel} de ${item.producto}`;
+    }
+    if (item.tipo === 'transferencia') {
+        return `Transferencia de ${unidadesLabel} de ${item.producto}`;
+    }
+    return `Ingreso de ${unidadesLabel} de ${item.producto}`;
+}
+
+function formatRelativeTime(timestamp) {
+    if (!Number.isFinite(timestamp)) {
+        return '';
+    }
+    const diffMs = Date.now() - timestamp;
+    if (diffMs < 60000) {
+        return 'Hace instantes';
+    }
+    const diffMinutes = Math.round(diffMs / 60000);
+    if (diffMinutes < 60) {
+        return `Hace ${diffMinutes} min`;
+    }
+    const diffHours = Math.round(diffMinutes / 60);
+    if (diffHours < 24) {
+        return `Hace ${diffHours} h`;
+    }
+    const diffDays = Math.round(diffHours / 24);
+    return diffDays === 1 ? 'Hace 1 día' : `Hace ${diffDays} días`;
+}
+
+function renderStockAlerts() {
+    if (!stockAlertList) return;
+    stockAlertList.innerHTML = '';
+    const lowStock = dashboardState.products
+        .filter(producto => producto.stock <= producto.minimo)
+        .sort((a, b) => a.stock - b.stock);
+
+    if (!lowStock.length) {
+        const empty = document.createElement('li');
+        empty.className = 'stock-alert-item';
+        empty.innerHTML = '<div class="stock-alert-info"><div class="stock-alert-icon"><i class="fas fa-check"></i></div><div><div class="stock-alert-name">Inventario equilibrado</div><div class="stock-alert-detail">No hay productos con stock crítico</div></div></div>';
+        stockAlertList.appendChild(empty);
+        return;
+    }
+
+    lowStock.forEach(producto => {
+        const li = document.createElement('li');
+        li.className = 'stock-alert-item';
+        li.innerHTML = `
+            <div class="stock-alert-info">
+                <div class="stock-alert-icon"><i class="fas fa-box-open"></i></div>
+                <div>
+                    <div class="stock-alert-name">${producto.nombre}</div>
+                    <div class="stock-alert-detail">${producto.area || 'Sin área'} - ${producto.zona || 'Sin zona'}</div>
+                </div>
+            </div>
+            <div class="stock-alert-stock">${producto.stock} ${producto.stock === 1 ? 'unidad' : 'unidades'}</div>`;
+        stockAlertList.appendChild(li);
+    });
+}
+
+function renderRecentActivity() {
+    if (!recentActivityList) return;
+    recentActivityList.innerHTML = '';
+    const items = dashboardState.activity
+        .slice()
+        .sort((a, b) => b.timestamp - a.timestamp)
+        .slice(0, 6);
+
+    if (!items.length) {
+        const empty = document.createElement('li');
+        empty.className = 'activity-item';
+        empty.innerHTML = '<div class="activity-icon"><i class="fas fa-inbox"></i></div><div class="activity-details"><div class="activity-description">Sin movimientos registrados</div><div class="activity-time">Comienza registrando tus primeras entradas o salidas</div></div>';
+        recentActivityList.appendChild(empty);
+        return;
+    }
+
+    items.forEach(item => {
+        const li = document.createElement('li');
+        li.className = 'activity-item';
+        const icon = item.tipo === 'salida' ? 'fa-arrow-up' : item.tipo === 'transferencia' ? 'fa-exchange-alt' : 'fa-arrow-down';
+        li.innerHTML = `
+            <div class="activity-icon"><i class="fas ${icon}"></i></div>
+            <div class="activity-details">
+                <div class="activity-description">${formatMovementDescription(item)}</div>
+                <div class="activity-time">${formatRelativeTime(item.timestamp)}</div>
+            </div>`;
+        recentActivityList.appendChild(li);
+    });
+}
+
+function renderSummaryCards() {
+    const lowStockCount = dashboardState.products.filter(producto => producto.stock <= producto.minimo).length;
+    if (activeAlertsValue) {
+        activeAlertsValue.textContent = String(lowStockCount);
+    }
+
+    if (movimientosHoyValue) {
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+        const movementsToday = dashboardState.activity.filter(item => {
+            const date = new Date(item.timestamp);
+            return date >= today;
+        }).length;
+        movimientosHoyValue.textContent = String(movementsToday);
+    }
+
+    if (zonasCriticasValue) {
+        const zonas = new Set();
+        dashboardState.products.forEach(producto => {
+            if (producto.stock <= producto.minimo && producto.zona) {
+                zonas.add(`${producto.area}::${producto.zona}`);
+            }
+        });
+        zonasCriticasValue.textContent = String(zonas.size);
+    }
+}
+
+function renderDashboardWidgets() {
+    renderStockAlerts();
+    renderRecentActivity();
+    renderSummaryCards();
+}
+
+function handleMovementSubmit(event) {
+    event.preventDefault();
+    if (!movementForm) return;
+    const productId = movementProductSelect ? movementProductSelect.value : '';
+    const unidades = movementUnitsInput ? parseInt(movementUnitsInput.value, 10) : 0;
+    if (!productId) {
+        notifyDashboard('Selecciona un producto del inventario.');
+        return;
+    }
+    if (!Number.isFinite(unidades) || unidades <= 0) {
+        notifyDashboard('Ingresa una cantidad válida de unidades.');
+        return;
+    }
+
+    const producto = dashboardState.products.find(p => p.id === productId);
+    if (!producto) {
+        notifyDashboard('No se encontró el producto seleccionado.');
+        return;
+    }
+
+    if (movementMode === 'salida' && unidades > producto.stock) {
+        notifyDashboard('La cantidad excede el stock disponible.');
+        return;
+    }
+
+    if (movementMode === 'entrada') {
+        const area = movementAreaSelect ? movementAreaSelect.value : '';
+        const zona = movementZoneSelect ? movementZoneSelect.value : '';
+        if (!area || !zona) {
+            notifyDashboard('Selecciona el área y la zona destino.');
+            return;
+        }
+        producto.area = area;
+        producto.zona = zona;
+        producto.stock += unidades;
+    } else {
+        producto.stock = Math.max(0, producto.stock - unidades);
+    }
+
+    const movimiento = {
+        id: `mov-${Date.now()}`,
+        tipo: movementMode,
+        productoId: producto.id,
+        producto: producto.nombre,
+        unidades,
+        area: producto.area,
+        zona: producto.zona,
+        descripcion: movementMode === 'salida'
+            ? `Egreso de ${unidades} ${unidades === 1 ? 'unidad' : 'unidades'} de ${producto.nombre}`
+            : `Ingreso de ${unidades} ${unidades === 1 ? 'unidad' : 'unidades'} de ${producto.nombre}`,
+        timestamp: Date.now()
+    };
+
+    dashboardState.activity.unshift(movimiento);
+    dashboardState.activity = dashboardState.activity.slice(0, 25);
+    persistDashboardState();
+    renderDashboardWidgets();
+    closeMovementModal();
+    notifyDashboard('Movimiento registrado correctamente.');
+    document.dispatchEvent(new CustomEvent('movimientoRegistrado', { detail: movimiento }));
+}
+
+if (movementProductSelect) {
+    movementProductSelect.addEventListener('change', () => {
+        const producto = dashboardState.products.find(p => p.id === movementProductSelect.value);
+        updateStockSummary(movementProductSelect.value);
+        if (movementMode === 'entrada' && producto) {
+            populateAreaSelect(producto.area);
+            populateZoneSelect(producto.area, producto.zona);
+        }
+    });
+}
+
+movementAreaSelect?.addEventListener('change', () => {
+    populateZoneSelect(movementAreaSelect.value);
+});
+
+movementForm?.addEventListener('submit', handleMovementSubmit);
+movementCloseBtn?.addEventListener('click', closeMovementModal);
+movementCancelBtn?.addEventListener('click', closeMovementModal);
+movementBackdrop?.addEventListener('click', closeMovementModal);
+
+registrarEntradaBtn?.addEventListener('click', () => openMovementModal('entrada'));
+registrarSalidaBtn?.addEventListener('click', () => openMovementModal('salida'));
+
+document.addEventListener('keydown', event => {
+    if (event.key === 'Escape' && movementModalEl && movementModalEl.classList.contains('is-open')) {
+        closeMovementModal();
+    }
+});
+
 const FALLBACK_TIME_ZONE_LABEL = (() => {
     const offsetMinutes = -new Date().getTimezoneOffset();
     const sign = offsetMinutes >= 0 ? '+' : '-';
@@ -204,10 +781,9 @@ function loadMetrics() {
 }
 
 function saveHomeData() {
+    persistDashboardState();
     const data = {
         empresaTitulo: document.getElementById('empresaTitulo')?.textContent || '',
-        stockAlerts: document.querySelector('#stockAlertsCard .stock-alert-list')?.innerHTML || '',
-        recentActivity: document.querySelector('#recentActivityCard .activity-list')?.innerHTML || '',
         highRotation: document.getElementById('highRotationList')?.innerHTML || '',
         zoneCapacity: document.getElementById('zoneCapacityList')?.innerHTML || '',
         accessLogs: document.getElementById('accessLogsList')?.innerHTML || ''
@@ -216,16 +792,24 @@ function saveHomeData() {
 }
 
 function restoreHomeData() {
+    try {
+        const storedState = sessionStorage.getItem(DASHBOARD_STORAGE_KEY);
+        if (storedState) {
+            dashboardState = normalizeDashboardState(JSON.parse(storedState));
+        }
+    } catch (error) {
+        console.warn('No se pudo restaurar el estado del dashboard desde sessionStorage', error);
+    }
+
     const raw = sessionStorage.getItem('homeData');
-    if (!raw) return;
+    if (!raw) {
+        renderDashboardWidgets();
+        return;
+    }
     try {
         const data = JSON.parse(raw);
         const empresaTitulo = document.getElementById('empresaTitulo');
         if (empresaTitulo && data.empresaTitulo) empresaTitulo.textContent = data.empresaTitulo;
-        const stockAlerts = document.querySelector('#stockAlertsCard .stock-alert-list');
-        if (stockAlerts && data.stockAlerts) stockAlerts.innerHTML = data.stockAlerts;
-        const recentActivity = document.querySelector('#recentActivityCard .activity-list');
-        if (recentActivity && data.recentActivity) recentActivity.innerHTML = data.recentActivity;
         const highRotation = document.getElementById('highRotationList');
         if (highRotation && data.highRotation) highRotation.innerHTML = data.highRotation;
         const zoneCapacity = document.getElementById('zoneCapacityList');
@@ -235,6 +819,7 @@ function restoreHomeData() {
     } catch (e) {
         console.error('Error restoring home data', e);
     }
+    renderDashboardWidgets();
 }
 
 function formatRelativeDate(date) {
@@ -816,6 +1401,7 @@ document.addEventListener("DOMContentLoaded", function () {
         });
     }
 
+    renderDashboardWidgets();
     loadMetrics();
     loadAccessLogs();
     restoreHomeData();

--- a/styles/gest_inve/inventario_basico.css
+++ b/styles/gest_inve/inventario_basico.css
@@ -441,6 +441,16 @@ img {
   box-shadow: 0 12px 30px -22px rgba(255, 107, 107, 0.4);
 }
 
+.btn-icon--primary {
+  background: rgba(15, 40, 65, 0.12);
+  color: var(--primary-color);
+}
+
+.btn-icon--primary:hover {
+  background: rgba(15, 40, 65, 0.18);
+  box-shadow: 0 12px 30px -22px rgba(15, 40, 65, 0.35);
+}
+
 .btn-icon--accent {
   background: rgba(15, 180, 212, 0.12);
   color: var(--accent-color);

--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -922,6 +922,210 @@ img {
     color: var(--danger-color);
 }
 
+.dashboard-modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 140;
+    font-family: inherit;
+}
+
+.dashboard-modal.is-open {
+    display: flex;
+}
+
+.dashboard-modal__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.55);
+}
+
+.dashboard-modal__dialog {
+    position: relative;
+    width: min(480px, 92vw);
+    background: var(--card-bg);
+    border-radius: 24px;
+    box-shadow: 0 24px 65px -24px rgba(15, 40, 65, 0.55);
+    border: 1px solid rgba(15, 40, 65, 0.08);
+    padding: 1.75rem;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.dashboard-modal__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+.dashboard-modal__eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.75rem;
+    color: var(--muted-color);
+    font-weight: 600;
+}
+
+.dashboard-modal__title {
+    font-size: 1.35rem;
+    font-weight: 600;
+    color: var(--text-color);
+    margin-top: 0.25rem;
+}
+
+.dashboard-modal__close {
+    border: none;
+    background: rgba(15, 40, 65, 0.08);
+    color: var(--text-color);
+    width: 42px;
+    height: 42px;
+    border-radius: 14px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.dashboard-modal__close:hover {
+    background: rgba(15, 40, 65, 0.14);
+    transform: translateY(-1px);
+}
+
+.movement-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.movement-form__group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+}
+
+.movement-form__group--inline {
+    flex-direction: row;
+    align-items: stretch;
+    gap: 1rem;
+}
+
+.movement-form__field {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.movement-form__field--summary {
+    background: var(--primary-surface-extra);
+    border: 1px solid var(--primary-border-soft);
+    border-radius: 18px;
+    padding: 0.75rem 1rem;
+    justify-content: center;
+}
+
+.movement-form__summary-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted-color);
+}
+
+.movement-form__summary-value {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-color);
+}
+
+.movement-form__label {
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--text-color);
+}
+
+.movement-form__select,
+.movement-form__input {
+    width: 100%;
+    padding: 0.8rem 1rem;
+    border-radius: 14px;
+    border: 1px solid var(--border-color);
+    background: rgba(255, 255, 255, 0.85);
+    color: var(--text-color);
+    font-size: 0.95rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.movement-form__select:focus,
+.movement-form__input:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(255, 111, 145, 0.2);
+}
+
+.movement-form__help {
+    font-size: 0.78rem;
+    color: var(--muted-color);
+}
+
+.movement-form__actions {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: flex-end;
+}
+
+.movement-form__btn {
+    padding: 0.8rem 1.4rem;
+    border-radius: 14px;
+    border: 1px solid transparent;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.movement-form__btn--primary {
+    background: var(--primary-color);
+    color: #fff;
+    box-shadow: 0 18px 32px -20px rgba(255, 111, 145, 0.65);
+}
+
+.movement-form__btn--ghost {
+    background: rgba(15, 40, 65, 0.06);
+    color: var(--text-color);
+    border-color: rgba(15, 40, 65, 0.08);
+}
+
+.movement-form__btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 35px -22px rgba(15, 40, 65, 0.35);
+}
+
+.movement-form__group--area.is-hidden,
+.movement-form__group--inline.is-hidden {
+    display: none;
+}
+
+.movement-form__group--inline {
+    flex-wrap: wrap;
+}
+
+.movement-form__field--summary {
+    min-width: 140px;
+}
+
+.movement-form__select option[disabled] {
+    color: var(--muted-color);
+}
+
+.movement-form__select option[value=""] {
+    color: var(--muted-color);
+}
+
 .activity-icon {
     width: 44px;
     height: 44px;


### PR DESCRIPTION
## Summary
- add a reusable modal on the dashboard for registrar entrada/salida with product, unidades y ubicación destino, and persist movements in the home widgets
- render dinámicamente las tarjetas de alertas de stock y actividad reciente con estado persistente en almacenamiento local
- incorporar en inventario un botón y modal de transferencia para actualizar área/zona de un producto desde la interfaz

## Testing
- not run (no automated tests provided)

------
https://chatgpt.com/codex/tasks/task_e_68cf15756fe4832cbd1dd220aec6711b