### PR TITLE
Improve responsive layout for areas and zones tables

### DIFF
--- a/scripts/area_almac_v2/gestion_areas_zonas.js
+++ b/scripts/area_almac_v2/gestion_areas_zonas.js
@@ -120,12 +120,12 @@ async function renderAreas() {
     areas.forEach(a => {
       const tr = document.createElement('tr');
       tr.innerHTML = `
-        <td>${a.nombre}</td>
-        <td>${a.descripcion}</td>
-        <td>${a.ancho}×${a.largo}×${a.alto}</td>
-        <td>${parseFloat(a.volumen).toFixed(2)}</td>
-        <td>${zonasPorArea[a.id] || 0}</td>
-        <td>
+        <td data-label="Área">${a.nombre}</td>
+        <td data-label="Descripción">${a.descripcion}</td>
+        <td data-label="Dimensiones">${a.ancho}×${a.largo}×${a.alto}</td>
+        <td data-label="Volumen">${parseFloat(a.volumen).toFixed(2)}</td>
+        <td data-label="Zonas asignadas">${zonasPorArea[a.id] || 0}</td>
+        <td data-label="Acciones">
           <div class="table-actions">
             <button class="table-action table-action--edit" data-action="edit-area" data-id="${a.id}">Editar</button>
             <button class="table-action table-action--delete" data-action="delete-area" data-id="${a.id}">Eliminar</button>
@@ -220,12 +220,12 @@ async function renderZonas() {
     zonasAsignadas.forEach(z => {
       const tr = document.createElement('tr');
       tr.innerHTML = `
-        <td>${z.nombre}</td>
-        <td>${areasMap[z.area_id] || z.area_id}</td>
-        <td>${z.ancho}×${z.largo}×${z.alto}</td>
-        <td>${parseFloat(z.volumen).toFixed(2)}</td>
-        <td>${z.tipo_almacenamiento}</td>
-        <td>
+        <td data-label="Zona">${z.nombre}</td>
+        <td data-label="Área">${areasMap[z.area_id] || z.area_id}</td>
+        <td data-label="Dimensiones">${z.ancho}×${z.largo}×${z.alto}</td>
+        <td data-label="Volumen">${parseFloat(z.volumen).toFixed(2)}</td>
+        <td data-label="Tipo">${z.tipo_almacenamiento}</td>
+        <td data-label="Acciones">
           <div class="table-actions">
             <button class="table-action table-action--edit" data-action="edit-zone" data-id="${z.id}">Editar</button>
             <button class="table-action table-action--delete" data-action="delete-zone" data-id="${z.id}">Eliminar</button>
@@ -246,11 +246,11 @@ async function renderZonas() {
     zonasSinAsignar.forEach(z => {
       const tr = document.createElement('tr');
       tr.innerHTML = `
-        <td>${z.nombre}</td>
-        <td>${z.ancho}×${z.largo}×${z.alto}</td>
-        <td>${parseFloat(z.volumen).toFixed(2)}</td>
-        <td>${z.tipo_almacenamiento}</td>
-        <td>
+        <td data-label="Zona">${z.nombre}</td>
+        <td data-label="Dimensiones">${z.ancho}×${z.largo}×${z.alto}</td>
+        <td data-label="Volumen">${parseFloat(z.volumen).toFixed(2)}</td>
+        <td data-label="Tipo">${z.tipo_almacenamiento}</td>
+        <td data-label="Acciones">
           <div class="table-actions">
             <button class="table-action table-action--edit" data-action="edit-zone" data-id="${z.id}">Editar</button>
             <button class="table-action table-action--delete" data-action="delete-zone" data-id="${z.id}">Eliminar</button>

--- a/styles/Area_almac_v2/gestion_areas_zonas.css
+++ b/styles/Area_almac_v2/gestion_areas_zonas.css
@@ -314,6 +314,66 @@ img {
   font-style: italic;
 }
 
+@media (max-width: 600px) {
+  .table-wrapper {
+    overflow-x: visible;
+  }
+
+  .data-table,
+  .data-table tbody,
+  .data-table tr {
+    display: block;
+    width: 100%;
+  }
+
+  .data-table thead {
+    display: none;
+  }
+
+  .data-table tr {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-soft);
+    margin-bottom: 1rem;
+    overflow: hidden;
+  }
+
+  .data-table td {
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+    padding: 0.75rem 1rem;
+    border: none;
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  .data-table tr:last-child td:last-child,
+  .data-table td:last-child {
+    border-bottom: none;
+  }
+
+  .data-table td::before {
+    content: attr(data-label);
+    flex: 0 0 40%;
+    max-width: 180px;
+    color: var(--muted-color);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .data-table td[data-label="Acciones"] {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .data-table td[data-label="Acciones"] .table-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}
+
 .table-actions {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- add a mobile-focused media query that turns the warehouse tables into stacked cards and removes horizontal scrolling
- include `data-label` attributes in dynamically rendered cells so the mobile layout can show their column titles

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5be9a975c832c987e69859245a3db