### PR TITLE
Limitar movimientos recientes a cinco entradas

### DIFF
--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -827,7 +827,7 @@ async function loadRecentMovements() {
 
         recentActivityList.innerHTML = '';
 
-        movimientos.slice(0, 8).forEach(mov => {
+        movimientos.slice(0, 5).forEach(mov => {
             const tipo = (mov.tipo || '').toLowerCase();
             let movementClass = 'mov-ajuste';
             let iconClass = 'fa-exchange-alt';


### PR DESCRIPTION
## Summary
- limitar la tabla de actividad reciente a un máximo de cinco movimientos

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5a13082e4832ca114bf2c072e4a96