### PR TITLE
Add user activation management

### DIFF
--- a/pages/admin_usuar/administracion_usuarios.html
+++ b/pages/admin_usuar/administracion_usuarios.html
@@ -65,7 +65,7 @@
               <circle cx="11" cy="11" r="7"></circle>
               <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
             </svg>
-            <input type="search" id="buscarUsuario" placeholder="Buscar por nombre, correo o rol" aria-label="Buscar en usuarios" />
+            <input type="search" id="buscarUsuario" placeholder="Buscar por nombre, correo, rol o estado" aria-label="Buscar en usuarios" />
           </div>
         </div>
       </div>
@@ -78,6 +78,7 @@
               <th scope="col">Apellido</th>
               <th scope="col">Correo</th>
               <th scope="col">Rol</th>
+              <th scope="col">Estado</th>
               <th scope="col" class="actions-column">Acciones</th>
             </tr>
           </thead>

--- a/scripts/php/actualizar_estado_usuario.php
+++ b/scripts/php/actualizar_estado_usuario.php
@@ -1,0 +1,59 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+
+$servername = "localhost";
+$db_user    = "u296155119_Admin";
+$db_pass    = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+$conn = mysqli_connect($servername, $db_user, $db_pass, $database);
+
+if (!$conn) {
+    echo json_encode(["success" => false, "message" => "Error de conexión a la base de datos."]);
+    exit;
+}
+
+mysqli_set_charset($conn, 'utf8mb4');
+
+require_once __DIR__ . '/log_utils.php';
+
+$data = json_decode(file_get_contents('php://input'), true);
+
+$id_usuario = intval($data['id_usuario'] ?? 0);
+$nuevoEstado = isset($data['activo']) ? intval($data['activo']) : null;
+$id_empresa = intval($data['id_empresa'] ?? 0);
+
+if (!$id_usuario || ($nuevoEstado !== 0 && $nuevoEstado !== 1) || !$id_empresa) {
+    echo json_encode(["success" => false, "message" => "Datos incompletos para actualizar el estado."]);
+    exit;
+}
+
+$sql = "UPDATE usuario u
+        INNER JOIN usuario_empresa ue ON u.id_usuario = ue.id_usuario
+        SET u.activo = ?
+        WHERE u.id_usuario = ? AND ue.id_empresa = ?";
+
+$stmt = $conn->prepare($sql);
+
+if (!$stmt) {
+    echo json_encode(["success" => false, "message" => "No se pudo preparar la consulta."]);
+    exit;
+}
+
+$stmt->bind_param('iii', $nuevoEstado, $id_usuario, $id_empresa);
+
+if ($stmt->execute()) {
+    if ($stmt->affected_rows > 0) {
+        $accion = $nuevoEstado === 1 ? 'Activación' : 'Desactivación';
+        registrarLog($conn, $_SESSION['usuario_id'] ?? 0, 'Usuarios', "$accion de usuario empresa: $id_usuario");
+        echo json_encode(["success" => true]);
+    } else {
+        echo json_encode(["success" => false, "message" => "No se encontró el usuario o el estado ya está aplicado."]);
+    }
+} else {
+    echo json_encode(["success" => false, "message" => "No se pudo actualizar el estado del usuario."]);
+}
+
+$stmt->close();
+$conn->close();

--- a/scripts/php/login.php
+++ b/scripts/php/login.php
@@ -43,6 +43,12 @@ if ($user) {
     $lastFailedAttempt  = strtotime($user['ultimo_intento']);
     $currentTime        = time();
 
+    if (isset($user['activo']) && intval($user['activo']) === 0) {
+        registrarAcceso($conn, $user['id_usuario'], 'Intento');
+        echo json_encode(["success" => false, "message" => "Tu cuenta ha sido desactivada. Contacta al administrador de tu empresa."]);
+        exit;
+    }
+
     if ($failedAttempts >= 4 && ($currentTime - $lastFailedAttempt) < 300) {
     registrarAcceso($conn, $user['id_usuario'], 'Intento');
         echo json_encode(["success"=>false,"message"=>"Tu cuenta está bloqueada. Intenta nuevamente en 5 minutos."]);

--- a/scripts/php/obtener_usuarios_empresa.php
+++ b/scripts/php/obtener_usuarios_empresa.php
@@ -19,7 +19,7 @@ try {
 $data = json_decode(file_get_contents("php://input"), true);
 $id_empresa = intval($data['id_empresa']);
 
-$sql = "SELECT u.id_usuario, u.nombre, u.apellido, u.correo, u.rol, u.telefono, u.fecha_nacimiento, u.foto_perfil
+$sql = "SELECT u.id_usuario, u.nombre, u.apellido, u.correo, u.rol, u.telefono, u.fecha_nacimiento, u.foto_perfil, u.activo
         FROM usuario u
         INNER JOIN usuario_empresa ue ON u.id_usuario = ue.id_usuario
         WHERE ue.id_empresa = ? AND u.rol != 'Administrador'";

--- a/scripts/sql/20240924_add_usuario_activo.sql
+++ b/scripts/sql/20240924_add_usuario_activo.sql
@@ -1,0 +1,3 @@
+-- Agrega la columna `activo` para controlar el acceso a las cuentas de usuario.
+ALTER TABLE usuario
+  ADD COLUMN activo TINYINT(1) NOT NULL DEFAULT 1 AFTER foto_perfil;

--- a/styles/Admin_usuar/administracion_usuarios.css
+++ b/styles/Admin_usuar/administracion_usuarios.css
@@ -516,6 +516,28 @@ body {
   text-transform: uppercase;
 }
 
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.status-chip--active {
+  background: rgba(25, 135, 84, 0.16);
+  color: #198754;
+}
+
+.status-chip--inactive {
+  background: rgba(220, 53, 69, 0.16);
+  color: #dc3545;
+}
+
 .action-buttons {
   display: inline-flex;
   gap: 0.5rem;
@@ -559,6 +581,33 @@ body {
 }
 
 .btn-action--delete:hover {
+  background: rgba(220, 53, 69, 0.22);
+}
+
+.btn-action--status {
+  background: rgba(13, 110, 253, 0.14);
+  color: #0d6efd;
+}
+
+.btn-action--status:hover {
+  background: rgba(13, 110, 253, 0.2);
+}
+
+.btn-status--activate {
+  background: rgba(25, 135, 84, 0.16);
+  color: #198754;
+}
+
+.btn-status--activate:hover {
+  background: rgba(25, 135, 84, 0.24);
+}
+
+.btn-status--deactivate {
+  background: rgba(220, 53, 69, 0.12);
+  color: #dc3545;
+}
+
+.btn-status--deactivate:hover {
   background: rgba(220, 53, 69, 0.22);
 }
 


### PR DESCRIPTION
## Summary
- add an activation state column to the user table schema and expose it in the admin table
- provide UI controls to toggle user activation and display each account's status
- prevent deactivated accounts from signing in and add a PHP endpoint to flip activation state

## Testing
- php -l scripts/php/actualizar_estado_usuario.php
- php -l scripts/php/login.php
- php -l scripts/php/obtener_usuarios_empresa.php

------
https://chatgpt.com/codex/tasks/task_e_68d172b74d30832c82861ea07651f666