### PR TITLE
Add smooth page transition animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
 
     <link rel="stylesheet" href="styles/index/index.css">
+    <script src="scripts/common/page-transition.js" defer></script>
 </head>
 <body>
     <!-- Navbar -->

--- a/pages/account_suscrip/account_suscrip.html
+++ b/pages/account_suscrip/account_suscrip.html
@@ -19,6 +19,7 @@
     href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
   />
   <link rel="stylesheet" href="../../styles/account_suscrip/account_suscrip.css" />
+  <script src="../../scripts/common/page-transition.js" defer></script>
 </head>
 <body>
   <main class="account-page container-fluid py-4 px-3 px-md-4">

--- a/pages/admin_usuar/administracion_usuarios.html
+++ b/pages/admin_usuar/administracion_usuarios.html
@@ -10,6 +10,7 @@
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
   <link rel="stylesheet" href="../../styles/Admin_usuar/administracion_usuarios.css" />
+  <script src="../../scripts/common/page-transition.js" defer></script>
 </head>
 <body>
   <div class="users-page container-fluid py-4 px-3 px-md-4">

--- a/pages/admin_usuar/registro_usuario_empresa.html
+++ b/pages/admin_usuar/registro_usuario_empresa.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="../../styles/regis_login/regist/registro_p1.css">
+    <script src="../../scripts/common/page-transition.js" defer></script>
 </head>
 <body class="d-flex justify-content-center align-items-center vh-100">
 

--- a/pages/area_almac/areas_zonas.html
+++ b/pages/area_almac/areas_zonas.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="../../styles/Area_almac/areas_zonas.css" />
   <script src="../../scripts/area_almac/areas_zonas.js" defer></script>
+  <script src="../../scripts/common/page-transition.js" defer></script>
 </head>
 <body>
   <div class="warehouse-page container-fluid py-4 px-3 px-md-4">

--- a/pages/area_almac_v2/gestion_areas_zonas.html
+++ b/pages/area_almac_v2/gestion_areas_zonas.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="../../styles/Area_almac_v2/gestion_areas_zonas.css" />
   <script defer src="../../scripts/area_almac_v2/gestion_areas_zonas.js"></script>
+  <script src="../../scripts/common/page-transition.js" defer></script>
 </head>
 <body>
   <div class="warehouse-page">

--- a/pages/control_log/log.html
+++ b/pages/control_log/log.html
@@ -16,6 +16,7 @@
   />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" />
   <link rel="stylesheet" href="../../styles/control_log/log.css" />
+  <script src="../../scripts/common/page-transition.js" defer></script>
 </head>
 <body>
   <div class="log-page container-fluid py-4 px-3 px-md-4">

--- a/pages/gest_inve/inventario.html
+++ b/pages/gest_inve/inventario.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="../../styles/gest_inve/inventario.css" />
+  <script src="../../scripts/common/page-transition.js" defer></script>
 </head>
 <body>
   <div class="inventory-page container-fluid py-4 px-3 px-md-4">

--- a/pages/gest_inve/inventario_basico.html
+++ b/pages/gest_inve/inventario_basico.html
@@ -12,6 +12,7 @@
   />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="../../styles/gest_inve/inventario_basico.css" />
+  <script src="../../scripts/common/page-transition.js" defer></script>
 </head>
 <body>
   <div class="inventory-page container-fluid py-4 px-3 px-md-4">

--- a/pages/gest_inve/lector_qr.html
+++ b/pages/gest_inve/lector_qr.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Lector QR</title>
     <script src="https://unpkg.com/html5-qrcode@2.3.8/minified/html5-qrcode.min.js"></script>
+    <script src="../../scripts/common/page-transition.js" defer></script>
 </head>
 <body>
     <div id="reader" style="width:300px"></div>

--- a/pages/main_menu/global_search.html
+++ b/pages/main_menu/global_search.html
@@ -9,6 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="../../styles/main_menu/main_menu.css">
+    <script src="../../scripts/common/page-transition.js" defer></script>
 </head>
 <body class="search-page-body">
     <div class="sidebar">

--- a/pages/main_menu/main_menu.html
+++ b/pages/main_menu/main_menu.html
@@ -10,6 +10,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="../../styles/main_menu/main_menu.css">
+    <script src="../../scripts/common/page-transition.js" defer></script>
 </head>
 <body>
     <!-- Sidebar Navigation -->

--- a/pages/regis_login/login/login.html
+++ b/pages/regis_login/login/login.html
@@ -8,6 +8,7 @@
     <script src="https://apis.google.com/js/platform.js" async defer></script>
     <script src="https://accounts.google.com/gsi/client" async defer></script>
     <link rel="stylesheet" href="../../../styles/regis_login/login/login.css">
+    <script src="../../../scripts/common/page-transition.js" defer></script>
 </head>
 <body class="d-flex justify-content-center align-items-center vh-100">
     <div class="nav-links">

--- a/pages/regis_login/login/pass_recuperar.html
+++ b/pages/regis_login/login/pass_recuperar.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Reestablecer Contraseña</title>
     <link rel="stylesheet" href="../../../styles/regis_login/login/pass_recuperar.css">
+    <script src="../../../scripts/common/page-transition.js" defer></script>
 </head>
 <body>
     <div class="container">

--- a/pages/regis_login/login/reset_pass.html
+++ b/pages/regis_login/login/reset_pass.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Restablecer Contraseña</title>
     <link rel="stylesheet" href="../../../styles/regis_login/login/login.css"> <!-- Ajusta el path si es necesario -->
+    <script src="../../../scripts/common/page-transition.js" defer></script>
 </head>
 <body>
     <div class="container">

--- a/pages/regis_login/regist/regist_empresa.html
+++ b/pages/regis_login/regist/regist_empresa.html
@@ -7,6 +7,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="../../../styles/regis_login/regist/registro_empresa.css">
+    <script src="../../../scripts/common/page-transition.js" defer></script>
 </head>
 <body>
     <div class="container">

--- a/pages/regis_login/regist/regist_google.html
+++ b/pages/regis_login/regist/regist_google.html
@@ -6,6 +6,7 @@
     <title>Completar Registro</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="../../../styles/regis_login/regist/regist_google.css">
+    <script src="../../../scripts/common/page-transition.js" defer></script>
 </head>
 <body class="d-flex justify-content-center align-items-center vh-100">
 

--- a/pages/regis_login/regist/regist_inter.html
+++ b/pages/regis_login/regist/regist_inter.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="../../../styles/regis_login/regist/regist_inter.css">
     <title>Verificación de Correo</title>
+    <script src="../../../scripts/common/page-transition.js" defer></script>
 </head>
 <body>
     <div class="container">

--- a/pages/regis_login/regist/registro_p1.html
+++ b/pages/regis_login/regist/registro_p1.html
@@ -6,6 +6,7 @@
     <title>Registro - OptiStock</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="../../../styles/regis_login/regist/registro_p1.css">
+    <script src="../../../scripts/common/page-transition.js" defer></script>
 </head>
 <body class="d-flex justify-content-center align-items-center vh-100">
 

--- a/pages/regis_login/regist/registro_p2.html
+++ b/pages/regis_login/regist/registro_p2.html
@@ -6,6 +6,7 @@
     <title>Registro</title>
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="../../../styles/regis_login/regist/registro_p1.css">
+    <script src="../../../scripts/common/page-transition.js" defer></script>
 </head>
 
 <body>

--- a/pages/reports/reportes.html
+++ b/pages/reports/reportes.html
@@ -8,6 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="../../styles/reports/reportes.css" />
+  <script src="../../scripts/common/page-transition.js" defer></script>
 </head>
 <body>
   <main class="report-layout">

--- a/scripts/common/page-transition.js
+++ b/scripts/common/page-transition.js
@@ -1,0 +1,140 @@
+(function () {
+  const TRANSITION_DURATION = 300;
+  const styleContent = `
+  body {
+    opacity: 0;
+    transform: translateY(16px);
+    transition: opacity ${TRANSITION_DURATION}ms ease, transform ${TRANSITION_DURATION}ms ease;
+  }
+
+  body.page-transition-visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  body.page-transition-exiting {
+    pointer-events: none;
+  }
+
+  .page-transition-spinner {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(15, 23, 42, 0.08);
+    backdrop-filter: blur(2px);
+    z-index: 9999;
+    opacity: 0;
+    transition: opacity ${TRANSITION_DURATION}ms ease;
+  }
+
+  .page-transition-spinner.active {
+    opacity: 1;
+  }
+
+  .page-transition-spinner::before {
+    content: "";
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    border: 4px solid rgba(255, 183, 77, 0.35);
+    border-top-color: rgba(255, 183, 77, 0.9);
+    animation: page-transition-spin 0.9s linear infinite;
+  }
+
+  @keyframes page-transition-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  `;
+
+  function injectStyle() {
+    if (document.getElementById('page-transition-style')) {
+      return;
+    }
+    const style = document.createElement('style');
+    style.id = 'page-transition-style';
+    style.textContent = styleContent;
+    document.head.appendChild(style);
+  }
+
+  function handleLinkClick(event) {
+    const anchor = event.currentTarget;
+    if (anchor.target && anchor.target !== '_self') {
+      return;
+    }
+    if (anchor.hasAttribute('download')) {
+      return;
+    }
+    const href = anchor.getAttribute('href');
+    if (!href || href.startsWith('#')) {
+      return;
+    }
+
+    const url = new URL(href, window.location.href);
+    if (url.origin !== window.location.origin) {
+      return;
+    }
+
+    event.preventDefault();
+    startExitTransition(() => {
+      window.location.href = url.href;
+    });
+  }
+
+  function startExitTransition(callback) {
+    document.body.classList.remove('page-transition-visible');
+    document.body.classList.add('page-transition-exiting');
+
+    const spinner = document.querySelector('.page-transition-spinner');
+    if (spinner) {
+      spinner.classList.add('active');
+    }
+
+    window.setTimeout(callback, TRANSITION_DURATION);
+  }
+
+  function markPageVisible() {
+    document.body.classList.add('page-transition-visible');
+    document.body.classList.remove('page-transition-exiting');
+
+    const spinner = document.querySelector('.page-transition-spinner');
+    if (spinner) {
+      spinner.classList.remove('active');
+    }
+  }
+
+  function setupTransition() {
+    injectStyle();
+
+    if (!document.querySelector('.page-transition-spinner')) {
+      const spinner = document.createElement('div');
+      spinner.className = 'page-transition-spinner';
+      document.body.appendChild(spinner);
+    }
+
+    requestAnimationFrame(markPageVisible);
+
+    const anchors = Array.from(document.querySelectorAll('a[href]'));
+    anchors.forEach((anchor) => {
+      if (anchor.dataset.transition === 'disabled') {
+        return;
+      }
+      anchor.addEventListener('click', handleLinkClick);
+    });
+
+    window.addEventListener('pageshow', (event) => {
+      if (event.persisted) {
+        markPageVisible();
+      }
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setupTransition);
+  } else {
+    setupTransition();
+  }
+})();


### PR DESCRIPTION
## Summary
- add a shared page transition script that injects fade and loading spinner styles
- load the transition script on every public page so navigation animates consistently

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d1f7b39c38832c8cdc556ce53d142a