### PR TITLE
Move inventory summary table to top of inventory page

### DIFF
--- a/pages/gest_inve/inventario_basico.html
+++ b/pages/gest_inve/inventario_basico.html
@@ -42,6 +42,69 @@
       </div>
     </section>
 
+    <section class="table-card">
+      <div class="table-heading">
+        <div>
+          <h2 class="table-title">Resumen del inventario</h2>
+          <span class="table-subtitle" id="tablaResumenDescripcion">Selecciona una vista para consultar los registros disponibles.</span>
+        </div>
+        <div class="summary-actions">
+          <button id="btnIngreso" class="btn-icon btn-icon--success" type="button" title="Registrar ingreso">
+            <span class="btn-icon__circle" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                <polyline points="23 4 23 10 17 10"></polyline>
+                <polyline points="1 20 1 14 7 14"></polyline>
+                <path d="M3.51 9a9 9 0 0 1 14.13-3.36L23 10"></path>
+                <path d="M20.49 15A9 9 0 0 1 6.36 18L1 14"></path>
+              </svg>
+            </span>
+            <span class="btn-icon__label">Ingreso</span>
+          </button>
+          <button id="btnEgreso" class="btn-icon btn-icon--danger" type="button" title="Registrar egreso">
+            <span class="btn-icon__circle" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                <path d="M9 14l-4-4 4-4"></path>
+                <path d="M5 10h14"></path>
+                <path d="M15 6l4 4-4 4"></path>
+              </svg>
+            </span>
+            <span class="btn-icon__label">Egreso</span>
+          </button>
+          <button id="btnRecargarResumen" class="btn-icon" type="button" title="Recargar datos">
+            <span class="btn-icon__circle" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                <polyline points="23 4 23 10 17 10"></polyline>
+                <polyline points="1 20 1 14 7 14"></polyline>
+                <path d="M3.51 9a9 9 0 0 1 14.13-3.36L23 10"></path>
+                <path d="M20.49 15A9 9 0 0 1 6.36 18L1 14"></path>
+              </svg>
+            </span>
+            <span class="btn-icon__label">Recargar</span>
+          </button>
+          <button id="btnScanQR" class="btn-icon btn-icon--accent" type="button" title="Escanear QR">
+            <span class="btn-icon__circle" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                <rect x="3" y="3" width="7" height="7"></rect>
+                <rect x="14" y="3" width="7" height="7"></rect>
+                <rect x="3" y="14" width="7" height="7"></rect>
+                <path d="M14 14h3v3h-3z"></path>
+                <path d="M17 17h4"></path>
+                <path d="M17 13v-3"></path>
+              </svg>
+            </span>
+            <span class="btn-icon__label">Escanear</span>
+          </button>
+        </div>
+      </div>
+
+      <div class="inventory-table-wrapper">
+        <table id="tablaResumen" class="inventory-table">
+          <thead id="tablaHead"></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </section>
+
     <section class="inventory-shell">
       <div class="shell-header">
         <div class="shell-header__info">
@@ -211,69 +274,6 @@
             </div>
           </form>
         </section>
-      </div>
-    </section>
-
-    <section class="table-card">
-      <div class="table-heading">
-        <div>
-          <h2 class="table-title">Resumen del inventario</h2>
-          <span class="table-subtitle" id="tablaResumenDescripcion">Selecciona una vista para consultar los registros disponibles.</span>
-        </div>
-        <div class="summary-actions">
-          <button id="btnIngreso" class="btn-icon btn-icon--success" type="button" title="Registrar ingreso">
-            <span class="btn-icon__circle" aria-hidden="true">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
-                <polyline points="23 4 23 10 17 10"></polyline>
-                <polyline points="1 20 1 14 7 14"></polyline>
-                <path d="M3.51 9a9 9 0 0 1 14.13-3.36L23 10"></path>
-                <path d="M20.49 15A9 9 0 0 1 6.36 18L1 14"></path>
-              </svg>
-            </span>
-            <span class="btn-icon__label">Ingreso</span>
-          </button>
-          <button id="btnEgreso" class="btn-icon btn-icon--danger" type="button" title="Registrar egreso">
-            <span class="btn-icon__circle" aria-hidden="true">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
-                <path d="M9 14l-4-4 4-4"></path>
-                <path d="M5 10h14"></path>
-                <path d="M15 6l4 4-4 4"></path>
-              </svg>
-            </span>
-            <span class="btn-icon__label">Egreso</span>
-          </button>
-          <button id="btnRecargarResumen" class="btn-icon" type="button" title="Recargar datos">
-            <span class="btn-icon__circle" aria-hidden="true">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
-                <polyline points="23 4 23 10 17 10"></polyline>
-                <polyline points="1 20 1 14 7 14"></polyline>
-                <path d="M3.51 9a9 9 0 0 1 14.13-3.36L23 10"></path>
-                <path d="M20.49 15A9 9 0 0 1 6.36 18L1 14"></path>
-              </svg>
-            </span>
-            <span class="btn-icon__label">Recargar</span>
-          </button>
-          <button id="btnScanQR" class="btn-icon btn-icon--accent" type="button" title="Escanear QR">
-            <span class="btn-icon__circle" aria-hidden="true">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
-                <rect x="3" y="3" width="7" height="7"></rect>
-                <rect x="14" y="3" width="7" height="7"></rect>
-                <rect x="3" y="14" width="7" height="7"></rect>
-                <path d="M14 14h3v3h-3z"></path>
-                <path d="M17 17h4"></path>
-                <path d="M17 13v-3"></path>
-              </svg>
-            </span>
-            <span class="btn-icon__label">Escanear</span>
-          </button>
-        </div>
-      </div>
-
-      <div class="inventory-table-wrapper">
-        <table id="tablaResumen" class="inventory-table">
-          <thead id="tablaHead"></thead>
-          <tbody></tbody>
-        </table>
       </div>
     </section>
   </div>


### PR DESCRIPTION
## Summary
- reposition the inventory summary table so it appears immediately after the main header on the basic inventory page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d726311d28832ca5210e38060c06c5