### PR TITLE
Improve QR scanning reliability and enlarge generated codes

### DIFF
--- a/scripts/php/guardar_productos.php
+++ b/scripts/php/guardar_productos.php
@@ -215,7 +215,7 @@ if ($method === 'POST' || $method === 'PUT') {
             mkdir($qrDir,0777,true);
         }
         $qrFile = $qrDir.$newId.'.png';
-        QRcode::png((string)$newId, $qrFile, QR_ECLEVEL_L, 4, 2);
+        QRcode::png((string)$newId, $qrFile, QR_ECLEVEL_L, 8, 2);
         $qrRel = 'images/qr/'.$newId.'.png';
 
         // Guardar ruta del QR en la base de datos


### PR DESCRIPTION
## Summary
- adjust the QR scanner to dynamically size the capture box, log scan noise, and restart gracefully after invalid codes for more reliable reads
- enlarge generated product QR images so they are easier to print and scan

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d57f738508832c85374ed5d5b4a15c