### PR TITLE
Add area and zone selection to inventory products

### DIFF
--- a/pages/gest_inve/inventario.html
+++ b/pages/gest_inve/inventario.html
@@ -281,6 +281,20 @@
                 </select>
               </div>
               <div class="col-md-6">
+                <label for="productoArea" class="form-label">Área de almacén</label>
+                <select id="productoArea" class="form-select">
+                  <option value="">Área</option>
+                </select>
+              </div>
+            </div>
+            <div class="row g-3">
+              <div class="col-md-6">
+                <label for="productoZona" class="form-label">Zona de almacén</label>
+                <select id="productoZona" class="form-select">
+                  <option value="">Zona</option>
+                </select>
+              </div>
+              <div class="col-md-6">
                 <label for="productoStock" class="form-label">Stock inicial</label>
                 <input type="number" id="productoStock" class="form-control" placeholder="Cantidad" min="0" />
               </div>


### PR DESCRIPTION
## Summary
- add area y zona al formulario de productos del inventario
- cargar las áreas y zonas de la empresa y mostrarlas en las vistas de resumen y tarjetas
- mantener la sincronización al editar o reiniciar el formulario, filtrando las zonas por área

## Testing
- no se ejecutaron pruebas (no disponibles)


------
https://chatgpt.com/codex/tasks/task_e_68d1d0f0bce0832cb968fdaedf28ad02