### PR TITLE
Add QR scanner workflow to main menu flash actions

### DIFF
--- a/pages/main_menu/main_menu.html
+++ b/pages/main_menu/main_menu.html
@@ -9,6 +9,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="../../styles/main_menu/main_menu.css">
 </head>
 <body>
@@ -363,7 +364,73 @@
   </div>
 </div>
 
+  <!-- Modal escáner rápido -->
+  <div class="modal fade" id="flashScanModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+      <div class="modal-content qr-modal shadow-lg">
+        <div class="modal-header border-0">
+          <div>
+            <span class="modal-eyebrow">Escáner</span>
+            <h5 class="modal-title fw-bold">Escanear código QR</h5>
+          </div>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+        </div>
+        <div class="modal-body">
+          <div id="flashQrReader" class="qr-reader d-none" role="img" aria-label="Visor para lectura de códigos QR"></div>
+          <p id="flashQrHelperText" class="qr-helper">
+            Coloca el código frente a la cámara para registrar el movimiento y confirma la operación antes de guardarla.
+          </p>
+          <div id="flashScanResult" class="scan-result d-none" aria-live="polite">
+            <div class="scan-product">
+              <h6 id="flashScanProductoNombre" class="scan-product__name">Producto seleccionado</h6>
+              <p id="flashScanProductoCodigo" class="scan-product__code">ID interno:</p>
+              <div class="scan-stock">
+                <span class="scan-stock__label">Stock actual</span>
+                <span id="flashScanProductoStock" class="scan-stock__value">0</span>
+              </div>
+            </div>
+            <div class="scan-form" role="group" aria-label="Formulario de movimientos">
+              <div class="mb-3">
+                <label for="flashScanMovimientoTipo" class="form-label">Tipo de movimiento</label>
+                <select id="flashScanMovimientoTipo" class="form-select" disabled>
+                  <option value="ingreso">Ingreso</option>
+                  <option value="egreso">Egreso</option>
+                </select>
+              </div>
+              <div class="mb-3">
+                <label for="flashScanMovimientoCantidad" class="form-label">Cantidad</label>
+                <input
+                  id="flashScanMovimientoCantidad"
+                  type="number"
+                  class="form-control"
+                  min="1"
+                  step="1"
+                  placeholder="1"
+                  disabled
+                  inputmode="numeric"
+                  pattern="[0-9]*"
+                />
+                <div id="flashScanCantidadAyuda" class="form-text">Escanea un producto para registrar su movimiento.</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer border-0 flex-column gap-2">
+          <div class="w-100 d-flex flex-column flex-sm-row gap-2">
+            <button id="flashScanRegistrar" class="btn btn-primary flex-fill" type="button" disabled>Registrar movimiento</button>
+            <button id="flashScanReintentar" class="btn btn-outline-secondary flex-fill" type="button">Escanear otro código</button>
+          </div>
+          <button class="btn btn-link text-decoration-none px-0" type="button" data-bs-dismiss="modal">Cerrar escáner</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="toast-container position-fixed top-0 end-0 p-3" id="flashToastStack" aria-live="polite" aria-atomic="true"></div>
+
     <script src="../../scripts/theme.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://unpkg.com/html5-qrcode@2.3.8/html5-qrcode.min.js"></script>
     <script src="../../scripts/main_menu/main_menu.js"></script>
 </body>
 </html>

--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -1470,6 +1470,124 @@ img {
     color: #fff;
 }
 
+/* QR scanner modal */
+.modal-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.3rem 0.7rem;
+    border-radius: var(--radius-pill);
+    background: var(--primary-surface);
+    color: var(--primary-color);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 600;
+}
+
+.qr-modal {
+    background: var(--card-bg);
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--border-color);
+}
+
+.qr-reader {
+    width: 100%;
+    min-height: 320px;
+    border-radius: var(--radius-md);
+    background: repeating-linear-gradient(
+            135deg,
+            rgba(255, 111, 145, 0.08),
+            rgba(255, 111, 145, 0.08) 12px,
+            rgba(15, 180, 212, 0.08) 12px,
+            rgba(15, 180, 212, 0.08) 24px
+        ),
+        #fff;
+    border: 1px dashed rgba(255, 111, 145, 0.35);
+    display: grid;
+    place-items: center;
+}
+
+.qr-helper {
+    margin: 0.75rem 0 0;
+    font-size: 0.85rem;
+    color: var(--muted-color);
+    text-align: center;
+}
+
+.scan-result {
+    margin-top: 1.5rem;
+    padding: 1.25rem;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border-color);
+    background: var(--primary-surface-extra);
+    display: grid;
+    gap: 1rem;
+}
+
+@media (min-width: 576px) {
+    .scan-result {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        align-items: flex-start;
+    }
+}
+
+.scan-product {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.scan-product__name {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-color);
+}
+
+.scan-product__code {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--muted-color);
+}
+
+.scan-stock {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+
+.scan-stock__label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--muted-color);
+    font-weight: 600;
+}
+
+.scan-stock__value {
+    font-size: 1.45rem;
+    font-weight: 700;
+    color: var(--primary-color);
+}
+
+.scan-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.scan-form .form-label {
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.scan-form .form-text {
+    color: var(--muted-color);
+}
+
 /* Modal */
 .modal-overlay,
 .color-modal {


### PR DESCRIPTION
## Summary
- add Bootstrap, html5-qrcode and a reusable QR scanner modal to the main menu page
- wire the flash action buttons to a camera workflow that mirrors the inventory QR scanner logic
- extend the main menu styles to theme the scanner modal and product summary

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d5923e94a8832c8a29178798f82fc5