### PR TITLE
Track tutorial completion in database

### DIFF
--- a/pages/main_menu/main_menu.html
+++ b/pages/main_menu/main_menu.html
@@ -44,6 +44,9 @@
             <button id="openColorModal" class="btn btn-warning" style="width: 100%;">
                 <i class="fas fa-palette"></i> <span>Personalizar</span>
             </button>
+            <button id="openTutorialBtn" class="btn btn-secondary" style="width: 100%;">
+                <i class="fas fa-question-circle"></i> <span>Ver tutorial</span>
+            </button>
         </div>
     </div>
     

--- a/scripts/php/get_tutorial_status.php
+++ b/scripts/php/get_tutorial_status.php
@@ -1,0 +1,49 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+
+$response = ['success' => false, 'message' => ''];
+
+if (!isset($_SESSION['usuario_id'])) {
+    $response['message'] = 'Sesión no válida';
+    echo json_encode($response);
+    exit;
+}
+
+$servername = "localhost";
+$db_user    = "u296155119_Admin";
+$db_pass    = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+$conn = mysqli_connect($servername, $db_user, $db_pass, $database);
+if (!$conn) {
+    $response['message'] = 'Error de conexión a la base de datos';
+    echo json_encode($response);
+    exit;
+}
+
+$usuarioId = intval($_SESSION['usuario_id']);
+
+$stmt = mysqli_prepare($conn, "SELECT tutorial_visto FROM usuario WHERE id_usuario = ?");
+if (!$stmt) {
+    $response['message'] = 'Error al preparar la consulta';
+    echo json_encode($response);
+    mysqli_close($conn);
+    exit;
+}
+
+mysqli_stmt_bind_param($stmt, "i", $usuarioId);
+mysqli_stmt_execute($stmt);
+mysqli_stmt_bind_result($stmt, $tutorialVisto);
+
+if (mysqli_stmt_fetch($stmt)) {
+    $response['success'] = true;
+    $response['tutorial_visto'] = (int) $tutorialVisto;
+} else {
+    $response['message'] = 'Usuario no encontrado';
+}
+
+mysqli_stmt_close($stmt);
+mysqli_close($conn);
+
+echo json_encode($response);

--- a/scripts/php/login.php
+++ b/scripts/php/login.php
@@ -74,6 +74,7 @@ if ($user) {
         $_SESSION['usuario_rol']         = $user['rol'];
         $_SESSION['usuario_suscripcion'] = $user['suscripcion'];
         $_SESSION['usuario_foto_perfil'] = $user['foto_perfil'];
+        $_SESSION['tutorial_visto']      = isset($user['tutorial_visto']) ? (int) $user['tutorial_visto'] : 0;
         registrarAcceso($conn, $user['id_usuario'], 'Inicio');
 
         /*─────────────────────────────────────────────
@@ -131,7 +132,8 @@ if ($user) {
             "suscripcion"    => $user['suscripcion'],
             "foto_perfil"    => $user['foto_perfil'],
             "id_empresa"     => $id_empresa,
-            "empresa_nombre" => $empresa_nombre
+            "empresa_nombre" => $empresa_nombre,
+            "tutorial_visto" => isset($user['tutorial_visto']) ? (int) $user['tutorial_visto'] : 0
         ];
 
         if ($user['verificacion_cuenta'] == 0) {

--- a/scripts/php/update_tutorial_status.php
+++ b/scripts/php/update_tutorial_status.php
@@ -1,0 +1,49 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+
+$response = ['success' => false, 'message' => ''];
+
+if (!isset($_SESSION['usuario_id'])) {
+    $response['message'] = 'Sesión no válida';
+    echo json_encode($response);
+    exit;
+}
+
+$servername = "localhost";
+$db_user    = "u296155119_Admin";
+$db_pass    = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+$conn = mysqli_connect($servername, $db_user, $db_pass, $database);
+if (!$conn) {
+    $response['message'] = 'Error de conexión a la base de datos';
+    echo json_encode($response);
+    exit;
+}
+
+$usuarioId = intval($_SESSION['usuario_id']);
+
+$stmt = mysqli_prepare($conn, "UPDATE usuario SET tutorial_visto = 1 WHERE id_usuario = ?");
+if (!$stmt) {
+    $response['message'] = 'Error al preparar la consulta';
+    echo json_encode($response);
+    mysqli_close($conn);
+    exit;
+}
+
+mysqli_stmt_bind_param($stmt, "i", $usuarioId);
+$success = mysqli_stmt_execute($stmt);
+
+if ($success) {
+    $_SESSION['tutorial_visto'] = 1;
+    $response['success'] = true;
+    $response['tutorial_visto'] = 1;
+} else {
+    $response['message'] = 'No se pudo actualizar el tutorial';
+}
+
+mysqli_stmt_close($stmt);
+mysqli_close($conn);
+
+echo json_encode($response);

--- a/scripts/regis_login/login/login.js
+++ b/scripts/regis_login/login/login.js
@@ -16,6 +16,13 @@ document.addEventListener("DOMContentLoaded", function () {
         }
     }
 
+    const storeTutorialStatus = (userId, status) => {
+        if (!userId) return;
+        const normalizedStatus = (status === 1 || status === '1' || status === true) ? '1' : '0';
+        localStorage.setItem(`tutorialVisto_${userId}`, normalizedStatus);
+        localStorage.removeItem(`tutorialShown_${userId}`);
+    };
+
     // Función para manejar la respuesta del login con Google
     function handleCredentialResponse(response) {
         function parseJwt(token) {
@@ -63,6 +70,8 @@ document.addEventListener("DOMContentLoaded", function () {
 
                 localStorage.setItem('id_empresa', data.id_empresa);
                 localStorage.setItem('empresa_nombre', data.empresa_nombre);
+
+                storeTutorialStatus(data.id, data.tutorial_visto ?? 0);
                 
                 // Normaliza la ruta antes de guardar en localStorage
                 let fotoPerfil = data.foto_perfil || '/images/profile.jpg';
@@ -143,6 +152,8 @@ document.addEventListener("DOMContentLoaded", function () {
 
                 localStorage.setItem('id_empresa',      data.id_empresa     ?? '');
                 localStorage.setItem('empresa_nombre',  data.empresa_nombre ?? '');
+
+                storeTutorialStatus(data.id_usuario, data.tutorial_visto ?? 0);
 
                 // Normaliza la ruta antes de guardar en localStorage
                 let fotoPerfil = data.foto_perfil || '/images/profile.jpg';

--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -102,6 +102,10 @@ img {
     border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+.sidebar-footer .btn + .btn {
+    margin-top: 12px;
+}
+
 /* Topbar */
 .topbar {
     background: var(--topbar-color);

--- a/u296155119_OptiStock (3).sql
+++ b/u296155119_OptiStock (3).sql
@@ -583,7 +583,8 @@ CREATE TABLE `usuario` (
   `suscripcion` tinyint(1) DEFAULT 0,
   `intentos_fallidos` int(11) DEFAULT 0,
   `ultimo_intento` datetime DEFAULT NULL,
-  `foto_perfil` varchar(255) DEFAULT 'images/profile.jpg'
+  `foto_perfil` varchar(255) DEFAULT 'images/profile.jpg',
+  `tutorial_visto` tinyint(1) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --


### PR DESCRIPTION
## Summary
- add a `tutorial_visto` flag to the `usuario` schema and surface its state through the login responses
- provide PHP endpoints to read and update the tutorial status backed by the database column
- update the main menu tutorial logic to consult the backend flag, persist completion remotely, and offer a button to replay the walkthrough

## Testing
- php -l scripts/php/get_tutorial_status.php
- php -l scripts/php/update_tutorial_status.php
- php -l scripts/php/login.php
- php -l scripts/php/login_google.php

------
https://chatgpt.com/codex/tasks/task_e_68d2065a9cf8832c916f9005192e0501