### PR TITLE
Fix areas API endpoint in inventory module

### DIFF
--- a/scripts/gest_inve/inventario_basico.js
+++ b/scripts/gest_inve/inventario_basico.js
@@ -3,6 +3,7 @@
     categorias: '../../scripts/php/guardar_categorias.php',
     subcategorias: '../../scripts/php/guardar_subcategorias.php',
     productos: '../../scripts/php/guardar_productos.php',
+    areas:       '../../scripts/php/guardar_areas.php',
     zonas:         '../../scripts/php/guardar_zonas.php',
     movimiento:   '../../scripts/php/guardar_movimientos.php'
   };


### PR DESCRIPTION
## Summary
- add the missing `areas` API endpoint mapping in the inventory script so the areas request no longer resolves to `undefined`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1e3a819f0832c956764f1b4b57585