### PR TITLE
Log global search history

### DIFF
--- a/pages/main_menu/global_search.html
+++ b/pages/main_menu/global_search.html
@@ -61,9 +61,7 @@
             <article class="search-summary-card">
                 <div class="summary-label">Atajos destacados</div>
                 <ul class="summary-links" id="quickLinks">
-                    <li><button data-query="stock bajo">Stock bajo</button></li>
-                    <li><button data-query="ingreso">Registrar ingreso</button></li>
-                    <li><button data-query="proveedores">Proveedores</button></li>
+                    <li class="empty-message">Aún no hay búsquedas recientes.</li>
                 </ul>
             </article>
         </section>

--- a/scripts/php/get_search_history.php
+++ b/scripts/php/get_search_history.php
@@ -1,0 +1,138 @@
+<?php
+session_start();
+header('Content-Type: application/json; charset=utf-8');
+
+if (!isset($_SESSION['usuario_id'])) {
+    echo json_encode([
+        'success' => false,
+        'message' => 'Sesión no válida. Inicia sesión nuevamente.'
+    ]);
+    exit;
+}
+
+$servername = "localhost";
+$username   = "u296155119_Admin";
+$password   = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+$conn = new mysqli($servername, $username, $password, $database);
+
+if ($conn->connect_error) {
+    echo json_encode([
+        'success' => false,
+        'message' => 'Error de conexión a la base de datos.'
+    ]);
+    exit;
+}
+
+$conn->set_charset('utf8mb4');
+
+function ensureHistoryTable(mysqli $conn): bool
+{
+    $sql = "CREATE TABLE IF NOT EXISTS historial_busquedas (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        id_empresa INT NOT NULL,
+        id_usuario INT NOT NULL,
+        termino VARCHAR(255) NOT NULL,
+        fecha_busqueda DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        INDEX idx_empresa_fecha (id_empresa, fecha_busqueda),
+        CONSTRAINT fk_historial_empresa FOREIGN KEY (id_empresa) REFERENCES empresa(id_empresa) ON DELETE CASCADE,
+        CONSTRAINT fk_historial_usuario FOREIGN KEY (id_usuario) REFERENCES usuario(id_usuario) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+
+    return $conn->query($sql) === true;
+}
+
+function resolveEmpresaId(mysqli $conn, int $userId, int $requestedId): int
+{
+    if ($requestedId > 0) {
+        $sql = "SELECT e.id_empresa
+                FROM empresa e
+                LEFT JOIN usuario_empresa ue ON ue.id_empresa = e.id_empresa
+                WHERE e.id_empresa = ? AND (e.usuario_creador = ? OR ue.id_usuario = ?)
+                LIMIT 1";
+
+        if ($stmt = $conn->prepare($sql)) {
+            $stmt->bind_param('iii', $requestedId, $userId, $userId);
+            $stmt->execute();
+            $stmt->bind_result($empresaId);
+            if ($stmt->fetch()) {
+                $stmt->close();
+                return (int) $empresaId;
+            }
+            $stmt->close();
+        }
+    }
+
+    $sql = "SELECT e.id_empresa
+            FROM empresa e
+            LEFT JOIN usuario_empresa ue ON ue.id_empresa = e.id_empresa
+            WHERE e.usuario_creador = ? OR ue.id_usuario = ?
+            ORDER BY e.fecha_registro DESC
+            LIMIT 1";
+
+    if ($stmt = $conn->prepare($sql)) {
+        $stmt->bind_param('ii', $userId, $userId);
+        $stmt->execute();
+        $stmt->bind_result($empresaId);
+        if ($stmt->fetch()) {
+            $stmt->close();
+            return (int) $empresaId;
+        }
+        $stmt->close();
+    }
+
+    return 0;
+}
+
+$userId = (int) $_SESSION['usuario_id'];
+$requestedEmpresaId = isset($_GET['id_empresa']) ? (int) $_GET['id_empresa'] : 0;
+
+$idEmpresa = resolveEmpresaId($conn, $userId, $requestedEmpresaId);
+
+if ($idEmpresa <= 0) {
+    $conn->close();
+    echo json_encode([
+        'success' => false,
+        'message' => 'No se encontró una empresa asociada a tu usuario.'
+    ]);
+    exit;
+}
+
+if (!ensureHistoryTable($conn)) {
+    $conn->close();
+    echo json_encode([
+        'success' => false,
+        'message' => 'No se pudo preparar la tabla de historial de búsquedas.'
+    ]);
+    exit;
+}
+
+$historial = [];
+$sql = "SELECT termino, fecha_busqueda
+        FROM historial_busquedas
+        WHERE id_empresa = ?
+        ORDER BY fecha_busqueda DESC
+        LIMIT 5";
+
+if ($stmt = $conn->prepare($sql)) {
+    $stmt->bind_param('i', $idEmpresa);
+    $stmt->execute();
+    $result = $stmt->get_result();
+
+    while ($row = $result->fetch_assoc()) {
+        $historial[] = [
+            'termino' => $row['termino'],
+            'fecha_busqueda' => $row['fecha_busqueda']
+        ];
+    }
+
+    $stmt->close();
+}
+
+$conn->close();
+
+echo json_encode([
+    'success' => true,
+    'historial' => $historial
+], JSON_UNESCAPED_UNICODE);

--- a/scripts/php/save_search_query.php
+++ b/scripts/php/save_search_query.php
@@ -1,0 +1,140 @@
+<?php
+session_start();
+header('Content-Type: application/json; charset=utf-8');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode([
+        'success' => false,
+        'message' => 'Método no permitido.'
+    ]);
+    exit;
+}
+
+if (!isset($_SESSION['usuario_id'])) {
+    echo json_encode([
+        'success' => false,
+        'message' => 'Sesión no válida. Inicia sesión nuevamente.'
+    ]);
+    exit;
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+$termino = isset($input['termino']) ? trim((string) $input['termino']) : '';
+$idEmpresa = isset($input['id_empresa']) ? (int) $input['id_empresa'] : 0;
+$usuarioId = (int) $_SESSION['usuario_id'];
+
+if ($termino === '' || $idEmpresa <= 0) {
+    echo json_encode([
+        'success' => false,
+        'message' => 'Información incompleta para registrar la búsqueda.'
+    ]);
+    exit;
+}
+
+$servername = "localhost";
+$username   = "u296155119_Admin";
+$password   = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+$conn = new mysqli($servername, $username, $password, $database);
+
+if ($conn->connect_error) {
+    echo json_encode([
+        'success' => false,
+        'message' => 'Error de conexión a la base de datos.'
+    ]);
+    exit;
+}
+
+$conn->set_charset('utf8mb4');
+
+function ensureHistoryTable(mysqli $conn): bool
+{
+    $sql = "CREATE TABLE IF NOT EXISTS historial_busquedas (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        id_empresa INT NOT NULL,
+        id_usuario INT NOT NULL,
+        termino VARCHAR(255) NOT NULL,
+        fecha_busqueda DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        INDEX idx_empresa_fecha (id_empresa, fecha_busqueda),
+        CONSTRAINT fk_historial_empresa FOREIGN KEY (id_empresa) REFERENCES empresa(id_empresa) ON DELETE CASCADE,
+        CONSTRAINT fk_historial_usuario FOREIGN KEY (id_usuario) REFERENCES usuario(id_usuario) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+
+    return $conn->query($sql) === true;
+}
+
+function usuarioPerteneceAEmpresa(mysqli $conn, int $empresaId, int $usuarioId): bool
+{
+    $sql = "SELECT 1
+            FROM empresa e
+            LEFT JOIN usuario_empresa ue ON ue.id_empresa = e.id_empresa
+            WHERE e.id_empresa = ? AND (e.usuario_creador = ? OR ue.id_usuario = ?)
+            LIMIT 1";
+
+    if ($stmt = $conn->prepare($sql)) {
+        $stmt->bind_param('iii', $empresaId, $usuarioId, $usuarioId);
+        $stmt->execute();
+        $stmt->store_result();
+        $pertenece = $stmt->num_rows > 0;
+        $stmt->close();
+        return $pertenece;
+    }
+
+    return false;
+}
+
+if (!ensureHistoryTable($conn)) {
+    $conn->close();
+    echo json_encode([
+        'success' => false,
+        'message' => 'No se pudo preparar la tabla de historial de búsquedas.'
+    ]);
+    exit;
+}
+
+if (!usuarioPerteneceAEmpresa($conn, $idEmpresa, $usuarioId)) {
+    $conn->close();
+    echo json_encode([
+        'success' => false,
+        'message' => 'No tienes permisos para registrar búsquedas en esta empresa.'
+    ]);
+    exit;
+}
+
+$termino = mb_substr($termino, 0, 255, 'UTF-8');
+
+if ($stmt = $conn->prepare('INSERT INTO historial_busquedas (id_empresa, id_usuario, termino) VALUES (?, ?, ?)')) {
+    $stmt->bind_param('iis', $idEmpresa, $usuarioId, $termino);
+    $stmt->execute();
+    $stmt->close();
+}
+
+$historial = [];
+$sql = "SELECT termino, fecha_busqueda
+        FROM historial_busquedas
+        WHERE id_empresa = ?
+        ORDER BY fecha_busqueda DESC
+        LIMIT 5";
+
+if ($stmt = $conn->prepare($sql)) {
+    $stmt->bind_param('i', $idEmpresa);
+    $stmt->execute();
+    $result = $stmt->get_result();
+
+    while ($row = $result->fetch_assoc()) {
+        $historial[] = [
+            'termino' => $row['termino'],
+            'fecha_busqueda' => $row['fecha_busqueda']
+        ];
+    }
+
+    $stmt->close();
+}
+
+$conn->close();
+
+echo json_encode([
+    'success' => true,
+    'historial' => $historial
+], JSON_UNESCAPED_UNICODE);

--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -274,6 +274,15 @@ img {
     padding: 0;
 }
 
+.summary-links .empty-message {
+    padding: 0.6rem 1.3rem;
+    border-radius: var(--radius-pill);
+    background: rgba(15, 180, 212, 0.08);
+    border: 1px dashed rgba(15, 180, 212, 0.35);
+    color: rgba(15, 23, 42, 0.7);
+    font-weight: 500;
+}
+
 .summary-links button {
     border: 1px solid rgba(15, 180, 212, 0.25);
     border-radius: var(--radius-pill);

--- a/u296155119_OptiStock (3).sql
+++ b/u296155119_OptiStock (3).sql
@@ -890,6 +890,25 @@ ALTER TABLE `pass_resets`
   ADD CONSTRAINT `pass_resets_ibfk_1` FOREIGN KEY (`id_usuario`) REFERENCES `usuario` (`id_usuario`);
 
 --
+-- --------------------------------------------------------
+
+--
+-- Estructura de tabla para la tabla `historial_busquedas`
+--
+
+CREATE TABLE IF NOT EXISTS `historial_busquedas` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `id_empresa` int NOT NULL,
+  `id_usuario` int NOT NULL,
+  `termino` varchar(255) NOT NULL,
+  `fecha_busqueda` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_historial_empresa_fecha` (`id_empresa`,`fecha_busqueda`),
+  CONSTRAINT `fk_historial_busquedas_empresa` FOREIGN KEY (`id_empresa`) REFERENCES `empresa` (`id_empresa`) ON DELETE CASCADE,
+  CONSTRAINT `fk_historial_busquedas_usuario` FOREIGN KEY (`id_usuario`) REFERENCES `usuario` (`id_usuario`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
 -- Filtros para la tabla `productos`
 --
 ALTER TABLE `productos`


### PR DESCRIPTION
## Summary
- mostrar en el panel de búsqueda rápida las últimas consultas realizadas por la empresa
- registrar cada búsqueda desde la interfaz y persistirla mediante nuevos endpoints PHP
- añadir la definición SQL de la tabla `historial_busquedas` para respaldar el historial

## Testing
- no se ejecutaron pruebas (no se solicitaron)

------
https://chatgpt.com/codex/tasks/task_e_68d19341ecf4832c89122de879b5112f