### PR TITLE
Simplify flash scanner movement selection

### DIFF
--- a/pages/main_menu/main_menu.html
+++ b/pages/main_menu/main_menu.html
@@ -9,6 +9,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="../../styles/main_menu/main_menu.css">
 </head>
 <body>
@@ -363,7 +364,74 @@
   </div>
 </div>
 
+  <!-- Modal escáner rápido -->
+  <div class="modal fade" id="flashScanModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+      <div class="modal-content qr-modal shadow-lg">
+        <div class="modal-header border-0">
+          <div>
+            <span class="modal-eyebrow">Escáner</span>
+            <h5 class="modal-title fw-bold">Escanear código QR</h5>
+          </div>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+        </div>
+        <div class="modal-body">
+          <div id="flashQrReader" class="qr-reader d-none" role="img" aria-label="Visor para lectura de códigos QR"></div>
+          <p id="flashQrHelperText" class="qr-helper">
+            Coloca el código frente a la cámara para registrar el movimiento y confirma la operación antes de guardarla.
+          </p>
+          <div id="flashScanResult" class="scan-result d-none" aria-live="polite">
+            <div class="scan-product">
+              <h6 id="flashScanProductoNombre" class="scan-product__name">Producto seleccionado</h6>
+              <p id="flashScanProductoCodigo" class="scan-product__code">ID interno:</p>
+              <div class="scan-stock">
+                <span class="scan-stock__label">Stock actual</span>
+                <span id="flashScanProductoStock" class="scan-stock__value">0</span>
+              </div>
+            </div>
+            <div class="scan-form" role="group" aria-label="Formulario de movimientos">
+              <div class="mb-3">
+                <label class="form-label d-block" for="flashScanMovimientoResumen">Movimiento seleccionado</label>
+                <span
+                  id="flashScanMovimientoResumen"
+                  class="badge rounded-pill bg-success"
+                  aria-live="polite"
+                >Ingreso</span>
+              </div>
+              <div class="mb-3">
+                <label for="flashScanMovimientoCantidad" class="form-label">Cantidad</label>
+                <input
+                  id="flashScanMovimientoCantidad"
+                  type="number"
+                  class="form-control"
+                  min="1"
+                  step="1"
+                  placeholder="1"
+                  disabled
+                  inputmode="numeric"
+                  pattern="[0-9]*"
+                />
+                <div id="flashScanCantidadAyuda" class="form-text">Escanea un producto para registrar su movimiento.</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer border-0 flex-column gap-2">
+          <div class="w-100 d-flex flex-column flex-sm-row gap-2">
+            <button id="flashScanRegistrar" class="btn btn-primary flex-fill" type="button" disabled>Registrar movimiento</button>
+            <button id="flashScanReintentar" class="btn btn-outline-secondary flex-fill" type="button">Escanear otro código</button>
+          </div>
+          <button class="btn btn-link text-decoration-none px-0" type="button" data-bs-dismiss="modal">Cerrar escáner</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="toast-container position-fixed top-0 end-0 p-3" id="flashToastStack" aria-live="polite" aria-atomic="true"></div>
+
     <script src="../../scripts/theme.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://unpkg.com/html5-qrcode@2.3.8/html5-qrcode.min.js"></script>
     <script src="../../scripts/main_menu/main_menu.js"></script>
 </body>
 </html>

--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -1492,13 +1492,601 @@ if (notificationViewAll) {
     });
 }
 
-// Quick actions buttons
-document.getElementById('ingresoFlashBtn').addEventListener('click', function() {
-    alert('Función Ingreso Flash activada\n\nEscanea el código del producto para registrar su ingreso al almacén');
+// Quick actions QR scanner
+const ingresoFlashBtn = document.getElementById('ingresoFlashBtn');
+const egresoFlashBtn = document.getElementById('egresoFlashBtn');
+const flashScanModalElement = document.getElementById('flashScanModal');
+const flashScanModal = flashScanModalElement && typeof bootstrap !== 'undefined'
+    ? new bootstrap.Modal(flashScanModalElement)
+    : null;
+const flashQrReader = document.getElementById('flashQrReader');
+const flashQrHelperText = document.getElementById('flashQrHelperText');
+const flashScanResult = document.getElementById('flashScanResult');
+const flashScanProdName = document.getElementById('flashScanProductoNombre');
+const flashScanProdCodigo = document.getElementById('flashScanProductoCodigo');
+const flashScanProdStock = document.getElementById('flashScanProductoStock');
+const flashScanTipoDisplay = document.getElementById('flashScanMovimientoResumen');
+const flashScanCantidadInput = document.getElementById('flashScanMovimientoCantidad');
+const flashScanCantidadHelp = document.getElementById('flashScanCantidadAyuda');
+const flashScanRegistrar = document.getElementById('flashScanRegistrar');
+const flashScanReintentar = document.getElementById('flashScanReintentar');
+const flashToastStack = document.getElementById('flashToastStack');
+
+const FLASH_API = {
+    productos: '../../scripts/php/guardar_productos.php',
+    movimiento: '../../scripts/php/guardar_movimientos.php'
+};
+
+const FLASH_EMPRESA_ID = parseInt(localStorage.getItem('id_empresa'), 10) || 0;
+const FLASH_TEXTOS = {
+    base: 'Coloca el código frente a la cámara para registrar el movimiento y confirma la operación antes de guardarla.',
+    producto: 'Producto identificado. Confirma la cantidad antes de guardar el movimiento.'
+};
+
+let flashQrScanner = null;
+let flashScannerActivo = false;
+let flashPreferredCameraId = null;
+let flashFallbackCameraId = null;
+let flashProductoActual = null;
+let flashMovimientoForzado = 'ingreso';
+let flashIniciarEscaneoPendiente = false;
+let flashAvisoCantidadCero = false;
+let flashLastScanError = '';
+
+function flashActualizarMovimientoUI() {
+    if (!flashScanTipoDisplay) {
+        return;
+    }
+
+    const esEgreso = flashMovimientoForzado === 'egreso';
+    flashScanTipoDisplay.textContent = esEgreso ? 'Egreso' : 'Ingreso';
+    flashScanTipoDisplay.classList.toggle('bg-danger', esEgreso);
+    flashScanTipoDisplay.classList.toggle('bg-success', !esEgreso);
+}
+
+function flashShowToast(message, type = 'info') {
+    if (!flashToastStack || typeof bootstrap === 'undefined') {
+        alert(message);
+        return;
+    }
+
+    const tipoClase = type === 'success'
+        ? 'text-bg-success'
+        : type === 'error'
+            ? 'text-bg-danger'
+            : 'text-bg-primary';
+
+    const toast = document.createElement('div');
+    toast.className = `toast align-items-center ${tipoClase} border-0 shadow`;
+    toast.setAttribute('role', 'status');
+    toast.setAttribute('aria-live', 'polite');
+    toast.innerHTML = `
+        <div class="d-flex">
+            <div class="toast-body">${message}</div>
+            <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Cerrar"></button>
+        </div>
+    `;
+
+    flashToastStack.appendChild(toast);
+    const delay = type === 'error' ? 3600 : 2600;
+    const toastInstance = new bootstrap.Toast(toast, { delay });
+    toastInstance.show();
+    toast.addEventListener('hidden.bs.toast', () => toast.remove());
+}
+
+async function flashFetchJSON(url, method = 'GET', payload) {
+    const options = { method };
+    if (payload) {
+        options.headers = { 'Content-Type': 'application/json' };
+        options.body = JSON.stringify(payload);
+    }
+
+    const response = await fetch(url, options);
+    const text = await response.text();
+    let data;
+    try {
+        data = text ? JSON.parse(text) : {};
+    } catch (error) {
+        throw new Error(`Respuesta no válida del servidor (${response.status})`);
+    }
+
+    if (!response.ok) {
+        const mensaje = data?.error || `Error HTTP ${response.status}`;
+        throw new Error(mensaje);
+    }
+
+    return data;
+}
+
+function flashObtenerStock(producto) {
+    if (!producto) return 0;
+    const raw = producto.stock ?? producto.stock_actual ?? 0;
+    const parsed = parseInt(raw, 10);
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function flashActualizarUIProducto() {
+    if (!flashProductoActual) return;
+    if (flashScanProdName) {
+        flashScanProdName.textContent = flashProductoActual.nombre || `Producto #${flashProductoActual.id}`;
+    }
+    if (flashScanProdCodigo) {
+        flashScanProdCodigo.textContent = `ID interno: ${flashProductoActual.id}`;
+    }
+    if (flashScanProdStock) {
+        flashScanProdStock.textContent = String(flashObtenerStock(flashProductoActual));
+    }
+}
+
+function flashActualizarAyudaCantidad() {
+    if (!flashProductoActual) {
+        if (flashScanCantidadHelp) {
+            flashScanCantidadHelp.textContent = 'Escanea un producto para registrar su movimiento.';
+        }
+        if (flashScanRegistrar) {
+            flashScanRegistrar.disabled = true;
+        }
+        return;
+    }
+
+    if (!flashScanCantidadInput) return;
+
+    const tipo = flashMovimientoForzado === 'egreso' ? 'egreso' : 'ingreso';
+    const stockActual = flashObtenerStock(flashProductoActual);
+    const rawCantidad = flashScanCantidadInput.value.trim();
+    const cantidad = rawCantidad === '' ? 1 : parseInt(rawCantidad, 10);
+
+    flashScanCantidadInput.min = '1';
+
+    if (tipo === 'egreso') {
+        if (stockActual <= 0) {
+            flashScanCantidadInput.value = '';
+            flashScanCantidadInput.disabled = true;
+            flashScanCantidadInput.removeAttribute('max');
+            if (flashScanCantidadHelp) {
+                flashScanCantidadHelp.textContent = 'No hay unidades disponibles para registrar un egreso.';
+            }
+            if (flashScanRegistrar) {
+                flashScanRegistrar.disabled = true;
+            }
+            return;
+        }
+
+        flashScanCantidadInput.disabled = false;
+        flashScanCantidadInput.max = String(stockActual);
+        if (rawCantidad !== '' && Number.isFinite(cantidad) && cantidad > stockActual) {
+            flashScanCantidadInput.value = String(stockActual);
+        }
+        if (flashScanCantidadHelp) {
+            const plural = stockActual === 1 ? '' : 'es';
+            flashScanCantidadHelp.textContent = `Puedes retirar hasta ${stockActual} unidad${plural}.`;
+        }
+        if (flashScanRegistrar) {
+            flashScanRegistrar.disabled = false;
+        }
+        return;
+    }
+
+    flashScanCantidadInput.disabled = false;
+    flashScanCantidadInput.removeAttribute('max');
+    if (flashScanCantidadHelp) {
+        flashScanCantidadHelp.textContent = 'Las unidades ingresadas se sumarán al stock actual.';
+    }
+    if (flashScanRegistrar) {
+        flashScanRegistrar.disabled = false;
+    }
+}
+
+function flashPrepararUI() {
+    flashProductoActual = null;
+    flashQrReader?.classList.remove('d-none');
+    flashScanResult?.classList.add('d-none');
+    if (flashQrHelperText) {
+        flashQrHelperText.textContent = FLASH_TEXTOS.base;
+    }
+    if (flashScanProdName) {
+        flashScanProdName.textContent = 'Producto seleccionado';
+    }
+    if (flashScanProdCodigo) {
+        flashScanProdCodigo.textContent = 'ID interno:';
+    }
+    if (flashScanProdStock) {
+        flashScanProdStock.textContent = '0';
+    }
+    flashActualizarMovimientoUI();
+    if (flashScanCantidadInput) {
+        flashScanCantidadInput.value = '';
+        flashScanCantidadInput.disabled = true;
+        flashScanCantidadInput.removeAttribute('max');
+    }
+    flashAvisoCantidadCero = false;
+    if (flashScanCantidadHelp) {
+        flashScanCantidadHelp.textContent = 'Escanea un producto para registrar su movimiento.';
+    }
+    if (flashScanRegistrar) {
+        flashScanRegistrar.disabled = true;
+    }
+}
+
+function flashMostrarProducto(producto) {
+    flashProductoActual = producto;
+    flashQrReader?.classList.add('d-none');
+    flashScanResult?.classList.remove('d-none');
+    if (flashQrHelperText) {
+        flashQrHelperText.textContent = FLASH_TEXTOS.producto;
+    }
+    flashActualizarMovimientoUI();
+    if (flashScanCantidadInput) {
+        flashScanCantidadInput.disabled = false;
+        flashScanCantidadInput.value = '';
+        flashScanCantidadInput.min = '1';
+        flashScanCantidadInput.removeAttribute('max');
+    }
+    flashAvisoCantidadCero = false;
+    if (flashScanRegistrar) {
+        flashScanRegistrar.disabled = false;
+    }
+    flashActualizarUIProducto();
+    flashActualizarAyudaCantidad();
+}
+
+async function flashDetenerScanner() {
+    if (!flashQrScanner || !flashScannerActivo) return;
+
+    try {
+        await flashQrScanner.stop();
+    } catch (error) {
+        console.warn('No se pudo detener el escáner', error);
+    } finally {
+        flashScannerActivo = false;
+    }
+
+    try {
+        await flashQrScanner.clear();
+    } catch (error) {
+        console.debug('No se pudo limpiar el contenedor del escáner', error);
+    }
+}
+
+function flashGetScannerConfig() {
+    const readerWidth = flashQrReader?.offsetWidth || 0;
+    const maxBox = Math.min(420, Math.max(readerWidth - 40, 0));
+    const size = Math.max(260, maxBox || 320);
+    const config = {
+        fps: 10,
+        qrbox: { width: size, height: size },
+        aspectRatio: 1
+    };
+    if (window.Html5QrcodeSupportedFormats?.QR_CODE) {
+        config.formatsToSupport = [window.Html5QrcodeSupportedFormats.QR_CODE];
+    }
+    return config;
+}
+
+async function flashIniciarScanner() {
+    if (!flashScanModalElement?.classList.contains('show')) {
+        flashIniciarEscaneoPendiente = true;
+        return;
+    }
+    if (flashScannerActivo) {
+        return;
+    }
+    if (!flashQrReader) {
+        flashShowToast('No se encontró el lector QR en la interfaz', 'error');
+        return;
+    }
+    if (typeof Html5Qrcode === 'undefined') {
+        flashShowToast('El lector QR no está disponible en este navegador.', 'error');
+        return;
+    }
+
+    if (!flashQrScanner) {
+        flashQrScanner = new Html5Qrcode('flashQrReader');
+    }
+
+    const config = flashGetScannerConfig();
+
+    const startWithCamera = async cameraId => {
+        if (!cameraId) {
+            await flashQrScanner.start({ facingMode: { ideal: 'environment' } }, config, flashProcesarLectura, flashHandleScanError);
+            return;
+        }
+        await flashQrScanner.start({ deviceId: { exact: cameraId } }, config, flashProcesarLectura, flashHandleScanError);
+    };
+
+    try {
+        await startWithCamera(flashPreferredCameraId);
+        flashScannerActivo = true;
+        flashIniciarEscaneoPendiente = false;
+    } catch (error) {
+        console.warn('No se pudo iniciar la cámara preferida, intentando alternativa.', error);
+        if (flashFallbackCameraId && flashFallbackCameraId !== flashPreferredCameraId) {
+            try {
+                await startWithCamera(flashFallbackCameraId);
+                flashScannerActivo = true;
+                flashIniciarEscaneoPendiente = false;
+                return;
+            } catch (fallbackError) {
+                console.error('No se pudo iniciar la cámara alternativa', fallbackError);
+            }
+        }
+
+        flashQrReader?.classList.add('d-none');
+        flashScanModal?.hide();
+        flashShowToast('Error al iniciar la cámara', 'error');
+    }
+}
+
+function flashHandleScanError(errorMessage) {
+    if (typeof errorMessage !== 'string') return;
+    if (errorMessage === flashLastScanError) return;
+    flashLastScanError = errorMessage;
+}
+
+async function flashProcesarLectura(decodedText) {
+    await flashDetenerScanner();
+
+    const productoId = parseInt(String(decodedText).trim(), 10);
+    if (!Number.isFinite(productoId)) {
+        flashShowToast('Código QR no reconocido', 'error');
+        flashPrepararUI();
+        try {
+            await flashIniciarScanner();
+        } catch (error) {
+            console.warn('No se pudo reiniciar el escáner tras un código inválido', error);
+        }
+        return;
+    }
+
+    let producto = null;
+    try {
+        producto = await flashFetchJSON(`${FLASH_API.productos}?empresa_id=${FLASH_EMPRESA_ID}&id=${productoId}`);
+    } catch (error) {
+        console.warn('No se pudo obtener el producto escaneado', error);
+    }
+
+    if (!producto || !producto.id) {
+        flashShowToast('El producto escaneado no se encuentra en el inventario.', 'error');
+        flashPrepararUI();
+        try {
+            await flashIniciarScanner();
+        } catch (reinicioError) {
+            console.warn('No se pudo reiniciar el escáner tras un producto desconocido', reinicioError);
+        }
+        return;
+    }
+
+    flashMostrarProducto(producto);
+}
+
+async function flashPrepararCamara() {
+    if (!navigator.mediaDevices || !window.isSecureContext) {
+        flashShowToast('La cámara no es compatible o se requiere HTTPS/localhost', 'error');
+        return false;
+    }
+
+    let testStream;
+    try {
+        testStream = await navigator.mediaDevices.getUserMedia({ video: true });
+    } catch (error) {
+        console.error('No se pudo obtener permiso para la cámara', error);
+        flashShowToast('Permiso de cámara denegado o no disponible', 'error');
+        return false;
+    } finally {
+        if (testStream) {
+            testStream.getTracks().forEach(track => track.stop());
+        }
+    }
+
+    let cameras = [];
+    if (typeof Html5Qrcode !== 'undefined') {
+        try {
+            cameras = await Html5Qrcode.getCameras();
+        } catch (error) {
+            console.warn('No se pudieron enumerar las cámaras disponibles', error);
+            cameras = [];
+        }
+    }
+
+    if (Array.isArray(cameras) && cameras.length > 0) {
+        const backRegex = /(back|rear|environment)/i;
+        const backCamera = cameras.find(cam => backRegex.test(cam.label));
+        flashPreferredCameraId = (backCamera || cameras[0]).id;
+        const secondary = cameras.find(cam => cam.id !== flashPreferredCameraId);
+        flashFallbackCameraId = secondary ? secondary.id : null;
+    } else {
+        flashPreferredCameraId = null;
+        flashFallbackCameraId = null;
+    }
+
+    return true;
+}
+
+async function flashAbrirScanner(tipo) {
+    if (!flashScanModal) {
+        flashShowToast('No se pudo abrir el escáner QR', 'error');
+        return;
+    }
+    if (!FLASH_EMPRESA_ID) {
+        flashShowToast('Registra una empresa antes de usar el escáner QR.', 'error');
+        return;
+    }
+
+    const ok = await flashPrepararCamara();
+    if (!ok) {
+        return;
+    }
+
+    flashMovimientoForzado = tipo === 'egreso' ? 'egreso' : 'ingreso';
+    flashActualizarMovimientoUI();
+    flashPrepararUI();
+    flashIniciarEscaneoPendiente = true;
+    flashScanModal.show();
+}
+
+flashScanModalElement?.addEventListener('shown.bs.modal', async () => {
+    flashPrepararUI();
+    flashIniciarEscaneoPendiente = false;
+    try {
+        await flashIniciarScanner();
+    } catch (error) {
+        console.warn('No se pudo iniciar el escáner al abrir el modal', error);
+    }
 });
 
-document.getElementById('egresoFlashBtn').addEventListener('click', function() {
-    alert('Función Egreso Flash activada\n\nEscanea el código del producto para registrar su salida del almacén');
+flashScanModalElement?.addEventListener('hidden.bs.modal', async () => {
+    await flashDetenerScanner();
+    flashIniciarEscaneoPendiente = false;
+    flashPrepararUI();
+});
+
+flashScanCantidadInput?.addEventListener('input', () => {
+    if (!flashScanCantidadInput) return;
+
+    const raw = flashScanCantidadInput.value.trim();
+
+    if (raw === '') {
+        flashAvisoCantidadCero = false;
+        flashActualizarAyudaCantidad();
+        return;
+    }
+
+    let value = parseInt(raw, 10);
+
+    if (!Number.isFinite(value)) {
+        flashScanCantidadInput.value = '';
+        flashActualizarAyudaCantidad();
+        return;
+    }
+
+    if (value === 0) {
+        if (!flashAvisoCantidadCero) {
+            flashShowToast('La cantidad debe ser mayor a cero.', 'error');
+            flashAvisoCantidadCero = true;
+        }
+        flashScanCantidadInput.value = '';
+        flashActualizarAyudaCantidad();
+        return;
+    }
+
+    flashAvisoCantidadCero = false;
+
+    if (value < 0) {
+        flashScanCantidadInput.value = '';
+        flashActualizarAyudaCantidad();
+        return;
+    }
+
+    if (flashProductoActual && flashMovimientoForzado === 'egreso') {
+        const stockActual = flashObtenerStock(flashProductoActual);
+        if (stockActual > 0 && value > stockActual) {
+            value = stockActual;
+        }
+    }
+
+    flashScanCantidadInput.value = String(value);
+    flashActualizarAyudaCantidad();
+});
+
+flashScanReintentar?.addEventListener('click', async () => {
+    await flashDetenerScanner();
+    flashPrepararUI();
+    try {
+        await flashIniciarScanner();
+    } catch (error) {
+        console.warn('No se pudo reiniciar el escáner manualmente', error);
+    }
+});
+
+flashScanRegistrar?.addEventListener('click', async () => {
+    if (!flashProductoActual) {
+        flashShowToast('Escanea un producto antes de registrar el movimiento.', 'error');
+        return;
+    }
+
+    const prodId = parseInt(flashProductoActual.id, 10);
+    if (!Number.isFinite(prodId)) {
+        flashShowToast('El identificador del producto es inválido.', 'error');
+        return;
+    }
+
+    const tipo = flashMovimientoForzado === 'egreso' ? 'egreso' : 'ingreso';
+    const rawCantidad = flashScanCantidadInput?.value?.trim() ?? '';
+    const cantidad = rawCantidad === '' ? 1 : parseInt(rawCantidad, 10);
+
+    if (!Number.isFinite(cantidad) || cantidad <= 0) {
+        flashShowToast('La cantidad debe ser mayor a cero.', 'error');
+        if (flashScanCantidadInput) {
+            flashScanCantidadInput.value = '';
+        }
+        flashActualizarAyudaCantidad();
+        return;
+    }
+
+    const stockActual = flashObtenerStock(flashProductoActual);
+
+    if (tipo === 'egreso') {
+        if (stockActual <= 0) {
+            flashShowToast('No hay unidades disponibles para egresar.', 'error');
+            flashActualizarAyudaCantidad();
+            return;
+        }
+        if (cantidad > stockActual) {
+            flashShowToast('La cantidad no puede exceder el stock disponible.', 'error');
+            if (flashScanCantidadInput) {
+                flashScanCantidadInput.value = String(stockActual);
+            }
+            flashActualizarAyudaCantidad();
+            return;
+        }
+    }
+
+    try {
+        if (flashScanRegistrar) {
+            flashScanRegistrar.disabled = true;
+        }
+
+        const payload = {
+            empresa_id: FLASH_EMPRESA_ID,
+            producto_id: prodId,
+            tipo,
+            cantidad
+        };
+
+        const resultado = await flashFetchJSON(FLASH_API.movimiento, 'POST', payload);
+        if (resultado?.success !== true) {
+            throw new Error(resultado?.error || 'No se pudo registrar el movimiento');
+        }
+
+        const nuevoStock = (() => {
+            const remoto = parseInt(resultado.stock_actual, 10);
+            if (Number.isFinite(remoto)) {
+                return remoto;
+            }
+            return tipo === 'ingreso' ? stockActual + cantidad : stockActual - cantidad;
+        })();
+
+        flashProductoActual.stock = nuevoStock;
+        flashActualizarUIProducto();
+        flashShowToast(`Movimiento ${tipo} registrado`, 'success');
+        flashActualizarAyudaCantidad();
+    } catch (error) {
+        console.error(error);
+        flashShowToast('Error al registrar movimiento: ' + (error?.message || 'desconocido'), 'error');
+    } finally {
+        if (flashScanRegistrar) {
+            flashScanRegistrar.disabled = false;
+        }
+        flashActualizarAyudaCantidad();
+    }
+});
+
+ingresoFlashBtn?.addEventListener('click', () => {
+    flashAbrirScanner('ingreso');
+});
+
+egresoFlashBtn?.addEventListener('click', () => {
+    flashAbrirScanner('egreso');
 });
 
 // Manual tutorial trigger for testing (remove in production)

--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -1470,6 +1470,124 @@ img {
     color: #fff;
 }
 
+/* QR scanner modal */
+.modal-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.3rem 0.7rem;
+    border-radius: var(--radius-pill);
+    background: var(--primary-surface);
+    color: var(--primary-color);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 600;
+}
+
+.qr-modal {
+    background: var(--card-bg);
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--border-color);
+}
+
+.qr-reader {
+    width: 100%;
+    min-height: 320px;
+    border-radius: var(--radius-md);
+    background: repeating-linear-gradient(
+            135deg,
+            rgba(255, 111, 145, 0.08),
+            rgba(255, 111, 145, 0.08) 12px,
+            rgba(15, 180, 212, 0.08) 12px,
+            rgba(15, 180, 212, 0.08) 24px
+        ),
+        #fff;
+    border: 1px dashed rgba(255, 111, 145, 0.35);
+    display: grid;
+    place-items: center;
+}
+
+.qr-helper {
+    margin: 0.75rem 0 0;
+    font-size: 0.85rem;
+    color: var(--muted-color);
+    text-align: center;
+}
+
+.scan-result {
+    margin-top: 1.5rem;
+    padding: 1.25rem;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border-color);
+    background: var(--primary-surface-extra);
+    display: grid;
+    gap: 1rem;
+}
+
+@media (min-width: 576px) {
+    .scan-result {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        align-items: flex-start;
+    }
+}
+
+.scan-product {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.scan-product__name {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-color);
+}
+
+.scan-product__code {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--muted-color);
+}
+
+.scan-stock {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+
+.scan-stock__label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--muted-color);
+    font-weight: 600;
+}
+
+.scan-stock__value {
+    font-size: 1.45rem;
+    font-weight: 700;
+    color: var(--primary-color);
+}
+
+.scan-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.scan-form .form-label {
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.scan-form .form-text {
+    color: var(--muted-color);
+}
+
 /* Modal */
 .modal-overlay,
 .color-modal {


### PR DESCRIPTION
## Summary
- replace the QR scanner modal movement dropdown with a read-only badge that reflects the button-initiated action
- update the flash scanner workflow to rely on the forced movement type and adjust related helper text accordingly

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d5923e94a8832c8a29178798f82fc5