### PR TITLE
Improve mobile layout for warehouse areas view

### DIFF
--- a/styles/Area_almac/areas_zonas.css
+++ b/styles/Area_almac/areas_zonas.css
@@ -448,6 +448,12 @@ img {
   font-size: 0.85rem;
 }
 
+.zona-item span {
+  flex: 1;
+  word-break: break-word;
+  line-height: 1.4;
+}
+
 .zona-actions {
   display: flex;
   gap: 0.35rem;
@@ -514,5 +520,32 @@ img {
   .dimension-row,
   .sublevels-container > div {
     grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
+
+  .shell-grid,
+  .resumen-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .area-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .area-actions {
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .zona-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .zona-actions {
+    width: 100%;
+    justify-content: flex-end;
   }
 }


### PR DESCRIPTION
## Summary
- allow area and zone rows to wrap and stack so long texts fit on narrow screens
- tighten small-screen grid layouts so the highlights, summary, and forms render in a single column
- adjust action groups to align to the right while keeping buttons accessible on phones

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5aeb88ca4832cb8eded5f2bdb532b