### PR TITLE
Add modal QR viewer and collapsible product form

### DIFF
--- a/pages/gest_inve/inventario.html
+++ b/pages/gest_inve/inventario.html
@@ -162,7 +162,85 @@
                   <input list="sugerenciasProducto" id="buscarProducto" placeholder="Buscar producto..." />
                   <datalist id="sugerenciasProducto"></datalist>
                 </div>
-                <button type="button" class="btn-add">+ Nuevo producto</button>
+                <button type="button" class="btn-add" id="abrirFormularioProducto">+ Nuevo producto</button>
+              </div>
+
+              <div id="productoFormContainer" class="collapse-form" hidden>
+                <div class="collapse-card">
+                  <div class="collapse-card__header">
+                    <h3 id="productoFormTitulo" class="collapse-card__title">Nuevo producto</h3>
+                    <button type="button" class="btn-close" aria-label="Cerrar" id="cerrarFormularioProducto"></button>
+                  </div>
+                  <form id="productoForm" class="compact-form">
+                    <input type="hidden" id="productoId" />
+                    <div class="row g-3">
+                      <div class="col-md-6">
+                        <label for="productoNombre" class="form-label">Nombre</label>
+                        <input type="text" id="productoNombre" class="form-control" placeholder="Nombre del producto" required />
+                      </div>
+                      <div class="col-md-6">
+                        <label for="productoCategoria" class="form-label">Categoría</label>
+                        <select id="productoCategoria" class="form-select" required>
+                          <option value="">Categoría</option>
+                        </select>
+                      </div>
+                    </div>
+                    <div class="row g-3">
+                      <div class="col-md-6">
+                        <label for="productoSubcategoria" class="form-label">Subcategoría</label>
+                        <select id="productoSubcategoria" class="form-select" required>
+                          <option value="">Subcategoría</option>
+                        </select>
+                      </div>
+                      <div class="col-md-6">
+                        <label for="productoArea" class="form-label">Área de almacén</label>
+                        <select id="productoArea" class="form-select">
+                          <option value="">Selecciona un área</option>
+                        </select>
+                      </div>
+                    </div>
+                    <div class="row g-3">
+                      <div class="col-md-6">
+                        <label for="productoZona" class="form-label">Zona de almacén</label>
+                        <select id="productoZona" class="form-select" disabled>
+                          <option value="">Selecciona un área para ver zonas</option>
+                        </select>
+                      </div>
+                      <div class="col-md-6">
+                        <label for="productoStock" class="form-label">Stock inicial</label>
+                        <input type="number" id="productoStock" class="form-control" placeholder="Cantidad" min="0" />
+                      </div>
+                    </div>
+                    <div class="row g-3">
+                      <div class="col-md-4">
+                        <label for="productoDimX" class="form-label">Dimensión X (m)</label>
+                        <input type="number" id="productoDimX" class="form-control" placeholder="Ancho" min="0" step="0.01" />
+                      </div>
+                      <div class="col-md-4">
+                        <label for="productoDimY" class="form-label">Dimensión Y (m)</label>
+                        <input type="number" id="productoDimY" class="form-control" placeholder="Alto" min="0" step="0.01" />
+                      </div>
+                      <div class="col-md-4">
+                        <label for="productoDimZ" class="form-label">Dimensión Z (m)</label>
+                        <input type="number" id="productoDimZ" class="form-control" placeholder="Largo" min="0" step="0.01" />
+                      </div>
+                    </div>
+                    <div class="row g-3">
+                      <div class="col-md-6">
+                        <label for="productoPrecio" class="form-label">Precio de compra</label>
+                        <input type="number" id="productoPrecio" class="form-control" placeholder="0.00" min="0" step="0.01" />
+                      </div>
+                      <div class="col-md-6">
+                        <label for="productoDesc" class="form-label">Descripción</label>
+                        <textarea id="productoDesc" class="form-control" placeholder="Características y notas"></textarea>
+                      </div>
+                    </div>
+                    <div class="form-actions">
+                      <button type="button" class="btn btn-outline-secondary" id="cancelarFormularioProducto">Cancelar</button>
+                      <button type="submit" class="btn btn-primary">Guardar</button>
+                    </div>
+                  </form>
+                </div>
               </div>
 
               <div id="alertasStock" class="panel-alert" role="status"></div>
@@ -251,97 +329,21 @@
     </section>
   </div>
 
-  <div class="modal fade" id="productoModal" tabindex="-1" aria-labelledby="productoModalTitulo" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered modal-lg">
+  <div class="modal fade" id="qrModal" tabindex="-1" aria-labelledby="qrModalTitulo" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title" id="productoModalTitulo">Nuevo producto</h5>
+          <h5 class="modal-title" id="qrModalTitulo">Código QR</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
         </div>
         <div class="modal-body">
-          <form id="productoForm" class="compact-form">
-            <input type="hidden" id="productoId" />
-            <div class="row g-3">
-              <div class="col-md-6">
-                <label for="productoNombre" class="form-label">Nombre</label>
-                <input type="text" id="productoNombre" class="form-control" placeholder="Nombre del producto" required />
-              </div>
-              <div class="col-md-6">
-                <label for="productoCategoria" class="form-label">Categoría</label>
-                <select id="productoCategoria" class="form-select" required>
-                  <option value="">Categoría</option>
-                </select>
-              </div>
-            </div>
-            <div class="row g-3">
-              <div class="col-md-6">
-                <label for="productoSubcategoria" class="form-label">Subcategoría</label>
-                <select id="productoSubcategoria" class="form-select" required>
-                  <option value="">Subcategoría</option>
-                </select>
-              </div>
-              <div class="col-md-6">
-                <label for="productoArea" class="form-label">Área de almacén</label>
-                <select id="productoArea" class="form-select">
-                  <option value="">Área</option>
-                </select>
-              </div>
-            </div>
-            <div class="row g-3">
-              <div class="col-md-6">
-                <label for="productoZona" class="form-label">Zona de almacén</label>
-                <select id="productoZona" class="form-select">
-                  <option value="">Zona</option>
-                </select>
-              </div>
-              <div class="col-md-6">
-                <label for="productoStock" class="form-label">Stock inicial</label>
-                <input type="number" id="productoStock" class="form-control" placeholder="Cantidad" min="0" />
-              </div>
-            </div>
-            <div class="row g-3">
-              <div class="col-md-6">
-                <label for="productoArea" class="form-label">Área de almacén</label>
-                <select id="productoArea" class="form-select">
-                  <option value="">Selecciona un área</option>
-                </select>
-              </div>
-              <div class="col-md-6">
-                <label for="productoZona" class="form-label">Zona de almacén</label>
-                <select id="productoZona" class="form-select" disabled>
-                  <option value="">Selecciona un área para ver zonas</option>
-                </select>
-              </div>
-            </div>
-            <div class="row g-3">
-              <div class="col-md-4">
-                <label for="productoDimX" class="form-label">Dimensión X (m)</label>
-                <input type="number" id="productoDimX" class="form-control" placeholder="Ancho" min="0" step="0.01" />
-              </div>
-              <div class="col-md-4">
-                <label for="productoDimY" class="form-label">Dimensión Y (m)</label>
-                <input type="number" id="productoDimY" class="form-control" placeholder="Alto" min="0" step="0.01" />
-              </div>
-              <div class="col-md-4">
-                <label for="productoDimZ" class="form-label">Dimensión Z (m)</label>
-                <input type="number" id="productoDimZ" class="form-control" placeholder="Largo" min="0" step="0.01" />
-              </div>
-            </div>
-            <div class="row g-3">
-              <div class="col-md-6">
-                <label for="productoPrecio" class="form-label">Precio de compra</label>
-                <input type="number" id="productoPrecio" class="form-control" placeholder="0.00" min="0" step="0.01" />
-              </div>
-              <div class="col-md-6">
-                <label for="productoDesc" class="form-label">Descripción</label>
-                <textarea id="productoDesc" class="form-control" placeholder="Características y notas"></textarea>
-              </div>
-            </div>
-            <div class="form-actions">
-              <button type="reset" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
-              <button type="submit" class="btn btn-primary">Guardar</button>
-            </div>
-          </form>
+          <div class="qr-preview">
+            <img id="qrModalImagen" src="" alt="Código QR de producto" class="qr-preview__image" />
+            <p class="qr-preview__details" id="qrModalDescripcion"></p>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <a id="qrModalDescargar" href="#" class="btn btn-primary" download>Descargar código</a>
         </div>
       </div>
     </div>

--- a/styles/gest_inve/inventario.css
+++ b/styles/gest_inve/inventario.css
@@ -603,6 +603,46 @@ img {
   box-shadow: 0 18px 40px -32px rgba(14, 20, 56, 0.4);
 }
 
+.collapse-form {
+  border: 1px dashed var(--primary-border-soft);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.6);
+  padding: clamp(1.25rem, 2.5vw, 1.75rem);
+  box-shadow: inset 0 0 0 1px rgba(255, 111, 145, 0.08);
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  opacity: 0;
+  transform: translateY(-12px);
+}
+
+.collapse-form.is-open {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.collapse-form[hidden] {
+  display: none;
+}
+
+.collapse-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.collapse-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.collapse-card__title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--primary-color);
+}
+
 .panel-header {
   display: flex;
   flex-wrap: wrap;
@@ -821,16 +861,48 @@ img {
 }
 
 .item-qr {
-  text-align: center;
-  font-size: 0.78rem;
-  color: var(--muted-color);
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-top: 0.75rem;
 }
 
-.qr-img {
-  width: 96px;
-  height: 96px;
-  object-fit: contain;
-  margin: 0 auto 0.25rem auto;
+.qr-button {
+  border: 1px solid var(--primary-border-soft);
+  background: rgba(255, 111, 145, 0.12);
+  color: var(--primary-color);
+  font-weight: 600;
+  font-size: 0.8rem;
+  padding: 0.45rem 0.85rem;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.qr-button:hover {
+  background: rgba(255, 111, 145, 0.18);
+  transform: translateY(-1px);
+}
+
+.qr-preview {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  text-align: center;
+}
+
+.qr-preview__image {
+  width: min(220px, 60vw);
+  height: auto;
+  border-radius: var(--radius-md);
+  box-shadow: 0 18px 45px -32px rgba(18, 26, 69, 0.4);
+}
+
+.qr-preview__details {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted-color);
 }
 
 @media (max-width: 992px) {


### PR DESCRIPTION
## Summary
- embed the product creation form directly in the inventory tab inside a collapsible panel with cancel and close controls
- replace the inline QR rendering with a Bootstrap modal that previews the code and offers a download link
- add styling and controller logic to manage the collapsible form and QR modal behaviour across the list and summary table

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d9c7b9d93c832caa4facf5ad2d116e