### PR TITLE
Improve mobile layout for main menu topbar

### DIFF
--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -1235,36 +1235,45 @@ img {
         padding: 8px 14px;
         padding-left: 14px;
         height: auto;
-        gap: 8px;
-        flex-wrap: wrap;
-        align-items: flex-start;
+        display: grid;
+        grid-template-columns: auto 1fr;
+        grid-template-areas:
+            "toggle title"
+            "actions actions";
+        column-gap: 12px;
         row-gap: 12px;
+        align-items: center;
     }
 
     .menu-toggle {
-        order: 0;
+        grid-area: toggle;
+        justify-self: flex-start;
     }
 
     .topbar-title {
-        order: 1;
-        flex: 1 1 auto;
+        grid-area: title;
         font-size: 1rem;
         min-width: 0;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        text-align: center;
     }
 
     .topbar-actions {
-        order: 2;
-        flex: 1 1 100%;
+        grid-area: actions;
         display: flex;
         align-items: center;
-        justify-content: flex-end;
+        justify-content: space-between;
         gap: 10px;
         min-width: 0;
         flex-wrap: wrap;
         padding: 0;
+        width: 100%;
+    }
+
+    .topbar-actions > * {
+        flex: 0 0 auto;
     }
 
     .notification-bell,
@@ -1285,6 +1294,8 @@ img {
         padding: 8px 12px;
         border-radius: 14px;
         background: rgba(255, 255, 255, 0.18);
+        flex: 1 1 100%;
+        min-width: 0;
     }
 
     .user-profile img {
@@ -1295,14 +1306,22 @@ img {
     .user-info {
         gap: 0;
         line-height: 1.1;
+        flex: 1 1 auto;
+        min-width: 0;
     }
 
     .user-name {
         font-size: 0.82rem;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     .user-role {
         font-size: 0.68rem;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     .dropdown-toggle {


### PR DESCRIPTION
## Summary
- reorganize the main menu top bar into a responsive grid on very small screens so the toggle, title, and actions stack cleanly
- ensure user profile content flexes and truncates text on mobile to avoid overflow while keeping controls accessible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d196a323f0832c8747db70d176d78e