### PR TITLE
Allow users table dropdown to render fully

### DIFF
--- a/styles/Admin_usuar/administracion_usuarios.css
+++ b/styles/Admin_usuar/administracion_usuarios.css
@@ -438,8 +438,9 @@ body {
 .users-table-wrapper {
   border-radius: var(--radius-md);
   border: 1px solid var(--border-color);
-  overflow: hidden;
+  background: #ffffff;
   overflow-x: auto;
+  overflow-y: visible;
   box-shadow: inset 0 1px 0 rgba(255, 111, 145, 0.08);
 }
 


### PR DESCRIPTION
## Summary
- allow the users table wrapper to keep only horizontal scrolling so dropdown menus can open outside the table
- add a background color to the wrapper to preserve the table border appearance without clipping

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d99636d5c8832c9565fc934f460c4a