### PR TITLE
Add modal QR viewer and collapsible product form

### DIFF
--- a/pages/gest_inve/inventario_basico.html
+++ b/pages/gest_inve/inventario_basico.html
@@ -133,16 +133,33 @@
 
       <div class="inventory-card">
         <section id="productoFormContainer" class="panel-card" aria-labelledby="btnProductos">
-          <header class="panel-header">
-            <span class="panel-eyebrow">Productos</span>
-            <h2 class="panel-title">Registrar nuevo producto</h2>
-            <p class="panel-description">
-              Define la información esencial de cada artículo, incluyendo medidas, categoría y zona de almacenamiento para
-              mantener tu inventario sincronizado.
-            </p>
+          <header class="panel-header panel-header--collapsible">
+            <div class="panel-header__content">
+              <span class="panel-eyebrow">Productos</span>
+              <h2 id="productoFormTitle" class="panel-title">Registrar nuevo producto</h2>
+              <p id="productoFormSubtitle" class="panel-description">
+                Define la información esencial de cada artículo, incluyendo medidas, categoría y zona de almacenamiento para
+                mantener tu inventario sincronizado.
+              </p>
+              <div id="productoFormModeHint" class="panel-mode-hint d-none" role="status">
+                Editando <span id="productoFormModeProduct" class="panel-mode-hint__product"></span>
+              </div>
+            </div>
+            <button
+              id="productoFormToggle"
+              class="btn btn-outline-primary panel-toggle"
+              type="button"
+              data-bs-toggle="collapse"
+              data-bs-target="#productoFormCollapse"
+              aria-controls="productoFormCollapse"
+              aria-expanded="true"
+            >
+              Ocultar formulario
+            </button>
           </header>
 
-          <form id="productoForm" class="compact-form" novalidate>
+          <div id="productoFormCollapse" class="collapse show">
+            <form id="productoForm" class="compact-form" novalidate>
             <div class="row g-3">
               <div class="col-lg-6">
                 <label for="prodNombre" class="form-label">Nombre del producto</label>
@@ -210,9 +227,10 @@
 
             <div class="form-actions">
               <button type="reset" class="btn btn-secondary">Cancelar</button>
-              <button type="submit" class="btn btn-primary">Guardar producto</button>
+              <button id="productoFormSubmit" type="submit" class="btn btn-primary">Guardar producto</button>
             </div>
-          </form>
+            </form>
+          </div>
         </section>
 
         <section id="categoriaFormContainer" class="panel-card d-none" aria-labelledby="btnCategorias">
@@ -276,6 +294,30 @@
         </section>
       </div>
     </section>
+  </div>
+
+  <div class="modal fade" id="productoQrModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content shadow-lg">
+        <div class="modal-header border-0">
+          <div>
+            <span class="modal-eyebrow">Código QR</span>
+            <h5 id="productoQrTitle" class="modal-title fw-bold">Código QR del producto</h5>
+          </div>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+        </div>
+        <div class="modal-body">
+          <div id="productoQrPreview" class="qr-preview">
+            <div id="productoQrPlaceholder" class="qr-placeholder">Generando código QR...</div>
+            <img id="productoQrImage" class="qr-image d-none" alt="Código QR del producto" />
+          </div>
+        </div>
+        <div class="modal-footer border-0 d-flex flex-column flex-sm-row gap-2">
+          <a id="productoQrDownload" class="btn btn-outline-primary flex-fill" download>Descargar QR</a>
+          <button class="btn btn-secondary flex-fill" type="button" data-bs-dismiss="modal">Cerrar</button>
+        </div>
+      </div>
+    </div>
   </div>
 
   <div class="modal fade" id="movimientoModal" tabindex="-1" aria-hidden="true">

--- a/styles/gest_inve/inventario_basico.css
+++ b/styles/gest_inve/inventario_basico.css
@@ -244,6 +244,51 @@ img {
   margin-bottom: 1.2rem;
 }
 
+.panel-header--collapsible {
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
+}
+
+.panel-header__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1 1 260px;
+}
+
+.panel-toggle {
+  align-self: flex-start;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  padding-inline: 1.25rem;
+  padding-block: 0.5rem;
+  box-shadow: none;
+}
+
+.panel-toggle:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}
+
+.panel-mode-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 111, 145, 0.12);
+  color: var(--primary-color);
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.panel-mode-hint__product {
+  font-weight: 600;
+}
+
 .panel-eyebrow {
   display: inline-flex;
   align-items: center;
@@ -316,6 +361,39 @@ img {
   display: flex;
   justify-content: flex-end;
   gap: 0.75rem;
+}
+
+.qr-preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  border: 1px dashed var(--border-color);
+  min-height: 220px;
+  background: rgba(245, 246, 251, 0.9);
+}
+
+.qr-image {
+  width: min(240px, 90%);
+  height: auto;
+}
+
+.qr-placeholder {
+  font-size: 0.95rem;
+  color: var(--muted-color);
+  text-align: center;
+}
+
+@media (max-width: 576px) {
+  .panel-header--collapsible {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .panel-toggle {
+    align-self: stretch;
+  }
 }
 
 .btn.btn-primary {


### PR DESCRIPTION
## Summary
- make the product creation form collapsible and show edit context when updating a product
- open product QR codes inside a Bootstrap modal with download support instead of a new tab
- add supporting UI styling and JavaScript logic for the new interactions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9d0882380832cadd0918cc70e30c0