### PR TITLE
Filtrar vistas según accesos por áreas y zonas

### DIFF
--- a/scripts/php/accesos_utils.php
+++ b/scripts/php/accesos_utils.php
@@ -1,0 +1,108 @@
+<?php
+require_once __DIR__ . '/log_utils.php';
+
+/**
+ * Construye un mapa de accesos (áreas y zonas) para el usuario indicado.
+ *
+ * @param mysqli   $conn       Conexión activa a la base de datos.
+ * @param int|null $usuarioId  Identificador del usuario. Si es null o <= 0, retorna un mapa vacío.
+ *
+ * @return array<int, null|int[]> Mapa donde la llave es el ID del área y el valor es:
+ *                                - null  => acceso completo a todas las zonas del área.
+ *                                - int[] => lista de IDs de zonas permitidas dentro del área.
+ */
+function construirMapaAccesosUsuario(mysqli $conn, ?int $usuarioId): array
+{
+    if (!$usuarioId || $usuarioId <= 0) {
+        return [];
+    }
+
+    $mapa = [];
+
+    $stmt = $conn->prepare('SELECT id_area, id_zona FROM usuario_area_zona WHERE id_usuario = ?');
+    if (!$stmt) {
+        return $mapa;
+    }
+
+    $stmt->bind_param('i', $usuarioId);
+    $stmt->execute();
+    $resultado = $stmt->get_result();
+
+    while ($fila = $resultado->fetch_assoc()) {
+        $areaId = isset($fila['id_area']) ? (int) $fila['id_area'] : 0;
+        if ($areaId <= 0) {
+            continue;
+        }
+
+        if (!array_key_exists($areaId, $mapa)) {
+            $mapa[$areaId] = [];
+        }
+
+        if ($fila['id_zona'] === null) {
+            $mapa[$areaId] = null;
+            continue;
+        }
+
+        if (is_array($mapa[$areaId])) {
+            $zonaId = (int) $fila['id_zona'];
+            if ($zonaId > 0 && !in_array($zonaId, $mapa[$areaId], true)) {
+                $mapa[$areaId][] = $zonaId;
+            }
+        }
+    }
+
+    $stmt->close();
+
+    return $mapa;
+}
+
+/**
+ * Indica si el mapa de accesos obliga a filtrar resultados.
+ */
+function debeFiltrarPorAccesos(array $mapaAccesos): bool
+{
+    return !empty($mapaAccesos);
+}
+
+/**
+ * Determina si el usuario puede ver la información de un área específica.
+ */
+function usuarioPuedeVerArea(array $mapaAccesos, ?int $areaId): bool
+{
+    if (!debeFiltrarPorAccesos($mapaAccesos) || !$areaId) {
+        return true;
+    }
+
+    return array_key_exists($areaId, $mapaAccesos);
+}
+
+/**
+ * Determina si el usuario puede ver la información asociada a una zona.
+ */
+function usuarioPuedeVerZona(array $mapaAccesos, ?int $areaId, ?int $zonaId): bool
+{
+    if (!debeFiltrarPorAccesos($mapaAccesos)) {
+        return true;
+    }
+
+    if (!$areaId) {
+        // Zonas sin área asociada quedan visibles cuando no hay un área que validar.
+        return true;
+    }
+
+    if (!array_key_exists($areaId, $mapaAccesos)) {
+        return false;
+    }
+
+    $zonasPermitidas = $mapaAccesos[$areaId];
+
+    if ($zonasPermitidas === null) {
+        return true;
+    }
+
+    if (!$zonaId) {
+        return false;
+    }
+
+    return in_array((int) $zonaId, $zonasPermitidas, true);
+}

--- a/scripts/php/get_high_rotation.php
+++ b/scripts/php/get_high_rotation.php
@@ -1,6 +1,9 @@
 <?php
 header('Content-Type: application/json');
 
+require_once __DIR__ . '/log_utils.php';
+require_once __DIR__ . '/accesos_utils.php';
+
 $empresaId = isset($_GET['id_empresa']) ? (int) $_GET['id_empresa'] : 0;
 if ($empresaId <= 0) {
     http_response_code(400);
@@ -26,19 +29,27 @@ if ($conn->connect_error) {
     exit;
 }
 
+$usuarioIdSesion = obtenerUsuarioIdSesion() ?? 0;
+$mapaAccesos = construirMapaAccesosUsuario($conn, $usuarioIdSesion);
+$filtrarPorAccesos = debeFiltrarPorAccesos($mapaAccesos);
+
 $sql = "
     SELECT
         p.id            AS producto_id,
         p.nombre        AS producto_nombre,
         SUM(m.cantidad) AS total_unidades,
         COUNT(*)        AS total_movimientos,
-        MAX(m.fecha_movimiento) AS ultima_fecha
+        MAX(m.fecha_movimiento) AS ultima_fecha,
+        z.id            AS zona_id,
+        a.id            AS area_id
     FROM movimientos m
     INNER JOIN productos p ON m.producto_id = p.id
+    LEFT JOIN zonas z ON p.zona_id = z.id
+    LEFT JOIN areas a ON z.area_id = a.id
     WHERE
         m.empresa_id = ?
         AND m.fecha_movimiento >= (NOW() - INTERVAL 1 DAY)
-    GROUP BY p.id, p.nombre
+    GROUP BY p.id, p.nombre, z.id, a.id
     ORDER BY total_movimientos DESC, total_unidades DESC
     LIMIT 5
 ";
@@ -60,6 +71,13 @@ $result = $stmt->get_result();
 
 $productos = [];
 while ($row = $result->fetch_assoc()) {
+    $areaId = isset($row['area_id']) ? (int) $row['area_id'] : 0;
+    $zonaId = isset($row['zona_id']) ? (int) $row['zona_id'] : 0;
+
+    if ($filtrarPorAccesos && !usuarioPuedeVerZona($mapaAccesos, $areaId ?: null, $zonaId ?: null)) {
+        continue;
+    }
+
     $row['total_unidades'] = (int) ($row['total_unidades'] ?? 0);
     $row['total_movimientos'] = (int) ($row['total_movimientos'] ?? 0);
     $productos[] = $row;


### PR DESCRIPTION
## Summary
- add shared helpers to build the per-user map of áreas y zonas permitidas
- update áreas, zonas y productos endpoints to responder solo con registros autorizados
- filtrar inventario, movimientos, reportes y buscador global usando los accesos por área/zona

## Testing
- php -l scripts/php/accesos_utils.php
- php -l scripts/php/obtener_areas_zonas.php
- php -l scripts/php/guardar_areas.php
- php -l scripts/php/guardar_zonas.php
- php -l scripts/php/guardar_productos.php
- php -l scripts/php/get_recent_movements.php
- php -l scripts/php/get_high_rotation.php
- php -l scripts/php/get_global_search.php

------
https://chatgpt.com/codex/tasks/task_e_68d98f5305f4832c8048f2ef5892f93f