### PR TITLE
Add user area and zone assignment management

### DIFF
--- a/pages/admin_usuar/administracion_usuarios.html
+++ b/pages/admin_usuar/administracion_usuarios.html
@@ -79,6 +79,7 @@
               <th scope="col">Correo</th>
               <th scope="col">Rol</th>
               <th scope="col">Estado</th>
+              <th scope="col">Accesos</th>
               <th scope="col" class="actions-column">Acciones</th>
             </tr>
           </thead>
@@ -147,7 +148,63 @@
       </div>
     </div>
   </div>
-  
+
+  <div class="modal fade" id="modalAsignarAccesos" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+      <div class="modal-content shadow-lg">
+        <div class="modal-header border-0">
+          <div>
+            <span class="modal-eyebrow">Accesos</span>
+            <h5 class="modal-title fw-bold" id="tituloModalAccesos">Gestionar accesos por área y zona</h5>
+            <p class="modal-subtitle" id="descripcionModalAccesos">Selecciona un usuario para administrar sus accesos.</p>
+          </div>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+        </div>
+
+        <div class="modal-body pt-0">
+          <form id="formAsignarAcceso" class="row g-3">
+            <div class="col-12">
+              <span class="modal-user-label">Usuario:</span>
+              <p class="modal-user-name" id="nombreUsuarioAccesos">—</p>
+            </div>
+            <div class="col-12 col-md-6">
+              <label for="asignarArea" class="form-label">Área *</label>
+              <select id="asignarArea" class="form-select" required>
+                <option value="">Selecciona un área</option>
+              </select>
+            </div>
+            <div class="col-12 col-md-6">
+              <label for="asignarZona" class="form-label">Zona (opcional)</label>
+              <select id="asignarZona" class="form-select" disabled>
+                <option value="">Selecciona un área primero</option>
+              </select>
+            </div>
+            <div class="col-12">
+              <button type="submit" class="btn btn-primary w-100" id="btnAgregarAcceso">Agregar acceso</button>
+            </div>
+          </form>
+
+          <hr class="my-4" />
+
+          <div>
+            <div class="d-flex justify-content-between align-items-center mb-3">
+              <h6 class="fw-semibold mb-0">Accesos asignados</h6>
+              <small class="text-muted" id="resumenAccesosUsuario">Acceso completo</small>
+            </div>
+            <div id="listaAccesosVacia" class="access-empty-message">
+              Este usuario puede acceder a todas las áreas y zonas.
+            </div>
+            <ul class="list-group access-list d-none" id="listaAccesosUsuario"></ul>
+          </div>
+        </div>
+
+        <div class="modal-footer border-0">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cerrar</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
     <section class="filters-card">
       <div class="filters-heading">
         <div>

--- a/scripts/php/eliminar_acceso_usuario.php
+++ b/scripts/php/eliminar_acceso_usuario.php
@@ -1,0 +1,45 @@
+<?php
+header('Content-Type: application/json');
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$servername = "localhost";
+$db_user    = "u296155119_Admin";
+$db_pass    = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+function jsonResponse($success, $message = '', $extra = []) {
+    echo json_encode(array_merge(['success' => $success, 'message' => $message], $extra));
+    exit;
+}
+
+try {
+    $conn = new mysqli($servername, $db_user, $db_pass, $database);
+    $conn->set_charset('utf8mb4');
+} catch (mysqli_sql_exception $e) {
+    jsonResponse(false, 'Error de conexión a la base de datos.');
+}
+
+$input = json_decode(file_get_contents('php://input'), true) ?: [];
+$idAsignacion = isset($input['id_asignacion']) ? (int) $input['id_asignacion'] : 0;
+
+if ($idAsignacion <= 0) {
+    jsonResponse(false, 'Identificador de asignación inválido.');
+}
+
+try {
+    $stmt = $conn->prepare('DELETE FROM usuario_area_zona WHERE id = ?');
+    $stmt->bind_param('i', $idAsignacion);
+    $stmt->execute();
+    $filasAfectadas = $stmt->affected_rows;
+    $stmt->close();
+
+    if ($filasAfectadas <= 0) {
+        jsonResponse(false, 'No se encontró la asignación que intentas eliminar.');
+    }
+
+    jsonResponse(true, 'Asignación eliminada correctamente.');
+} catch (mysqli_sql_exception $e) {
+    error_log('Error al eliminar acceso de usuario: ' . $e->getMessage());
+    jsonResponse(false, 'No fue posible eliminar la asignación solicitada.');
+}

--- a/scripts/php/guardar_acceso_usuario.php
+++ b/scripts/php/guardar_acceso_usuario.php
@@ -1,0 +1,122 @@
+<?php
+header('Content-Type: application/json');
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$servername = "localhost";
+$db_user    = "u296155119_Admin";
+$db_pass    = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+function jsonResponse($success, $message = '', $extra = []) {
+    echo json_encode(array_merge(['success' => $success, 'message' => $message], $extra));
+    exit;
+}
+
+try {
+    $conn = new mysqli($servername, $db_user, $db_pass, $database);
+    $conn->set_charset('utf8mb4');
+} catch (mysqli_sql_exception $e) {
+    jsonResponse(false, 'Error de conexión a la base de datos.');
+}
+
+$input = json_decode(file_get_contents('php://input'), true) ?: [];
+$idUsuario = isset($input['id_usuario']) ? (int) $input['id_usuario'] : 0;
+$idArea    = isset($input['id_area']) ? (int) $input['id_area'] : 0;
+$idZonaRaw = $input['id_zona'] ?? null;
+$idZona    = ($idZonaRaw === '' || $idZonaRaw === null) ? null : (int) $idZonaRaw;
+
+if ($idUsuario <= 0 || $idArea <= 0) {
+    jsonResponse(false, 'Datos incompletos. Selecciona al menos un área.');
+}
+
+try {
+    $stmtArea = $conn->prepare('SELECT id_empresa, nombre FROM areas WHERE id = ?');
+    $stmtArea->bind_param('i', $idArea);
+    $stmtArea->execute();
+    $areaResult = $stmtArea->get_result();
+    $area = $areaResult->fetch_assoc();
+    $stmtArea->close();
+
+    if (!$area) {
+        jsonResponse(false, 'El área seleccionada no existe.');
+    }
+
+    $idEmpresa = (int) $area['id_empresa'];
+
+    $stmtUsuarioEmpresa = $conn->prepare('SELECT 1 FROM usuario_empresa WHERE id_usuario = ? AND id_empresa = ? LIMIT 1');
+    $stmtUsuarioEmpresa->bind_param('ii', $idUsuario, $idEmpresa);
+    $stmtUsuarioEmpresa->execute();
+    $usuarioEmpresa = $stmtUsuarioEmpresa->get_result()->fetch_assoc();
+    $stmtUsuarioEmpresa->close();
+
+    if (!$usuarioEmpresa) {
+        jsonResponse(false, 'El usuario no pertenece a la empresa de esta área.');
+    }
+
+    $zonaNombre = null;
+    if ($idZona !== null) {
+        $stmtZona = $conn->prepare('SELECT id, area_id, nombre FROM zonas WHERE id = ? LIMIT 1');
+        $stmtZona->bind_param('i', $idZona);
+        $stmtZona->execute();
+        $zona = $stmtZona->get_result()->fetch_assoc();
+        $stmtZona->close();
+
+        if (!$zona) {
+            jsonResponse(false, 'La zona seleccionada no existe.');
+        }
+
+        if ((int) $zona['area_id'] !== $idArea) {
+            jsonResponse(false, 'La zona seleccionada no pertenece al área indicada.');
+        }
+
+        $zonaNombre = $zona['nombre'];
+
+        $stmtAccesoTotal = $conn->prepare('SELECT id FROM usuario_area_zona WHERE id_usuario = ? AND id_area = ? AND id_zona IS NULL LIMIT 1');
+        $stmtAccesoTotal->bind_param('ii', $idUsuario, $idArea);
+        $stmtAccesoTotal->execute();
+        $accesoTotal = $stmtAccesoTotal->get_result()->fetch_assoc();
+        $stmtAccesoTotal->close();
+
+        if ($accesoTotal) {
+            jsonResponse(false, 'El usuario ya tiene acceso completo a todas las zonas de esta área.');
+        }
+    }
+
+    if ($idZona === null) {
+        $stmtExiste = $conn->prepare('SELECT id FROM usuario_area_zona WHERE id_usuario = ? AND id_area = ? AND id_zona IS NULL LIMIT 1');
+        $stmtExiste->bind_param('ii', $idUsuario, $idArea);
+    } else {
+        $stmtExiste = $conn->prepare('SELECT id FROM usuario_area_zona WHERE id_usuario = ? AND id_area = ? AND id_zona = ? LIMIT 1');
+        $stmtExiste->bind_param('iii', $idUsuario, $idArea, $idZona);
+    }
+
+    $stmtExiste->execute();
+    $existe = $stmtExiste->get_result()->fetch_assoc();
+    $stmtExiste->close();
+
+    if ($existe) {
+        jsonResponse(false, 'La asignación seleccionada ya existe.');
+    }
+
+    if ($idZona === null) {
+        $stmtInsert = $conn->prepare('INSERT INTO usuario_area_zona (id_usuario, id_area, id_zona) VALUES (?, ?, NULL)');
+        $stmtInsert->bind_param('ii', $idUsuario, $idArea);
+    } else {
+        $stmtInsert = $conn->prepare('INSERT INTO usuario_area_zona (id_usuario, id_area, id_zona) VALUES (?, ?, ?)');
+        $stmtInsert->bind_param('iii', $idUsuario, $idArea, $idZona);
+    }
+
+    $stmtInsert->execute();
+    $nuevoId = $stmtInsert->insert_id;
+    $stmtInsert->close();
+
+    $mensajeExito = $idZona === null
+        ? 'Se otorgó acceso a todas las zonas del área seleccionada.'
+        : 'Se otorgó acceso a la zona seleccionada.';
+
+    jsonResponse(true, $mensajeExito, ['id' => $nuevoId, 'zona' => $zonaNombre]);
+} catch (mysqli_sql_exception $e) {
+    error_log('Error al guardar acceso de usuario: ' . $e->getMessage());
+    jsonResponse(false, 'No fue posible guardar la asignación solicitada.');
+}

--- a/scripts/php/obtener_accesos_usuario.php
+++ b/scripts/php/obtener_accesos_usuario.php
@@ -1,0 +1,59 @@
+<?php
+header('Content-Type: application/json');
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$servername = "localhost";
+$db_user    = "u296155119_Admin";
+$db_pass    = "4Dmin123o";
+$database   = "u296155119_OptiStock";
+
+function jsonResponse($success, $message = '', $extra = []) {
+    echo json_encode(array_merge(['success' => $success, 'message' => $message], $extra));
+    exit;
+}
+
+try {
+    $conn = new mysqli($servername, $db_user, $db_pass, $database);
+    $conn->set_charset('utf8mb4');
+} catch (mysqli_sql_exception $e) {
+    jsonResponse(false, 'Error de conexión a la base de datos.');
+}
+
+$input = json_decode(file_get_contents('php://input'), true) ?: [];
+$idUsuario = isset($input['id_usuario']) ? (int) $input['id_usuario'] : 0;
+
+if ($idUsuario <= 0) {
+    jsonResponse(false, 'Identificador de usuario inválido.', ['accesos' => []]);
+}
+
+try {
+    $stmt = $conn->prepare(
+        'SELECT uaz.id, uaz.id_area, uaz.id_zona, a.nombre AS area_nombre, z.nombre AS zona_nombre
+         FROM usuario_area_zona uaz
+         INNER JOIN areas a ON uaz.id_area = a.id
+         LEFT JOIN zonas z ON uaz.id_zona = z.id
+         WHERE uaz.id_usuario = ?
+         ORDER BY a.nombre ASC, z.nombre ASC'
+    );
+    $stmt->bind_param('i', $idUsuario);
+    $stmt->execute();
+    $resultado = $stmt->get_result();
+
+    $accesos = [];
+    while ($fila = $resultado->fetch_assoc()) {
+        $accesos[] = [
+            'id' => (int) $fila['id'],
+            'id_area' => (int) $fila['id_area'],
+            'area' => $fila['area_nombre'],
+            'id_zona' => $fila['id_zona'] !== null ? (int) $fila['id_zona'] : null,
+            'zona' => $fila['zona_nombre']
+        ];
+    }
+    $stmt->close();
+
+    jsonResponse(true, '', ['accesos' => $accesos]);
+} catch (mysqli_sql_exception $e) {
+    error_log('Error al obtener accesos de usuario: ' . $e->getMessage());
+    jsonResponse(false, 'No fue posible obtener los accesos del usuario.', ['accesos' => []]);
+}

--- a/styles/Admin_usuar/administracion_usuarios.css
+++ b/styles/Admin_usuar/administracion_usuarios.css
@@ -528,6 +528,51 @@ body {
   text-transform: uppercase;
 }
 
+.access-cell {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  max-width: 280px;
+}
+
+.access-tag {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.75rem;
+  background: rgba(108, 99, 255, 0.1);
+  color: #1c2340;
+  font-size: 0.75rem;
+  line-height: 1.2;
+  border: 1px solid rgba(108, 99, 255, 0.18);
+}
+
+.access-tag__area {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.access-tag__zone {
+  color: var(--muted-color);
+  font-size: 0.7rem;
+  letter-spacing: 0.03em;
+}
+
+.access-tag--full {
+  background: rgba(25, 135, 84, 0.16);
+  border-color: rgba(25, 135, 84, 0.25);
+  color: #17643d;
+}
+
+.access-tag--more {
+  background: rgba(255, 193, 7, 0.16);
+  border-color: rgba(255, 193, 7, 0.25);
+  color: #8c6c00;
+  align-self: center;
+}
+
 .status-chip--active {
   background: rgba(25, 135, 84, 0.16);
   color: #198754;
@@ -593,6 +638,15 @@ body {
   background: rgba(13, 110, 253, 0.2);
 }
 
+.btn-action--access {
+  background: rgba(255, 193, 7, 0.14);
+  color: #a07900;
+}
+
+.btn-action--access:hover {
+  background: rgba(255, 193, 7, 0.22);
+}
+
 .btn-status--activate {
   background: rgba(25, 135, 84, 0.16);
   color: #198754;
@@ -644,6 +698,62 @@ body {
 
 .modal-title {
   margin-top: 0.65rem;
+}
+
+.modal-subtitle {
+  margin: 0.35rem 0 0;
+  color: var(--muted-color);
+  font-size: 0.85rem;
+}
+
+.modal-user-label {
+  display: inline-block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-color);
+  font-weight: 600;
+}
+
+.modal-user-name {
+  margin: 0.25rem 0 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.access-empty-message {
+  padding: 1rem;
+  border-radius: var(--radius-md);
+  background: rgba(108, 99, 255, 0.08);
+  border: 1px dashed rgba(108, 99, 255, 0.3);
+  color: var(--muted-color);
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+.access-list {
+  max-height: 260px;
+  overflow-y: auto;
+  border-radius: var(--radius-md);
+}
+
+.access-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.access-item__area {
+  display: block;
+  font-weight: 600;
+  color: #1c2340;
+}
+
+.access-item__zone {
+  display: block;
+  color: var(--muted-color);
+  font-size: 0.8rem;
 }
 
 .form-floating > .form-control:focus,
@@ -712,6 +822,23 @@ body {
 
   .users-table {
     min-width: 100%;
+  }
+
+  .access-cell {
+    max-width: 100%;
+  }
+
+  .access-tag {
+    width: 100%;
+  }
+
+  .access-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .access-item button {
+    width: 100%;
   }
 }
 

--- a/u296155119_OptiStock (3).sql
+++ b/u296155119_OptiStock (3).sql
@@ -688,6 +688,20 @@ INSERT INTO `zonas` (`id`, `nombre`, `descripcion`, `ancho`, `alto`, `largo`, `v
 -- --------------------------------------------------------
 
 --
+-- Estructura de tabla para la tabla `usuario_area_zona`
+--
+
+CREATE TABLE `usuario_area_zona` (
+  `id` int(11) NOT NULL,
+  `id_usuario` int(11) NOT NULL,
+  `id_area` int(11) NOT NULL,
+  `id_zona` int(11) DEFAULT NULL,
+  `fecha_asignacion` timestamp NOT NULL DEFAULT current_timestamp()
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
 -- Estructura de tabla para la tabla `notificaciones`
 --
 
@@ -825,6 +839,15 @@ ALTER TABLE `usuario_empresa`
   ADD KEY `id_empresa` (`id_empresa`);
 
 --
+-- Indices de la tabla `usuario_area_zona`
+--
+ALTER TABLE `usuario_area_zona`
+  ADD PRIMARY KEY (`id`),
+  ADD UNIQUE KEY `uniq_usuario_area_zona` (`id_usuario`,`id_area`,`id_zona`),
+  ADD KEY `idx_uaz_area` (`id_area`),
+  ADD KEY `idx_uaz_zona` (`id_zona`);
+
+--
 -- Indices de la tabla `zonas`
 --
 ALTER TABLE `zonas`
@@ -900,6 +923,12 @@ ALTER TABLE `subcategorias`
 --
 ALTER TABLE `usuario`
   MODIFY `id_usuario` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=115;
+
+--
+-- AUTO_INCREMENT de la tabla `usuario_area_zona`
+--
+ALTER TABLE `usuario_area_zona`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT de la tabla `zonas`
@@ -996,6 +1025,14 @@ ALTER TABLE `subcategorias`
 ALTER TABLE `usuario_empresa`
   ADD CONSTRAINT `usuario_empresa_ibfk_1` FOREIGN KEY (`id_usuario`) REFERENCES `usuario` (`id_usuario`) ON DELETE CASCADE,
   ADD CONSTRAINT `usuario_empresa_ibfk_2` FOREIGN KEY (`id_empresa`) REFERENCES `empresa` (`id_empresa`) ON DELETE CASCADE;
+
+--
+-- Filtros para la tabla `usuario_area_zona`
+--
+ALTER TABLE `usuario_area_zona`
+  ADD CONSTRAINT `usuario_area_zona_ibfk_1` FOREIGN KEY (`id_usuario`) REFERENCES `usuario` (`id_usuario`) ON DELETE CASCADE,
+  ADD CONSTRAINT `usuario_area_zona_ibfk_2` FOREIGN KEY (`id_area`) REFERENCES `areas` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `usuario_area_zona_ibfk_3` FOREIGN KEY (`id_zona`) REFERENCES `zonas` (`id`) ON DELETE CASCADE;
 
 --
 -- Filtros para la tabla `zonas`


### PR DESCRIPTION
## Summary
- add a relational table, PHP services, and SQL migration for user area/zone assignments
- extend the admin users page with a modal to add or remove area/zone access per user and show a summary column
- filter area/zone responses by user assignments so non-assigned users continue to see everything by default

## Testing
- php -l scripts/php/guardar_acceso_usuario.php
- php -l scripts/php/eliminar_acceso_usuario.php
- php -l scripts/php/obtener_accesos_usuario.php

------
https://chatgpt.com/codex/tasks/task_e_68d982d44c84832c926e030e9eca2731