### PR TITLE
Adjust product form styling to remove extra box

### DIFF
--- a/styles/gest_inve/inventario_basico.css
+++ b/styles/gest_inve/inventario_basico.css
@@ -273,14 +273,14 @@ img {
 }
 
 .compact-form {
-  background: rgba(255, 255, 255, 0.92);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  padding: clamp(1.25rem, 2.5vw, 1.75rem);
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  box-shadow: 0 16px 40px -36px rgba(15, 23, 42, 0.35);
+  box-shadow: none;
 }
 
 .compact-form .form-label {


### PR DESCRIPTION
## Summary
- make the product registration form inherit the surrounding panel styling by clearing the inner card background, border, and shadow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d72b5a9930832ca12cb434fa8b8598