### PR TITLE
Show inventory movement options after scanning QR

### DIFF
--- a/pages/gest_inve/inventario_basico.html
+++ b/pages/gest_inve/inventario_basico.html
@@ -318,10 +318,48 @@
         </div>
         <div class="modal-body">
           <div id="qrReader" class="qr-reader d-none" role="img" aria-label="Visor para lectura de códigos QR"></div>
-          <p class="qr-helper">Coloca el código frente a la cámara para registrar el movimiento automáticamente.</p>
+          <p id="qrHelperText" class="qr-helper">
+            Coloca el código frente a la cámara para registrar el movimiento y confirma la operación antes de guardarla.
+          </p>
+          <div id="scanResult" class="scan-result d-none" aria-live="polite">
+            <div class="scan-product">
+              <h6 id="scanProductoNombre" class="scan-product__name">Producto seleccionado</h6>
+              <p id="scanProductoCodigo" class="scan-product__code">ID interno:</p>
+              <div class="scan-stock">
+                <span class="scan-stock__label">Stock actual</span>
+                <span id="scanProductoStock" class="scan-stock__value">0</span>
+              </div>
+            </div>
+            <div class="scan-form" role="group" aria-label="Formulario de movimientos">
+              <div class="mb-3">
+                <label for="scanMovimientoTipo" class="form-label">Tipo de movimiento</label>
+                <select id="scanMovimientoTipo" class="form-select" disabled>
+                  <option value="ingreso">Ingreso</option>
+                  <option value="egreso">Egreso</option>
+                </select>
+              </div>
+              <div class="mb-3">
+                <label for="scanMovimientoCantidad" class="form-label">Cantidad</label>
+                <input
+                  id="scanMovimientoCantidad"
+                  type="number"
+                  class="form-control"
+                  min="1"
+                  value="1"
+                  disabled
+                  inputmode="numeric"
+                />
+                <div id="scanCantidadAyuda" class="form-text">Escanea un producto para registrar su movimiento.</div>
+              </div>
+            </div>
+          </div>
         </div>
-        <div class="modal-footer border-0">
-          <button class="btn btn-outline-secondary" type="button" data-bs-dismiss="modal">Cerrar escáner</button>
+        <div class="modal-footer border-0 flex-column gap-2">
+          <div class="w-100 d-flex flex-column flex-sm-row gap-2">
+            <button id="scanRegistrar" class="btn btn-primary flex-fill" type="button" disabled>Registrar movimiento</button>
+            <button id="scanReintentar" class="btn btn-outline-secondary flex-fill" type="button">Escanear otro código</button>
+          </div>
+          <button class="btn btn-link text-decoration-none px-0" type="button" data-bs-dismiss="modal">Cerrar escáner</button>
         </div>
       </div>
     </div>

--- a/scripts/gest_inve/inventario_basico.js
+++ b/scripts/gest_inve/inventario_basico.js
@@ -189,6 +189,19 @@ prodCategoria?.addEventListener('change', () => {
   let qrScanner;
   const scanModalElement = document.getElementById('scanModal');
   const scanModal = scanModalElement ? new bootstrap.Modal(scanModalElement) : null;
+  const qrHelperText = document.getElementById('qrHelperText');
+  const textoAyudaEscaneoBase = 'Coloca el código frente a la cámara para registrar el movimiento y confirma la operación antes de guardarla.';
+  const textoAyudaProducto = 'Producto identificado. Selecciona el tipo de movimiento y confirma la cantidad antes de guardar.';
+  const scanResult = document.getElementById('scanResult');
+  const scanProdName = document.getElementById('scanProductoNombre');
+  const scanProdCodigo = document.getElementById('scanProductoCodigo');
+  const scanProdStock = document.getElementById('scanProductoStock');
+  const scanTipoSelect = document.getElementById('scanMovimientoTipo');
+  const scanCantidadInput = document.getElementById('scanMovimientoCantidad');
+  const scanCantidadHelp = document.getElementById('scanCantidadAyuda');
+  const scanRegistrar = document.getElementById('scanRegistrar');
+  const scanReintentar = document.getElementById('scanReintentar');
+  let scanProductoActual = null;
   let iniciarEscaneoPendiente = false;
   let scannerActivo = false;
   let preferredCameraId = null;
@@ -213,53 +226,414 @@ prodCategoria?.addEventListener('change', () => {
     }
   }
 
-  async function procesarLectura(decodedText) {
-    await detenerScanner();
-    qrReader?.classList.add('d-none');
-    scanModal?.hide();
+  const getScannerConfig = () => {
+    const readerWidth = qrReader?.offsetWidth || 0;
+    const maxBox = Math.min(420, Math.max(readerWidth - 40, 0));
+    const size = Math.max(260, maxBox || 320);
+    const config = {
+      fps: 10,
+      qrbox: { width: size, height: size },
+      aspectRatio: 1
+    };
+    if (window.Html5QrcodeSupportedFormats?.QR_CODE) {
+      config.formatsToSupport = [window.Html5QrcodeSupportedFormats.QR_CODE];
+    }
+    return config;
+  };
 
-    const productoId = parseInt(decodedText, 10);
-    if (!Number.isFinite(productoId)) {
-      showToast('Código QR no reconocido', 'error');
+  const obtenerStockNumerico = producto => {
+    if (!producto) {
+      return 0;
+    }
+    const raw = producto.stock ?? producto.stock_actual ?? 0;
+    const parsed = parseInt(raw, 10);
+    return Number.isFinite(parsed) ? parsed : 0;
+  };
+
+  function actualizarUIProductoEscaneado() {
+    if (!scanProductoActual) {
+      return;
+    }
+    if (scanProdName) {
+      scanProdName.textContent = scanProductoActual.nombre || `Producto #${scanProductoActual.id}`;
+    }
+    if (scanProdCodigo) {
+      scanProdCodigo.textContent = `ID interno: ${scanProductoActual.id}`;
+    }
+    if (scanProdStock) {
+      scanProdStock.textContent = String(obtenerStockNumerico(scanProductoActual));
+    }
+  }
+
+  function actualizarAyudaCantidad() {
+    if (!scanProductoActual) {
+      if (scanCantidadHelp) {
+        scanCantidadHelp.textContent = 'Escanea un producto para registrar su movimiento.';
+      }
+      if (scanRegistrar) {
+        scanRegistrar.disabled = true;
+      }
       return;
     }
 
-    try {
-      const movimientoPayload = { empresa_id: EMP_ID, producto_id: productoId, tipo: 'ingreso', cantidad: 1 };
-      const response = await fetch('../../scripts/php/guardar_movimientos.php', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(movimientoPayload)
-      });
-
-      if (!response.ok) {
-        throw new Error('Error al registrar movimiento');
-      }
-
-      const result = await response.json();
-      if (result?.success !== true) {
-        throw new Error(result?.error || 'Error al registrar movimiento');
-      }
-      await cargarProductos();
-      renderResumen();
-      showToast('Movimiento registrado', 'success');
-      document.dispatchEvent(new CustomEvent('movimientoRegistrado', {
-        detail: {
-          productoId: productoId,
-          tipo: movimientoPayload.tipo,
-          cantidad: movimientoPayload.cantidad,
-          stockActual: result.stock_actual ?? null
-        }
-      }));
-    } catch (error) {
-      console.error(error);
-      showToast('Error al registrar movimiento', 'error');
+    if (!scanTipoSelect || !scanCantidadInput) {
+      return;
     }
+
+    const tipo = scanTipoSelect.value === 'egreso' ? 'egreso' : 'ingreso';
+    const stockActual = obtenerStockNumerico(scanProductoActual);
+
+    scanCantidadInput.min = '1';
+
+    if (tipo === 'egreso') {
+      if (stockActual <= 0) {
+        scanCantidadInput.value = '1';
+        scanCantidadInput.disabled = true;
+        scanCantidadInput.removeAttribute('max');
+        if (scanCantidadHelp) {
+          scanCantidadHelp.textContent = 'No hay unidades disponibles para registrar un egreso.';
+        }
+        if (scanRegistrar) {
+          scanRegistrar.disabled = true;
+        }
+        return;
+      }
+
+      scanCantidadInput.disabled = false;
+      scanCantidadInput.max = String(stockActual);
+      const cantidadActual = parseInt(scanCantidadInput.value, 10);
+      if (Number.isFinite(cantidadActual) && cantidadActual > stockActual) {
+        scanCantidadInput.value = String(stockActual);
+      }
+      if (scanCantidadHelp) {
+        const plural = stockActual === 1 ? '' : 'es';
+        scanCantidadHelp.textContent = `Puedes retirar hasta ${stockActual} unidad${plural}.`;
+      }
+      if (scanRegistrar) {
+        scanRegistrar.disabled = false;
+      }
+      return;
+    }
+
+    scanCantidadInput.disabled = false;
+    scanCantidadInput.removeAttribute('max');
+    if (scanCantidadHelp) {
+      scanCantidadHelp.textContent = 'Las unidades ingresadas se sumarán al stock actual.';
+    }
+    if (scanRegistrar) {
+      scanRegistrar.disabled = false;
+    }
+  }
+
+  function prepararEscaneoUI() {
+    scanProductoActual = null;
+    scanResult?.classList.add('d-none');
+    qrReader?.classList.remove('d-none');
+    if (qrHelperText) {
+      qrHelperText.textContent = textoAyudaEscaneoBase;
+    }
+    if (scanProdName) {
+      scanProdName.textContent = 'Producto seleccionado';
+    }
+    if (scanProdCodigo) {
+      scanProdCodigo.textContent = 'ID interno:';
+    }
+    if (scanProdStock) {
+      scanProdStock.textContent = '0';
+    }
+    if (scanTipoSelect) {
+      scanTipoSelect.value = 'ingreso';
+      scanTipoSelect.disabled = true;
+    }
+    if (scanCantidadInput) {
+      scanCantidadInput.value = '1';
+      scanCantidadInput.disabled = true;
+      scanCantidadInput.removeAttribute('max');
+    }
+    if (scanCantidadHelp) {
+      scanCantidadHelp.textContent = 'Escanea un producto para registrar su movimiento.';
+    }
+    if (scanRegistrar) {
+      scanRegistrar.disabled = true;
+    }
+  }
+
+  function mostrarProductoEscaneado(producto) {
+    if (!producto) {
+      return;
+    }
+    scanProductoActual = producto;
+    qrReader?.classList.add('d-none');
+    scanResult?.classList.remove('d-none');
+    if (qrHelperText) {
+      qrHelperText.textContent = textoAyudaProducto;
+    }
+    if (scanTipoSelect) {
+      scanTipoSelect.disabled = false;
+      scanTipoSelect.value = 'ingreso';
+    }
+    if (scanCantidadInput) {
+      scanCantidadInput.disabled = false;
+      scanCantidadInput.value = '1';
+      scanCantidadInput.min = '1';
+      scanCantidadInput.removeAttribute('max');
+    }
+    if (scanRegistrar) {
+      scanRegistrar.disabled = false;
+    }
+    actualizarUIProductoEscaneado();
+    actualizarAyudaCantidad();
+  }
+
+  async function iniciarScanner() {
+    if (!scanModalElement?.classList.contains('show')) {
+      iniciarEscaneoPendiente = true;
+      return;
+    }
+    if (scannerActivo) {
+      return;
+    }
+    if (!qrReader) {
+      showToast('No se encontró el lector QR en la interfaz', 'error');
+      return;
+    }
+
+    if (!qrScanner) {
+      qrScanner = new Html5Qrcode('qrReader');
+    }
+
+    const config = getScannerConfig();
+
+    const startWithCamera = async cameraId => {
+      if (!cameraId) {
+        await qrScanner.start({ facingMode: { ideal: 'environment' } }, config, procesarLectura, handleScanError);
+        return;
+      }
+      await qrScanner.start({ deviceId: { exact: cameraId } }, config, procesarLectura, handleScanError);
+    };
+
+    try {
+      await startWithCamera(preferredCameraId);
+      scannerActivo = true;
+      iniciarEscaneoPendiente = false;
+    } catch (error) {
+      console.warn('No se pudo iniciar la cámara preferida, intentando alternativa.', error);
+      if (fallbackCameraId && fallbackCameraId !== preferredCameraId) {
+        try {
+          await startWithCamera(fallbackCameraId);
+          scannerActivo = true;
+          iniciarEscaneoPendiente = false;
+          return;
+        } catch (fallbackError) {
+          console.error('No se pudo iniciar la cámara alternativa', fallbackError);
+        }
+      }
+
+      qrReader?.classList.add('d-none');
+      scanModal?.hide();
+      showToast('Error al iniciar la cámara', 'error');
+    }
+  }
+
+  let lastScanError = '';
+  const handleScanError = errorMessage => {
+    if (typeof errorMessage !== 'string') {
+      return;
+    }
+    if (errorMessage === lastScanError) {
+      return;
+    }
+    lastScanError = errorMessage;
+    console.debug('Scanner detectó un error/ruido', errorMessage);
+  };
+
+  async function procesarLectura(decodedText) {
+    await detenerScanner();
+
+    const productoId = parseInt(String(decodedText).trim(), 10);
+
+    if (!Number.isFinite(productoId)) {
+      showToast('Código QR no reconocido', 'error');
+      prepararEscaneoUI();
+      try {
+        await iniciarScanner();
+      } catch (reinicioError) {
+        console.warn('No se pudo reiniciar el escáner tras un código inválido', reinicioError);
+      }
+      return;
+    }
+
+    let producto = productos.find(p => parseInt(p.id, 10) === productoId);
+
+    if (!producto) {
+      try {
+        const remoto = await fetchAPI(`${API.productos}?empresa_id=${EMP_ID}&id=${productoId}`);
+        if (remoto && remoto.id) {
+          producto = remoto;
+        }
+      } catch (consultaError) {
+        console.warn('No se pudo consultar el producto escaneado', consultaError);
+      }
+    }
+
+    if (!producto) {
+      showToast('El producto escaneado no se encuentra en el inventario.', 'error');
+      prepararEscaneoUI();
+      try {
+        await iniciarScanner();
+      } catch (reinicioError) {
+        console.warn('No se pudo reiniciar el escáner tras un producto desconocido', reinicioError);
+      }
+      return;
+    }
+
+    mostrarProductoEscaneado(producto);
   }
 
   scanModalElement?.addEventListener('hidden.bs.modal', async () => {
     await detenerScanner();
-    qrReader?.classList.add('d-none');
+    iniciarEscaneoPendiente = false;
+    prepararEscaneoUI();
+  });
+
+  scanTipoSelect?.addEventListener('change', () => {
+    actualizarAyudaCantidad();
+  });
+
+  scanCantidadInput?.addEventListener('input', () => {
+    if (!scanCantidadInput) {
+      return;
+    }
+    let value = parseInt(scanCantidadInput.value, 10);
+    if (!Number.isFinite(value) || value < 1) {
+      value = 1;
+    }
+    if (scanProductoActual && scanTipoSelect?.value === 'egreso') {
+      const stockActual = obtenerStockNumerico(scanProductoActual);
+      if (stockActual > 0 && value > stockActual) {
+        value = stockActual;
+      }
+    }
+    scanCantidadInput.value = String(value);
+    actualizarAyudaCantidad();
+  });
+
+  scanReintentar?.addEventListener('click', async () => {
+    await detenerScanner();
+    prepararEscaneoUI();
+    try {
+      await iniciarScanner();
+    } catch (error) {
+      console.warn('No se pudo reiniciar el escáner manualmente', error);
+    }
+  });
+
+  scanRegistrar?.addEventListener('click', async () => {
+    if (!scanProductoActual) {
+      showToast('Escanea un producto antes de registrar el movimiento.', 'error');
+      return;
+    }
+
+    const prodId = parseInt(scanProductoActual.id, 10);
+    if (!Number.isFinite(prodId)) {
+      showToast('El identificador del producto es inválido.', 'error');
+      return;
+    }
+
+    const tipo = scanTipoSelect?.value === 'egreso' ? 'egreso' : 'ingreso';
+    const cantidad = parseInt(scanCantidadInput?.value ?? '1', 10);
+
+    if (!Number.isFinite(cantidad) || cantidad <= 0) {
+      showToast('La cantidad debe ser mayor a cero.', 'error');
+      if (scanCantidadInput) {
+        scanCantidadInput.value = '1';
+      }
+      actualizarAyudaCantidad();
+      return;
+    }
+
+    const stockActual = obtenerStockNumerico(scanProductoActual);
+
+    if (tipo === 'egreso') {
+      if (stockActual <= 0) {
+        showToast('No hay unidades disponibles para egresar.', 'error');
+        actualizarAyudaCantidad();
+        return;
+      }
+      if (cantidad > stockActual) {
+        showToast('La cantidad no puede exceder el stock disponible.', 'error');
+        if (scanCantidadInput) {
+          scanCantidadInput.value = String(stockActual);
+        }
+        actualizarAyudaCantidad();
+        return;
+      }
+    }
+
+    try {
+      if (scanRegistrar) {
+        scanRegistrar.disabled = true;
+      }
+
+      const movimientoPayload = {
+        empresa_id: EMP_ID,
+        producto_id: prodId,
+        tipo,
+        cantidad
+      };
+
+      const resultado = await fetchAPI(API.movimiento, 'POST', movimientoPayload);
+      if (resultado?.success !== true) {
+        throw new Error(resultado?.error || 'No se pudo registrar el movimiento');
+      }
+
+      const nuevoStock = (() => {
+        const remoto = parseInt(resultado.stock_actual, 10);
+        if (Number.isFinite(remoto)) {
+          return remoto;
+        }
+        return tipo === 'ingreso' ? stockActual + cantidad : stockActual - cantidad;
+      })();
+
+      scanProductoActual.stock = nuevoStock;
+
+      if (scanCantidadInput) {
+        scanCantidadInput.value = '1';
+      }
+      if (qrHelperText) {
+        qrHelperText.textContent = 'Movimiento registrado. Puedes escanear otro código o ajustar el mismo producto.';
+      }
+
+      await cargarProductos();
+      renderResumen();
+
+      const productoActualizado = productos.find(p => parseInt(p.id, 10) === prodId);
+      if (productoActualizado) {
+        scanProductoActual = productoActualizado;
+      }
+
+      actualizarUIProductoEscaneado();
+      actualizarAyudaCantidad();
+
+      document.dispatchEvent(new CustomEvent('movimientoRegistrado', {
+        detail: {
+          productoId: prodId,
+          tipo,
+          cantidad,
+          stockActual: nuevoStock
+        }
+      }));
+
+      showToast(`Movimiento ${tipo} registrado`, 'success');
+    } catch (error) {
+      console.error(error);
+      showToast('Error al registrar movimiento: ' + (error?.message || 'desconocido'), 'error');
+    } finally {
+      if (scanRegistrar) {
+        scanRegistrar.disabled = false;
+      }
+      actualizarAyudaCantidad();
+    }
   });
 
 function poblarSelectProductos() {
@@ -322,39 +696,12 @@ btnScanQR?.addEventListener('click', async () => {
 });
 
 scanModalElement?.addEventListener('shown.bs.modal', async () => {
-  if (!iniciarEscaneoPendiente) return;
+  prepararEscaneoUI();
   iniciarEscaneoPendiente = false;
-
-  if (!qrScanner) {
-    qrScanner = new Html5Qrcode('qrReader');
-  }
-
-  const startWithCamera = async cameraId => {
-    if (!cameraId) {
-      await qrScanner.start({ facingMode: { ideal: 'environment' } }, { fps: 10, qrbox: 250 }, procesarLectura);
-      return;
-    }
-    await qrScanner.start({ deviceId: { exact: cameraId } }, { fps: 10, qrbox: 250 }, procesarLectura);
-  };
-
   try {
-    await startWithCamera(preferredCameraId);
-    scannerActivo = true;
+    await iniciarScanner();
   } catch (error) {
-    console.warn('No se pudo iniciar la cámara preferida, intentando alternativa.', error);
-    if (fallbackCameraId && fallbackCameraId !== preferredCameraId) {
-      try {
-        await startWithCamera(fallbackCameraId);
-        scannerActivo = true;
-        return;
-      } catch (fallbackError) {
-        console.error('No se pudo iniciar la cámara alternativa', fallbackError);
-      }
-    }
-
-    qrReader?.classList.add('d-none');
-    scanModal?.hide();
-    showToast('Error al iniciar la cámara', 'error');
+    console.warn('No se pudo iniciar el escáner al abrir el modal', error);
   }
 });
 

--- a/scripts/php/guardar_productos.php
+++ b/scripts/php/guardar_productos.php
@@ -215,7 +215,7 @@ if ($method === 'POST' || $method === 'PUT') {
             mkdir($qrDir,0777,true);
         }
         $qrFile = $qrDir.$newId.'.png';
-        QRcode::png((string)$newId, $qrFile, QR_ECLEVEL_L, 4, 2);
+        QRcode::png((string)$newId, $qrFile, QR_ECLEVEL_L, 8, 2);
         $qrRel = 'images/qr/'.$newId.'.png';
 
         // Guardar ruta del QR en la base de datos

--- a/styles/gest_inve/inventario_basico.css
+++ b/styles/gest_inve/inventario_basico.css
@@ -533,6 +533,79 @@ img {
   text-align: center;
 }
 
+.scan-result {
+  margin-top: 1.5rem;
+  padding: 1.25rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+  background: var(--primary-surface-extra);
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 576px) {
+  .scan-result {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: flex-start;
+  }
+}
+
+.scan-product {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.scan-product__name {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.scan-product__code {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted-color);
+}
+
+.scan-stock {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.scan-stock__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted-color);
+  font-weight: 600;
+}
+
+.scan-stock__value {
+  font-size: 1.45rem;
+  font-weight: 700;
+  color: var(--primary-color);
+}
+
+.scan-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.scan-form .form-label {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.scan-form .form-text {
+  color: var(--muted-color);
+}
+
 .toast-message {
   position: fixed;
   bottom: 1.5rem;


### PR DESCRIPTION
## Summary
- display scanned product details inside the QR modal along with controls to choose movimiento tipo and cantidad
- add styling for the scanned product panel and helper text within the scanner modal
- refactor the QR scanner workflow to pause on read, fetch product data, validate egresos against stock, and register movimientos through the existing API

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d57f738508832c85374ed5d5b4a15c