### PR TITLE
Refactor user actions menu and expose phone column

### DIFF
--- a/pages/admin_usuar/administracion_usuarios.html
+++ b/pages/admin_usuar/administracion_usuarios.html
@@ -77,6 +77,7 @@
               <th scope="col">Nombre</th>
               <th scope="col">Apellido</th>
               <th scope="col">Correo</th>
+              <th scope="col">Teléfono</th>
               <th scope="col">Rol</th>
               <th scope="col">Estado</th>
               <th scope="col">Accesos</th>

--- a/scripts/Admin_usuar/administracion_usuarios.js
+++ b/scripts/Admin_usuar/administracion_usuarios.js
@@ -110,6 +110,20 @@
     });
   }
 
+  function cerrarMenusAcciones(exceptMenu = null) {
+    document.querySelectorAll('.actions-menu--open').forEach(menu => {
+      if (!exceptMenu || menu !== exceptMenu) {
+        menu.classList.remove('actions-menu--open');
+      }
+    });
+  }
+
+  function manejarClickFueraMenus(event) {
+    if (!event.target.closest('.actions-menu')) {
+      cerrarMenusAcciones();
+    }
+  }
+
   function obtenerInstanciaModalAsignar() {
     if (!modalAsignar) return null;
     if (modalAsignarInstancia) return modalAsignarInstancia;
@@ -462,7 +476,7 @@
     const filtrados = usuariosEmpresa.filter(usuario => {
       const coincideRol = !rolSeleccionado || usuario.rol === rolSeleccionado;
       const estadoTexto = Number(usuario.activo) === 1 ? 'activo' : 'inactivo';
-      const textoUsuario = `${usuario.nombre || ''} ${usuario.apellido || ''} ${usuario.correo || ''} ${usuario.rol || ''} ${estadoTexto}`.toLowerCase();
+      const textoUsuario = `${usuario.nombre || ''} ${usuario.apellido || ''} ${usuario.correo || ''} ${usuario.telefono || ''} ${usuario.rol || ''} ${estadoTexto}`.toLowerCase();
       const coincideBusqueda = !termino || textoUsuario.includes(termino);
       return coincideRol && coincideBusqueda;
     });
@@ -478,7 +492,7 @@
 
     const contador = document.getElementById('usuariosCount');
     if (!usuarios.length) {
-      tbody.innerHTML = '<tr class="empty-row"><td colspan="6">No se encontraron usuarios con los filtros aplicados.</td></tr>';
+      tbody.innerHTML = '<tr class="empty-row"><td colspan="8">No se encontraron usuarios con los filtros aplicados.</td></tr>';
       if (contador) {
         contador.textContent = 'Sin usuarios disponibles';
       }
@@ -496,6 +510,7 @@
         : 'btn-action btn-action--status btn-status--activate';
       const estadoBotonTexto = activo ? 'Desactivar' : 'Activar';
       const resumenAccesos = generarResumenAccesos(usuario.accesos);
+      const telefono = usuario.telefono && String(usuario.telefono).trim() ? usuario.telefono : '—';
 
       tr.innerHTML = `
         <td>
@@ -506,41 +521,52 @@
         </td>
         <td>${usuario.apellido || ''}</td>
         <td><span class="cell-email">${usuario.correo || ''}</span></td>
+        <td><span class="cell-phone">${telefono}</span></td>
         <td><span class="role-chip">${usuario.rol || ''}</span></td>
         <td><span class="${estadoClase}">${estadoTexto}</span></td>
         <td class="access-cell">${resumenAccesos}</td>
-        <td>
-          <div class="action-buttons">
-            <button type="button" class="${estadoBotonClase}" title="${estadoBotonTexto}">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                <line x1="12" y1="4" x2="12" y2="12"></line>
-                <path d="M8 5a7 7 0 1 0 8 0"></path>
-              </svg>
-              <span>${estadoBotonTexto}</span>
+        <td class="actions-cell">
+          <div class="actions-menu">
+            <button type="button" class="actions-menu__toggle" title="Opciones">
+              <span class="actions-menu__dots" aria-hidden="true">
+                <span class="actions-menu__dot"></span>
+                <span class="actions-menu__dot"></span>
+                <span class="actions-menu__dot"></span>
+              </span>
+              <span class="visually-hidden">Mostrar acciones</span>
             </button>
-            <button type="button" class="btn-action btn-action--access" title="Gestionar accesos">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                <circle cx="11" cy="13" r="2"></circle>
-                <path d="M13.73 21a2 2 0 0 1-3.46 0L2 7a2 2 0 0 1 1.73-3H20.27A2 2 0 0 1 22 7Z"></path>
-              </svg>
-              <span>Accesos</span>
-            </button>
-            <button type="button" class="btn-action btn-action--edit" title="Editar">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M12 20h9"></path>
-                <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z"></path>
-              </svg>
-              <span>Editar</span>
-            </button>
-            <button type="button" class="btn-action btn-action--delete" title="Eliminar">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                <polyline points="3 6 5 6 21 6"></polyline>
-                <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"></path>
-                <path d="M10 11v6"></path>
-                <path d="M14 11v6"></path>
-              </svg>
-              <span>Eliminar</span>
-            </button>
+            <div class="actions-menu__list">
+              <button type="button" class="${estadoBotonClase}" title="${estadoBotonTexto}">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                  <line x1="12" y1="4" x2="12" y2="12"></line>
+                  <path d="M8 5a7 7 0 1 0 8 0"></path>
+                </svg>
+                <span>${estadoBotonTexto}</span>
+              </button>
+              <button type="button" class="btn-action btn-action--access" title="Gestionar accesos">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="11" cy="13" r="2"></circle>
+                  <path d="M13.73 21a2 2 0 0 1-3.46 0L2 7a2 2 0 0 1 1.73-3H20.27A2 2 0 0 1 22 7Z"></path>
+                </svg>
+                <span>Accesos</span>
+              </button>
+              <button type="button" class="btn-action btn-action--edit" title="Editar">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M12 20h9"></path>
+                  <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z"></path>
+                </svg>
+                <span>Editar</span>
+              </button>
+              <button type="button" class="btn-action btn-action--delete" title="Eliminar">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                  <polyline points="3 6 5 6 21 6"></polyline>
+                  <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"></path>
+                  <path d="M10 11v6"></path>
+                  <path d="M14 11v6"></path>
+                </svg>
+                <span>Eliminar</span>
+              </button>
+            </div>
           </div>
         </td>
       `;
@@ -549,21 +575,50 @@
       const botonEliminar = tr.querySelector('.btn-action--delete');
       const botonEstado = tr.querySelector('.btn-action--status');
       const botonAccesos = tr.querySelector('.btn-action--access');
+      const menu = tr.querySelector('.actions-menu');
+      const toggleMenu = tr.querySelector('.actions-menu__toggle');
+
+      if (toggleMenu && menu) {
+        toggleMenu.addEventListener('click', event => {
+          event.stopPropagation();
+          const isOpen = menu.classList.contains('actions-menu--open');
+          cerrarMenusAcciones();
+          if (!isOpen) {
+            menu.classList.add('actions-menu--open');
+          }
+        });
+      }
 
       if (botonEditar) {
-        botonEditar.addEventListener('click', () => editarUsuario(usuario));
+        botonEditar.addEventListener('click', event => {
+          event.stopPropagation();
+          cerrarMenusAcciones();
+          editarUsuario(usuario);
+        });
       }
 
       if (botonEliminar) {
-        botonEliminar.addEventListener('click', () => confirmarEliminacion(usuario.correo));
+        botonEliminar.addEventListener('click', event => {
+          event.stopPropagation();
+          cerrarMenusAcciones();
+          confirmarEliminacion(usuario.correo);
+        });
       }
 
       if (botonEstado) {
-        botonEstado.addEventListener('click', () => cambiarEstadoUsuario(usuario));
+        botonEstado.addEventListener('click', event => {
+          event.stopPropagation();
+          cerrarMenusAcciones();
+          cambiarEstadoUsuario(usuario);
+        });
       }
 
       if (botonAccesos) {
-        botonAccesos.addEventListener('click', () => abrirModalAccesos(usuario));
+        botonAccesos.addEventListener('click', event => {
+          event.stopPropagation();
+          cerrarMenusAcciones();
+          abrirModalAccesos(usuario);
+        });
       }
 
       tbody.appendChild(tr);
@@ -784,6 +839,7 @@
   addListener(document.getElementById('buscarUsuario'), 'input', aplicarFiltros);
   addListener(formAsignarAcceso, 'submit', manejarAsignacionAcceso);
   addListener(selectArea, 'change', manejarCambioArea);
+  addListener(document, 'click', manejarClickFueraMenus);
   addListener(modalAsignar, 'hidden.bs.modal', () => {
     usuarioAccesosSeleccionadoId = null;
     asignacionEnCurso = false;

--- a/styles/Admin_usuar/administracion_usuarios.css
+++ b/styles/Admin_usuar/administracion_usuarios.css
@@ -11,6 +11,18 @@ body {
   color: var(--text-color);
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .users-page {
   max-width: 1200px;
   margin: 0 auto;
@@ -502,6 +514,12 @@ body {
   color: var(--muted-color);
 }
 
+.cell-phone {
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  color: #1f2942;
+}
+
 .role-chip {
   display: inline-flex;
   align-items: center;
@@ -583,11 +601,6 @@ body {
   color: #dc3545;
 }
 
-.action-buttons {
-  display: inline-flex;
-  gap: 0.5rem;
-}
-
 .btn-action {
   border: none;
   border-radius: 999px;
@@ -663,6 +676,100 @@ body {
 
 .btn-status--deactivate:hover {
   background: rgba(220, 53, 69, 0.22);
+}
+
+.actions-cell {
+  position: relative;
+  text-align: right;
+}
+
+.actions-menu {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.actions-menu__toggle {
+  border: none;
+  background: rgba(255, 111, 145, 0.16);
+  color: var(--primary-color);
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.actions-menu__toggle:hover,
+.actions-menu--open .actions-menu__toggle {
+  background: rgba(255, 111, 145, 0.28);
+  transform: translateY(-1px);
+}
+
+.actions-menu__toggle:focus-visible,
+.actions-menu__list .btn-action:focus-visible {
+  outline: 3px solid rgba(255, 111, 145, 0.45);
+  outline-offset: 2px;
+}
+
+.actions-menu__dots {
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+}
+
+.actions-menu__dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.actions-menu__list {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  right: 0;
+  display: none;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 0.75rem;
+  min-width: 200px;
+  background: #ffffff;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 111, 145, 0.18);
+  box-shadow: 0 18px 36px -24px rgba(18, 26, 69, 0.45), 0 16px 32px -28px rgba(18, 26, 69, 0.22);
+  z-index: 5;
+}
+
+.actions-menu__list::before {
+  content: "";
+  position: absolute;
+  top: -8px;
+  right: 14px;
+  width: 16px;
+  height: 16px;
+  background: inherit;
+  border-left: 1px solid rgba(255, 111, 145, 0.18);
+  border-top: 1px solid rgba(255, 111, 145, 0.18);
+  transform: rotate(45deg);
+}
+
+.actions-menu--open .actions-menu__list {
+  display: flex;
+}
+
+.actions-menu__list .btn-action {
+  width: 100%;
+  justify-content: flex-start;
+  padding: 0.55rem 0.8rem;
+}
+
+.actions-menu__list .btn-action svg {
+  width: 18px;
+  height: 18px;
 }
 
 .actions-column {


### PR DESCRIPTION
## Summary
- add the phone number column to the admin users table and include it in filtering logic
- replace the inline action buttons with a contextual menu triggered by a three-dot toggle
- update styles to support the new menu layout and improve accessibility helpers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9903a23c8832ca424fdb454468af0