### PR TITLE
Use composite identifiers for user access management

### DIFF
--- a/scripts/Admin_usuar/administracion_usuarios.js
+++ b/scripts/Admin_usuar/administracion_usuarios.js
@@ -239,6 +239,9 @@
     accesos.forEach(acceso => {
       const item = document.createElement('li');
       item.className = 'list-group-item d-flex justify-content-between align-items-start access-item';
+      if (acceso?.composite_id) {
+        item.dataset.accessKey = acceso.composite_id;
+      }
 
       const zonaTexto = acceso?.zona ? escapeHtml(acceso.zona) : 'Todas las zonas';
       const areaTexto = escapeHtml(acceso?.area || `Área #${acceso?.id_area}`);
@@ -253,7 +256,7 @@
 
       const botonEliminar = item.querySelector('button');
       if (botonEliminar) {
-        botonEliminar.addEventListener('click', () => eliminarAcceso(acceso?.id));
+        botonEliminar.addEventListener('click', () => eliminarAcceso(acceso));
       }
 
       listaAccesos.appendChild(item);
@@ -417,17 +420,23 @@
       });
   }
 
-  function eliminarAcceso(idAcceso) {
-    if (!idAcceso) return;
+  function eliminarAcceso(acceso) {
+    if (!acceso || !acceso.id_usuario || !acceso.id_area) return;
 
     if (!confirm('¿Deseas eliminar este acceso asignado?')) {
       return;
     }
 
+    const payload = {
+      id_usuario: acceso.id_usuario,
+      id_area: acceso.id_area,
+      id_zona: acceso.id_zona === null || typeof acceso.id_zona === 'undefined' ? null : acceso.id_zona
+    };
+
     fetch('/scripts/php/eliminar_acceso_usuario.php', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id_asignacion: idAcceso })
+      body: JSON.stringify(payload)
     })
       .then(res => res.json())
       .then(data => {

--- a/scripts/php/obtener_accesos_usuario.php
+++ b/scripts/php/obtener_accesos_usuario.php
@@ -29,7 +29,7 @@ if ($idUsuario <= 0) {
 
 try {
     $stmt = $conn->prepare(
-        'SELECT uaz.id, uaz.id_area, uaz.id_zona, a.nombre AS area_nombre, z.nombre AS zona_nombre
+        'SELECT uaz.id_usuario, uaz.id_area, uaz.id_zona, a.nombre AS area_nombre, z.nombre AS zona_nombre
          FROM usuario_area_zona uaz
          INNER JOIN areas a ON uaz.id_area = a.id
          LEFT JOIN zonas z ON uaz.id_zona = z.id
@@ -42,11 +42,16 @@ try {
 
     $accesos = [];
     while ($fila = $resultado->fetch_assoc()) {
+        $idArea = (int) $fila['id_area'];
+        $idZona = $fila['id_zona'] !== null ? (int) $fila['id_zona'] : null;
+        $compositeId = $idUsuario . ':' . $idArea . ':' . ($idZona === null ? 'null' : $idZona);
+
         $accesos[] = [
-            'id' => (int) $fila['id'],
-            'id_area' => (int) $fila['id_area'],
+            'composite_id' => $compositeId,
+            'id_usuario' => $idUsuario,
+            'id_area' => $idArea,
             'area' => $fila['area_nombre'],
-            'id_zona' => $fila['id_zona'] !== null ? (int) $fila['id_zona'] : null,
+            'id_zona' => $idZona,
             'zona' => $fila['zona_nombre']
         ];
     }

--- a/scripts/php/obtener_usuarios_empresa.php
+++ b/scripts/php/obtener_usuarios_empresa.php
@@ -42,7 +42,7 @@ if ($idsUsuarios) {
     $placeholders = implode(',', array_fill(0, count($idsUsuarios), '?'));
     $tipos = str_repeat('i', count($idsUsuarios));
 
-    $sqlAccesos = "SELECT uaz.id, uaz.id_usuario, uaz.id_area, uaz.id_zona, a.nombre AS area_nombre, z.nombre AS zona_nombre
+    $sqlAccesos = "SELECT uaz.id_usuario, uaz.id_area, uaz.id_zona, a.nombre AS area_nombre, z.nombre AS zona_nombre
         FROM usuario_area_zona uaz
         INNER JOIN areas a ON uaz.id_area = a.id
         LEFT JOIN zonas z ON uaz.id_zona = z.id
@@ -60,11 +60,16 @@ if ($idsUsuarios) {
             continue;
         }
 
+        $idArea = (int) $acceso['id_area'];
+        $idZona = $acceso['id_zona'] !== null ? (int) $acceso['id_zona'] : null;
+        $compositeId = $idUsuario . ':' . $idArea . ':' . ($idZona === null ? 'null' : $idZona);
+
         $usuarios[$idUsuario]['accesos'][] = [
-            'id' => (int) $acceso['id'],
-            'id_area' => (int) $acceso['id_area'],
+            'composite_id' => $compositeId,
+            'id_usuario' => $idUsuario,
+            'id_area' => $idArea,
             'area' => $acceso['area_nombre'],
-            'id_zona' => $acceso['id_zona'] !== null ? (int) $acceso['id_zona'] : null,
+            'id_zona' => $idZona,
             'zona' => $acceso['zona_nombre']
         ];
     }


### PR DESCRIPTION
## Summary
- replace numeric access IDs with composite identifiers across user access queries
- update access persistence endpoints to validate duplicates and return composite metadata
- align the admin user UI to consume composite keys for rendering and deleting entries

## Testing
- php -l scripts/php/obtener_usuarios_empresa.php
- php -l scripts/php/obtener_accesos_usuario.php
- php -l scripts/php/guardar_acceso_usuario.php
- php -l scripts/php/eliminar_acceso_usuario.php

------
https://chatgpt.com/codex/tasks/task_e_68d98cdcb604832c9b76588d92772672