### PR TITLE
Implement area and zone capacity controls

### DIFF
--- a/pages/area_almac_v2/gestion_areas_zonas.html
+++ b/pages/area_almac_v2/gestion_areas_zonas.html
@@ -48,13 +48,44 @@
             Alterna entre formularios y consulta los resúmenes generales desde una vista limpia y moderna coherente con el resto del sistema.
           </p>
         </div>
-        <div class="shell-header__actions">
-          <button id="nuevaArea" class="shell-action shell-action--primary">Registrar nueva área</button>
-          <button id="nuevaZona" class="shell-action">Registrar nueva zona</button>
+      <div class="shell-header__actions">
+        <button id="nuevaArea" class="shell-action shell-action--primary">Registrar nueva área</button>
+        <button id="nuevaZona" class="shell-action">Registrar nueva zona</button>
+      </div>
+    </div>
+
+    <section class="filters-panel" aria-label="Filtros y reportes de zonas">
+      <div class="filters-grid">
+        <div class="filter-group">
+          <label for="filtroNombre">Buscar por nombre</label>
+          <input type="text" id="filtroNombre" placeholder="Nombre de la zona" />
+        </div>
+        <div class="filter-group">
+          <label for="filtroArea">Área asignada</label>
+          <select id="filtroArea">
+            <option value="todos">Todas las zonas</option>
+            <option value="sin-area">Zonas sin área</option>
+          </select>
+        </div>
+        <div class="filter-group">
+          <label for="filtroOcupacion">Capacidad utilizada mínima (%)</label>
+          <input type="range" id="filtroOcupacion" min="0" max="100" step="5" value="0" />
+          <span id="filtroOcupacionValor" class="filter-hint">Desde 0%</span>
+        </div>
+        <div class="filter-group">
+          <label for="filtroProductos">Productos almacenados (mínimo)</label>
+          <input type="number" id="filtroProductos" min="0" step="1" value="0" />
         </div>
       </div>
+      <div class="filters-actions">
+        <button type="button" id="exportExcel" class="shell-action">Exportar a Excel</button>
+        <button type="button" id="exportPdf" class="shell-action">Exportar a PDF</button>
+      </div>
+    </section>
 
-      <div class="shell-grid">
+    <div id="alertasSaturacion" class="alerts-banner" role="status" aria-live="polite"></div>
+
+    <div class="shell-grid">
         <div class="summary-stack">
           <section id="resumenAreas" class="data-card" aria-labelledby="tituloAreas">
             <header class="data-card__header">
@@ -70,7 +101,10 @@
                     <th>Descripción</th>
                     <th>Dimensiones (m)</th>
                     <th>Volumen (m³)</th>
-                    <th># Zonas</th>
+                    <th>Capacidad utilizada (m³)</th>
+                    <th>Disponible (m³)</th>
+                    <th>Ocupación</th>
+                    <th>Productos</th>
                     <th>Acciones</th>
                   </tr>
                 </thead>
@@ -92,8 +126,10 @@
                     <th>Zona</th>
                     <th>Área</th>
                     <th>Dimensiones (m)</th>
-                    <th>Volumen (m³)</th>
-                    <th>Tipo</th>
+                    <th>Capacidad utilizada (m³)</th>
+                    <th>Disponible (m³)</th>
+                    <th>Ocupación</th>
+                    <th>Productos</th>
                     <th>Acciones</th>
                   </tr>
                 </thead>
@@ -114,8 +150,10 @@
                   <tr>
                     <th>Zona</th>
                     <th>Dimensiones (m)</th>
-                    <th>Volumen (m³)</th>
-                    <th>Tipo</th>
+                    <th>Capacidad utilizada (m³)</th>
+                    <th>Disponible (m³)</th>
+                    <th>Ocupación</th>
+                    <th>Productos</th>
                     <th>Acciones</th>
                   </tr>
                 </thead>

--- a/scripts/php/infraestructura_utils.php
+++ b/scripts/php/infraestructura_utils.php
@@ -1,0 +1,186 @@
+<?php
+require_once __DIR__ . '/log_utils.php';
+
+function obtenerCapacidadMaximaAlmacen(mysqli $conn, int $empresaId): float
+{
+    $stmt = $conn->prepare('SELECT capacidad_maxima_m3 FROM empresa WHERE id_empresa = ?');
+    $stmt->bind_param('i', $empresaId);
+    $stmt->execute();
+    $stmt->bind_result($capacidadMaxima);
+    $stmt->fetch();
+    $stmt->close();
+
+    if ($capacidadMaxima === null) {
+        return 0.0;
+    }
+
+    return (float) $capacidadMaxima;
+}
+
+function obtenerUmbralAlertaCapacidad(mysqli $conn, int $empresaId): float
+{
+    $stmt = $conn->prepare('SELECT umbral_alerta_capacidad FROM empresa WHERE id_empresa = ?');
+    $stmt->bind_param('i', $empresaId);
+    $stmt->execute();
+    $stmt->bind_result($umbral);
+    $stmt->fetch();
+    $stmt->close();
+
+    if ($umbral === null || (float) $umbral <= 0) {
+        return 90.0;
+    }
+
+    return (float) $umbral;
+}
+
+function obtenerVolumenTotalZonas(mysqli $conn, int $areaId, ?int $zonaExcluir = null): float
+{
+    if ($zonaExcluir) {
+        $stmt = $conn->prepare('SELECT COALESCE(SUM(volumen), 0) FROM zonas WHERE area_id = ? AND id <> ?');
+        $stmt->bind_param('ii', $areaId, $zonaExcluir);
+    } else {
+        $stmt = $conn->prepare('SELECT COALESCE(SUM(volumen), 0) FROM zonas WHERE area_id = ?');
+        $stmt->bind_param('i', $areaId);
+    }
+    $stmt->execute();
+    $stmt->bind_result($total);
+    $stmt->fetch();
+    $stmt->close();
+
+    return (float) $total;
+}
+
+function calcularOcupacionZona(mysqli $conn, int $zonaId): ?array
+{
+    $stmt = $conn->prepare('SELECT id, nombre, volumen, id_empresa, area_id FROM zonas WHERE id = ?');
+    $stmt->bind_param('i', $zonaId);
+    $stmt->execute();
+    $zona = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+
+    if (!$zona) {
+        return null;
+    }
+
+    $stmt = $conn->prepare('SELECT COALESCE(SUM(GREATEST(stock,0) * COALESCE(dim_x,0) * COALESCE(dim_y,0) * COALESCE(dim_z,0)), 0), COUNT(*) FROM productos WHERE zona_id = ?');
+    $stmt->bind_param('i', $zonaId);
+    $stmt->execute();
+    $stmt->bind_result($ocupado, $productos);
+    $stmt->fetch();
+    $stmt->close();
+
+    $ocupado = (float) $ocupado;
+    $total = (float) $zona['volumen'];
+    $disponible = max($total - $ocupado, 0);
+    $porcentaje = $total > 0 ? min(100, ($ocupado / $total) * 100) : 0;
+
+    return [
+        'zona' => $zona,
+        'capacidad_utilizada' => $ocupado,
+        'capacidad_disponible' => $disponible,
+        'porcentaje_ocupacion' => $porcentaje,
+        'productos_registrados' => (int) $productos,
+    ];
+}
+
+function actualizarOcupacionZona(mysqli $conn, int $zonaId): void
+{
+    $datos = calcularOcupacionZona($conn, $zonaId);
+    if (!$datos) {
+        return;
+    }
+
+    $update = $conn->prepare('UPDATE zonas SET capacidad_utilizada = ?, porcentaje_ocupacion = ?, productos_registrados = ? WHERE id = ?');
+    $update->bind_param('ddii', $datos['capacidad_utilizada'], $datos['porcentaje_ocupacion'], $datos['productos_registrados'], $zonaId);
+    $update->execute();
+    $update->close();
+
+    $zona = $datos['zona'];
+    if (!empty($zona['area_id'])) {
+        actualizarOcupacionArea($conn, (int) $zona['area_id']);
+    }
+
+    $umbral = obtenerUmbralAlertaCapacidad($conn, (int) $zona['id_empresa']);
+    if ($datos['porcentaje_ocupacion'] >= $umbral) {
+        asegurarNotificacionSaturacion($conn, (int) $zona['id_empresa'], $zona['nombre'], $datos['porcentaje_ocupacion']);
+    }
+}
+
+function actualizarOcupacionArea(mysqli $conn, int $areaId): void
+{
+    $stmt = $conn->prepare('SELECT id, nombre, volumen, id_empresa FROM areas WHERE id = ?');
+    $stmt->bind_param('i', $areaId);
+    $stmt->execute();
+    $area = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+
+    if (!$area) {
+        return;
+    }
+
+    $stmt = $conn->prepare('SELECT COALESCE(SUM(capacidad_utilizada), 0), COALESCE(SUM(productos_registrados), 0) FROM zonas WHERE area_id = ?');
+    $stmt->bind_param('i', $areaId);
+    $stmt->execute();
+    $stmt->bind_result($ocupado, $productos);
+    $stmt->fetch();
+    $stmt->close();
+
+    $ocupado = (float) $ocupado;
+    $total = (float) $area['volumen'];
+    $porcentaje = $total > 0 ? min(100, ($ocupado / $total) * 100) : 0;
+
+    $update = $conn->prepare('UPDATE areas SET capacidad_utilizada = ?, porcentaje_ocupacion = ?, productos_registrados = ? WHERE id = ?');
+    $update->bind_param('ddii', $ocupado, $porcentaje, $productos, $areaId);
+    $update->execute();
+    $update->close();
+}
+
+function asegurarNotificacionSaturacion(mysqli $conn, int $empresaId, string $zonaNombre, float $porcentaje): void
+{
+    $ruta = 'area_almac_v2/gestion_areas_zonas.html';
+    $like = '%' . $zonaNombre . '%';
+    $stmt = $conn->prepare('SELECT id FROM notificaciones WHERE id_empresa = ? AND ruta_destino = ? AND mensaje LIKE ? AND estado IN ("Pendiente", "Enviada") LIMIT 1');
+    $stmt->bind_param('iss', $empresaId, $ruta, $like);
+    $stmt->execute();
+    $stmt->store_result();
+
+    if ($stmt->num_rows > 0) {
+        $stmt->close();
+        return;
+    }
+    $stmt->close();
+
+    $titulo = 'Zona con alta ocupación';
+    $mensaje = sprintf('La zona "%s" se encuentra al %.2f%% de su capacidad. Revisa las reasignaciones necesarias.', $zonaNombre, $porcentaje);
+
+    $insert = $conn->prepare('INSERT INTO notificaciones (id_empresa, titulo, mensaje, tipo_destinatario, ruta_destino, estado, prioridad) VALUES (?, ?, ?, "General", ?, "Pendiente", "Alta")');
+    $insert->bind_param('isss', $empresaId, $titulo, $mensaje, $ruta);
+    $insert->execute();
+    $insert->close();
+}
+
+function validarCapacidadContraAlmacen(mysqli $conn, int $empresaId, float $volumen): bool
+{
+    $capacidad = obtenerCapacidadMaximaAlmacen($conn, $empresaId);
+    if ($capacidad <= 0) {
+        return true;
+    }
+    return $volumen <= $capacidad;
+}
+
+function obtenerCapacidadDisponibleArea(mysqli $conn, int $areaId, ?int $zonaExcluir = null): float
+{
+    $stmt = $conn->prepare('SELECT volumen FROM areas WHERE id = ?');
+    $stmt->bind_param('i', $areaId);
+    $stmt->execute();
+    $stmt->bind_result($volumenArea);
+    $stmt->fetch();
+    $stmt->close();
+
+    if ($volumenArea === null) {
+        return 0.0;
+    }
+
+    $totalZonas = obtenerVolumenTotalZonas($conn, $areaId, $zonaExcluir);
+    return max(((float) $volumenArea) - $totalZonas, 0);
+}

--- a/styles/Area_almac_v2/gestion_areas_zonas.css
+++ b/styles/Area_almac_v2/gestion_areas_zonas.css
@@ -560,3 +560,135 @@ img {
     padding: 1rem;
   }
 }
+
+.filters-panel {
+  margin-top: 1.5rem;
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.filters-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.filter-group label {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--text-color);
+}
+
+.filter-group input,
+.filter-group select {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+  padding: 0.55rem 0.75rem;
+  font-size: 0.9rem;
+  font-family: var(--font-main);
+  background: rgba(245, 246, 251, 0.9);
+}
+
+.filter-group input[type="range"] {
+  padding: 0;
+}
+
+.filter-hint {
+  font-size: 0.75rem;
+  color: var(--muted-color);
+}
+
+.filters-actions {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.alerts-banner {
+  display: none;
+  margin: 1.5rem 0;
+  padding: 0.85rem 1.1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 107, 107, 0.35);
+  background: rgba(255, 107, 107, 0.12);
+  color: #b71c1c;
+  font-weight: 600;
+}
+
+.alerts-banner.active {
+  display: block;
+}
+
+.alerts-banner ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+  font-weight: 500;
+  color: #8c1d1d;
+}
+
+.capacity-bar {
+  position: relative;
+  height: 0.75rem;
+  background: rgba(23, 31, 52, 0.12);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+}
+
+.capacity-bar__fill {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, #6c63ff, #ff6f91);
+}
+
+.capacity-bar__label {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #fff;
+  text-shadow: 0 0 4px rgba(0, 0, 0, 0.35);
+}
+
+.capacity-bar--warning .capacity-bar__fill {
+  background: linear-gradient(90deg, #ffa41b, #ff6f91);
+}
+
+.capacity-bar--critical .capacity-bar__fill {
+  background: linear-gradient(90deg, #ff6b6b, #c0392b);
+}
+
+.table-title {
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.table-subtext {
+  display: block;
+  margin-top: 0.15rem;
+  font-size: 0.75rem;
+  color: var(--muted-color);
+}
+
+.row-alert {
+  background: rgba(255, 107, 107, 0.08);
+}
+
+.row-alert:hover {
+  background: rgba(255, 107, 107, 0.12);
+}

--- a/u296155119_OptiStock (3).sql
+++ b/u296155119_OptiStock (3).sql
@@ -35,6 +35,9 @@ CREATE TABLE `areas` (
   `alto` decimal(10,2) NOT NULL,
   `largo` decimal(10,2) NOT NULL,
   `volumen` decimal(15,2) NOT NULL,
+  `capacidad_utilizada` decimal(15,2) NOT NULL DEFAULT 0.00,
+  `porcentaje_ocupacion` decimal(5,2) NOT NULL DEFAULT 0.00,
+  `productos_registrados` int(11) NOT NULL DEFAULT 0,
   `id_empresa` int(11) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
@@ -42,14 +45,14 @@ CREATE TABLE `areas` (
 -- Volcado de datos para la tabla `areas`
 --
 
-INSERT INTO `areas` (`id`, `nombre`, `descripcion`, `ancho`, `alto`, `largo`, `volumen`, `id_empresa`) VALUES
-(21, 'area', 'mi area', 7.00, 2.50, 6.00, 105.00, 21),
-(22, 'Area 1', 'Es el area 1', 5.00, 2.00, 2.00, 20.00, 24),
-(23, 'Papeleria', 'ES una papeleria', 5.00, 2.00, 5.00, 50.00, 23),
-(24, 'El patolicismo', 'Una religion de patos', 99999999.99, 99999999.99, 99999999.99, 9999999999999.99, 28),
-(25, 'Papeleria', 'Descripcion', 8.00, 2.00, 5.00, 80.00, 24),
-(26, 'otra area', 'area dos', 20.00, 4.00, 14.00, 1120.00, 21),
-(28, 'Area1', 'area1', 20.00, 3.00, 30.00, 1800.00, 30);
+INSERT INTO `areas` (`id`, `nombre`, `descripcion`, `ancho`, `alto`, `largo`, `volumen`, `capacidad_utilizada`, `porcentaje_ocupacion`, `productos_registrados`, `id_empresa`) VALUES
+(21, 'area', 'mi area', 7.00, 2.50, 6.00, 105.00, 0.00, 0.00, 0, 21),
+(22, 'Area 1', 'Es el area 1', 5.00, 2.00, 2.00, 20.00, 0.00, 0.00, 0, 24),
+(23, 'Papeleria', 'ES una papeleria', 5.00, 2.00, 5.00, 50.00, 0.00, 0.00, 0, 23),
+(24, 'El patolicismo', 'Una religion de patos', 99999999.99, 99999999.99, 99999999.99, 9999999999999.99, 0.00, 0.00, 0, 28),
+(25, 'Papeleria', 'Descripcion', 8.00, 2.00, 5.00, 80.00, 0.00, 0.00, 0, 24),
+(26, 'otra area', 'area dos', 20.00, 4.00, 14.00, 1120.00, 0.00, 0.00, 0, 21),
+(28, 'Area1', 'area1', 20.00, 3.00, 30.00, 1800.00, 0.00, 0.00, 0, 30);
 
 -- --------------------------------------------------------
 
@@ -117,26 +120,28 @@ CREATE TABLE `empresa` (
   `logo_empresa` varchar(255) DEFAULT NULL,
   `sector_empresa` enum('Industrial','Comercial','Servicios','agropecuario','tecnol?gico','financiero','Construcci?n') DEFAULT NULL,
   `usuario_creador` int(11) DEFAULT NULL,
-  `fecha_registro` timestamp NOT NULL DEFAULT current_timestamp()
+  `fecha_registro` timestamp NOT NULL DEFAULT current_timestamp(),
+  `capacidad_maxima_m3` decimal(15,2) NOT NULL DEFAULT 0.00,
+  `umbral_alerta_capacidad` decimal(5,2) NOT NULL DEFAULT 90.00
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Volcado de datos para la tabla `empresa`
 --
 
-INSERT INTO `empresa` (`id_empresa`, `nombre_empresa`, `logo_empresa`, `sector_empresa`, `usuario_creador`, `fecha_registro`) VALUES
-(21, 'Discocks', '/images/logos/logo_21_1755907312.png', 'Comercial', 57, '2025-06-26 19:29:13'),
-(22, 'empresa', NULL, 'Industrial', 58, '2025-07-01 01:31:07'),
-(23, 'afwfqf', NULL, 'Industrial', 33, '2025-07-01 01:45:04'),
-(24, 'EL KINI CORP', '/images/logos/logo_24_1757520273.jpeg', 'Industrial', 60, '2025-07-01 01:45:36'),
-(25, 'elkini', NULL, 'Industrial', 56, '2025-07-01 13:17:34'),
-(26, 'Salchichas pepe', NULL, 'Comercial', 83, '2025-07-01 14:28:13'),
-(27, 'ROMO\'S', NULL, '', 91, '2025-08-02 14:54:20'),
-(28, 'Papamovil.net', NULL, '', 93, '2025-08-04 17:06:27'),
-(29, 'Optistock', NULL, 'Servicios', 97, '2025-08-08 04:18:41'),
-(30, 'KInicorp', '/images/logos/logo_1756916306.jpg', 'Servicios', 101, '2025-09-03 16:18:26'),
-(31, 'Discos de Vinilo y CD', NULL, 'Comercial', 102, '2025-09-05 00:27:10'),
-(32, 'Empresa.exe', NULL, '', 113, '2025-09-10 16:12:08');
+INSERT INTO `empresa` (`id_empresa`, `nombre_empresa`, `logo_empresa`, `sector_empresa`, `usuario_creador`, `fecha_registro`, `capacidad_maxima_m3`, `umbral_alerta_capacidad`) VALUES
+(21, 'Discocks', '/images/logos/logo_21_1755907312.png', 'Comercial', 57, '2025-06-26 19:29:13', 0.00, 90.00),
+(22, 'empresa', NULL, 'Industrial', 58, '2025-07-01 01:31:07', 0.00, 90.00),
+(23, 'afwfqf', NULL, 'Industrial', 33, '2025-07-01 01:45:04', 0.00, 90.00),
+(24, 'EL KINI CORP', '/images/logos/logo_24_1757520273.jpeg', 'Industrial', 60, '2025-07-01 01:45:36', 0.00, 90.00),
+(25, 'elkini', NULL, 'Industrial', 56, '2025-07-01 13:17:34', 0.00, 90.00),
+(26, 'Salchichas pepe', NULL, 'Comercial', 83, '2025-07-01 14:28:13', 0.00, 90.00),
+(27, 'ROMO\'S', NULL, '', 91, '2025-08-02 14:54:20', 0.00, 90.00),
+(28, 'Papamovil.net', NULL, '', 93, '2025-08-04 17:06:27', 0.00, 90.00),
+(29, 'Optistock', NULL, 'Servicios', 97, '2025-08-08 04:18:41', 0.00, 90.00),
+(30, 'KInicorp', '/images/logos/logo_1756916306.jpg', 'Servicios', 101, '2025-09-03 16:18:26', 0.00, 90.00),
+(31, 'Discos de Vinilo y CD', NULL, 'Comercial', 102, '2025-09-05 00:27:10', 0.00, 90.00),
+(32, 'Empresa.exe', NULL, '', 113, '2025-09-10 16:12:08', 0.00, 90.00);
 
 -- --------------------------------------------------------
 
@@ -664,6 +669,9 @@ CREATE TABLE `zonas` (
   `alto` decimal(10,2) NOT NULL,
   `largo` decimal(10,2) NOT NULL,
   `volumen` decimal(15,2) NOT NULL,
+  `capacidad_utilizada` decimal(15,2) NOT NULL DEFAULT 0.00,
+  `porcentaje_ocupacion` decimal(5,2) NOT NULL DEFAULT 0.00,
+  `productos_registrados` int(11) NOT NULL DEFAULT 0,
   `tipo_almacenamiento` varchar(50) DEFAULT NULL,
   `subniveles` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL CHECK (json_valid(`subniveles`)),
   `area_id` int(11) DEFAULT NULL,
@@ -674,16 +682,16 @@ CREATE TABLE `zonas` (
 -- Volcado de datos para la tabla `zonas`
 --
 
-INSERT INTO `zonas` (`id`, `nombre`, `descripcion`, `ancho`, `alto`, `largo`, `volumen`, `tipo_almacenamiento`, `subniveles`, `area_id`, `id_empresa`) VALUES
-(16, 'zona', 'mi zona', 3.00, 2.00, 1.00, 6.00, 'rack', '[]', 21, 21),
-(17, 'Zona 1', 'es la zona 1', 2.00, 2.00, 2.00, 8.00, 'gabinete', '[]', 22, 24),
-(18, 'Mostrador', 'SI', 2.00, 1.00, 2.00, 4.00, 'vitrina', '[]', 23, 23),
-(19, 'Iglesia Patólica', 'Una iglesia a nuestro señor y salvador emplumado', 0.00, 1.00, 0.00, 0.00, 'jaula', '[]', 24, 28),
-(20, 'rack A', 'rack para cosas pesadas', 1.50, 3.00, 5.00, 22.50, 'rack', '[]', 26, 21),
-(21, 'rack B', 'otro rack', 1.50, 3.00, 5.00, 22.50, 'rack', '[]', 26, 21),
-(22, 'rack C', 'otro rack', 1.50, 3.00, 5.00, 22.50, 'rack', '[]', 26, 21),
-(23, 'Zona1', 'zona1', 2.00, 1.00, 2.00, 4.00, 'cajón', '[]', 28, 30),
-(24, 'zona nueva', 'zona que no quiero con area', 10.00, 2.00, 10.00, 200.00, 'jaula', '[]', NULL, 21);
+INSERT INTO `zonas` (`id`, `nombre`, `descripcion`, `ancho`, `alto`, `largo`, `volumen`, `capacidad_utilizada`, `porcentaje_ocupacion`, `productos_registrados`, `tipo_almacenamiento`, `subniveles`, `area_id`, `id_empresa`) VALUES
+(16, 'zona', 'mi zona', 3.00, 2.00, 1.00, 6.00, 0.00, 0.00, 0, 'rack', '[]', 21, 21),
+(17, 'Zona 1', 'es la zona 1', 2.00, 2.00, 2.00, 8.00, 0.00, 0.00, 0, 'gabinete', '[]', 22, 24),
+(18, 'Mostrador', 'SI', 2.00, 1.00, 2.00, 4.00, 0.00, 0.00, 0, 'vitrina', '[]', 23, 23),
+(19, 'Iglesia Patólica', 'Una iglesia a nuestro señor y salvador emplumado', 0.00, 1.00, 0.00, 0.00, 0.00, 0.00, 0, 'jaula', '[]', 24, 28),
+(20, 'rack A', 'rack para cosas pesadas', 1.50, 3.00, 5.00, 22.50, 0.00, 0.00, 0, 'rack', '[]', 26, 21),
+(21, 'rack B', 'otro rack', 1.50, 3.00, 5.00, 22.50, 0.00, 0.00, 0, 'rack', '[]', 26, 21),
+(22, 'rack C', 'otro rack', 1.50, 3.00, 5.00, 22.50, 0.00, 0.00, 0, 'rack', '[]', 26, 21),
+(23, 'Zona1', 'zona1', 2.00, 1.00, 2.00, 4.00, 0.00, 0.00, 0, 'cajón', '[]', 28, 30),
+(24, 'zona nueva', 'zona que no quiero con area', 10.00, 2.00, 10.00, 200.00, 0.00, 0.00, 0, 'jaula', '[]', NULL, 21);
 
 -- --------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add infraestructura_utils helper to centralize warehouse capacity calculations and alert generation
- enforce new validation and occupancy updates in area, zone, and product PHP endpoints
- refresh areas/zones UI with filters, occupancy metrics, exports, and alert banner while expanding schema defaults

## Testing
- php -l scripts/php/infraestructura_utils.php
- php -l scripts/php/guardar_areas.php
- php -l scripts/php/guardar_zonas.php
- php -l scripts/php/guardar_productos.php

------
https://chatgpt.com/codex/tasks/task_e_68d9b921a4cc832cb1a7ba75d3936333