### PR TITLE
Add password confirmation when updating account password

### DIFF
--- a/pages/account_suscrip/account_suscrip.html
+++ b/pages/account_suscrip/account_suscrip.html
@@ -374,7 +374,23 @@
             </div>
             <div class="mb-2">
               <label for="inputContrasena" class="form-label">Nueva contraseña (opcional)</label>
-              <input type="password" class="form-control" id="inputContrasena" />
+              <input
+                type="password"
+                class="form-control"
+                id="inputContrasena"
+                autocomplete="new-password"
+              />
+            </div>
+            <div class="mb-2">
+              <label for="inputConfirmarContrasena" class="form-label"
+                >Confirmar nueva contraseña</label
+              >
+              <input
+                type="password"
+                class="form-control"
+                id="inputConfirmarContrasena"
+                autocomplete="new-password"
+              />
             </div>
           </form>
         </div>

--- a/scripts/account_suscrip/account_suscrip.js
+++ b/scripts/account_suscrip/account_suscrip.js
@@ -143,6 +143,7 @@ function mainAccountSuscrip() {
       document.getElementById('inputCorreo').value = u.correo;
       document.getElementById('inputTelefono').value = u.telefono || '';
       document.getElementById('inputContrasena').value = '';
+      document.getElementById('inputConfirmarContrasena').value = '';
       modalUsuario.show();
     }
   });
@@ -154,7 +155,15 @@ function mainAccountSuscrip() {
     formData.append('apellido', document.getElementById('inputApellido').value);
     formData.append('telefono', document.getElementById('inputTelefono').value);
     formData.append('correo', document.getElementById('inputCorreo').value);
-    formData.append('contrasena', document.getElementById('inputContrasena').value);
+    const nuevaContrasena = document.getElementById('inputContrasena').value.trim();
+    const confirmarContrasena = document.getElementById('inputConfirmarContrasena').value.trim();
+
+    if (nuevaContrasena !== confirmarContrasena) {
+      alert('Las contraseñas no coinciden.');
+      return;
+    }
+
+    formData.append('contrasena', nuevaContrasena);
     const file = document.getElementById('inputFoto').files[0];
     if (file) formData.append('foto_perfil', file);
 


### PR DESCRIPTION
## Summary
- add a confirmation input to the account edit modal for updating the password
- validate that the two password fields match before submitting updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf2e6dfd8c832ca963442ee2c09634