### PR TITLE
feat: add three-dot product action menu

### DIFF
--- a/styles/gest_inve/inventario_basico.css
+++ b/styles/gest_inve/inventario_basico.css
@@ -488,6 +488,74 @@ img {
   border-bottom: none;
 }
 
+.table-action-menu {
+  position: relative;
+  display: inline-flex;
+  justify-content: flex-end;
+  width: 100%;
+}
+
+.table-action-menu__toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+  background: var(--primary-surface);
+  color: var(--muted-color);
+  font-size: 1.35rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  padding: 0;
+}
+
+.table-action-menu__toggle:hover,
+.table-action-menu__toggle[aria-expanded="true"] {
+  background: var(--primary-color);
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 16px 32px -24px rgba(17, 24, 67, 0.55);
+}
+
+.table-action-menu__dropdown {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  min-width: 11rem;
+  padding: 0.6rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+  background: var(--card-bg);
+  box-shadow: 0 18px 36px -24px rgba(17, 24, 67, 0.55);
+  display: none;
+  flex-direction: column;
+  gap: 0.4rem;
+  z-index: 25;
+}
+
+.table-action-menu__dropdown.is-open {
+  display: flex;
+}
+
+.table-action-menu__item {
+  display: inline-flex;
+  align-items: center;
+  width: 100%;
+  justify-content: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  border-radius: var(--radius-sm);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.table-action-menu__item:active {
+  transform: translateY(1px);
+  box-shadow: inset 0 2px 6px rgba(17, 24, 67, 0.15);
+}
+
 .modal-eyebrow {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- replace the inline product action buttons with a three-dot toggle that opens a submenu
- add JavaScript helpers to manage menu state and close it on outside clicks or Escape
- style the dropdown menu to match the existing inventory design

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9c486a460832c985563b259ebc96c