### PR TITLE
Replace stock alert popups with toast notifications

### DIFF
--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -83,6 +83,9 @@ try {
 const DEFAULT_STOCK_ALERT_THRESHOLD = 10;
 const STOCK_THRESHOLD_STORAGE_PREFIX = 'stockAlertThreshold';
 
+const CRITICAL_STOCK_TOAST_CONTAINER_ID = 'criticalStockToastContainer';
+const CRITICAL_STOCK_TOAST_DURATION = 7000;
+
 // Selected theme colors
 let colorSidebarSeleccionado = getComputedStyle(document.documentElement)
     .getPropertyValue('--sidebar-color')
@@ -92,8 +95,58 @@ let colorTopbarSeleccionado = getComputedStyle(document.documentElement)
     .trim();
 
 
+function getCriticalStockToastContainer() {
+    let container = document.getElementById(CRITICAL_STOCK_TOAST_CONTAINER_ID);
+    if (!container) {
+        container = document.createElement('div');
+        container.id = CRITICAL_STOCK_TOAST_CONTAINER_ID;
+        container.className = 'critical-stock-toast-container';
+        container.setAttribute('aria-live', 'polite');
+        container.setAttribute('aria-atomic', 'true');
+        document.body.appendChild(container);
+    }
+    return container;
+}
+
 function showCriticalStockAlert(title, message) {
-    alert(`${title}\n\n${message}`.trim());
+    const container = getCriticalStockToastContainer();
+    const toast = document.createElement('article');
+    toast.className = 'critical-stock-toast';
+    toast.setAttribute('role', 'status');
+
+    const titleEl = document.createElement('p');
+    titleEl.className = 'critical-stock-toast__title';
+    titleEl.textContent = title.trim();
+
+    const messageEl = document.createElement('p');
+    messageEl.className = 'critical-stock-toast__message';
+    messageEl.textContent = message.trim();
+
+    toast.appendChild(titleEl);
+    toast.appendChild(messageEl);
+
+    container.appendChild(toast);
+
+    requestAnimationFrame(() => {
+        toast.classList.add('is-visible');
+    });
+
+    const removeToast = () => {
+        toast.classList.remove('is-visible');
+        toast.addEventListener('transitionend', () => {
+            toast.remove();
+            if (!container.hasChildNodes()) {
+                container.remove();
+            }
+        }, { once: true });
+    };
+
+    const timeoutId = setTimeout(removeToast, CRITICAL_STOCK_TOAST_DURATION);
+
+    toast.addEventListener('click', () => {
+        clearTimeout(timeoutId);
+        removeToast();
+    });
 }
 
 function formatRelativeNotificationTime(dateString) {

--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -1199,6 +1199,65 @@ img {
     gap: 1rem;
 }
 
+.critical-stock-toast-container {
+    position: fixed;
+    top: 1.5rem;
+    right: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    width: min(320px, calc(100vw - 3rem));
+    z-index: 120;
+    pointer-events: none;
+}
+
+.critical-stock-toast {
+    position: relative;
+    background: var(--card-bg);
+    color: var(--text-color);
+    border: 1px solid var(--primary-border-soft);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-soft);
+    padding: 1rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    transform: translateY(-12px);
+    opacity: 0;
+    transition: opacity var(--transition-speed) ease, transform var(--transition-speed) ease;
+    pointer-events: auto;
+    cursor: pointer;
+}
+
+.critical-stock-toast::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    border: 2px solid transparent;
+    background:
+        linear-gradient(var(--card-bg), var(--card-bg)) padding-box,
+        linear-gradient(135deg, var(--danger-color), var(--primary-color)) border-box;
+    z-index: -1;
+}
+
+.critical-stock-toast.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.critical-stock-toast__title {
+    font-weight: 600;
+    color: var(--danger-color);
+    font-size: 0.95rem;
+}
+
+.critical-stock-toast__message {
+    font-size: 0.9rem;
+    line-height: 1.4;
+    color: var(--text-color);
+}
+
 .stock-alert-item,
 .activity-item {
     display: flex;


### PR DESCRIPTION
## Summary
- replace the blocking `alert()` call for stock notifications with a custom toast component that can auto-dismiss or be dismissed on click
- ensure the toast container is created on demand and removed when empty for a cleaner DOM
- add styling for the new toast component so stock warnings appear as inline banners instead of modal browser alerts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5be949eb0832c84a088e5f66d6752