### PR TITLE
Fix area and zone assignment validation

### DIFF
--- a/scripts/Admin_usuar/administracion_usuarios.js
+++ b/scripts/Admin_usuar/administracion_usuarios.js
@@ -383,10 +383,17 @@
       return;
     }
 
-    const areaSeleccionada = selectArea ? parseInt(selectArea.value, 10) : 0;
-    const zonaSeleccionada = selectZona && selectZona.value ? parseInt(selectZona.value, 10) : null;
+    const areaSeleccionada = selectArea && selectArea.value !== '' ? Number(selectArea.value) : 0;
+    let zonaSeleccionada = null;
 
-    if (!areaSeleccionada) {
+    if (selectZona && typeof selectZona.value !== 'undefined' && selectZona.value !== '') {
+      const zonaValor = Number(selectZona.value);
+      if (!Number.isNaN(zonaValor) && Number.isInteger(zonaValor) && zonaValor > 0) {
+        zonaSeleccionada = zonaValor;
+      }
+    }
+
+    if (!Number.isInteger(areaSeleccionada) || areaSeleccionada <= 0) {
       alert('Debes seleccionar un área para continuar.');
       return;
     }


### PR DESCRIPTION
## Summary
- validate area and zone selections on the client before sending the access assignment request
- harden guardar_acceso_usuario.php with stricter zone validation, transactional insert, and clearer duplicate/foreign key handling

## Testing
- php -l scripts/php/guardar_acceso_usuario.php

------
https://chatgpt.com/codex/tasks/task_e_68d9ae1788e0832c9b8f8fc6a0c0239f