### PR TITLE
Adjust filters card layout in admin user page

### DIFF
--- a/pages/admin_usuar/administracion_usuarios.html
+++ b/pages/admin_usuar/administracion_usuarios.html
@@ -88,6 +88,52 @@
         </table>
       </div>
     </section>
+
+    <section class="filters-card">
+      <div class="filters-heading">
+        <div>
+          <span class="filters-eyebrow">Herramientas rápidas</span>
+          <h2 class="filters-title">Filtra y exporta la información de tus colaboradores</h2>
+        </div>
+        <div class="filters-actions">
+          <button type="button" onclick="exportarPDF()" class="btn-icon" title="Exportar PDF">
+            <span class="btn-icon__circle">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                <polyline points="14 2 14 8 20 8"></polyline>
+                <line x1="16" y1="13" x2="8" y2="13"></line>
+                <line x1="16" y1="17" x2="8" y2="17"></line>
+                <polyline points="10 9 9 9 8 9"></polyline>
+              </svg>
+            </span>
+            <span class="btn-icon__label">PDF</span>
+          </button>
+          <button type="button" onclick="exportarExcel()" class="btn-icon" title="Exportar Excel">
+            <span class="btn-icon__circle">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                <polyline points="14 2 14 8 20 8"></polyline>
+                <path d="M8 13h4"></path>
+                <path d="M8 17h4"></path>
+                <path d="M16 13h-4v4"></path>
+              </svg>
+            </span>
+            <span class="btn-icon__label">Excel</span>
+          </button>
+        </div>
+      </div>
+
+      <div class="filters-grid">
+        <div class="filter-field">
+          <label for="filtroRol" class="form-label">Filtrar por rol</label>
+          <select id="filtroRol" class="form-select">
+            <option value="">Todos los roles</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="metrics-grid" id="metricasUsuarios"></div>
+    </section>
   </div>
 
   <div class="modal fade" id="modalEditarUsuario" tabindex="-1" aria-hidden="true">
@@ -204,54 +250,6 @@
         </div>
       </div>
     </div>
-  </div>
-
-    <section class="filters-card">
-      <div class="filters-heading">
-        <div>
-          <span class="filters-eyebrow">Herramientas rápidas</span>
-          <h2 class="filters-title">Filtra y exporta la información de tus colaboradores</h2>
-        </div>
-        <div class="filters-actions">
-          <button type="button" onclick="exportarPDF()" class="btn-icon" title="Exportar PDF">
-            <span class="btn-icon__circle">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
-                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-                <polyline points="14 2 14 8 20 8"></polyline>
-                <line x1="16" y1="13" x2="8" y2="13"></line>
-                <line x1="16" y1="17" x2="8" y2="17"></line>
-                <polyline points="10 9 9 9 8 9"></polyline>
-              </svg>
-            </span>
-            <span class="btn-icon__label">PDF</span>
-          </button>
-          <button type="button" onclick="exportarExcel()" class="btn-icon" title="Exportar Excel">
-            <span class="btn-icon__circle">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
-                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-                <polyline points="14 2 14 8 20 8"></polyline>
-                <path d="M8 13h4"></path>
-                <path d="M8 17h4"></path>
-                <path d="M16 13h-4v4"></path>
-              </svg>
-            </span>
-            <span class="btn-icon__label">Excel</span>
-          </button>
-        </div>
-      </div>
-
-      <div class="filters-grid">
-        <div class="filter-field">
-          <label for="filtroRol" class="form-label">Filtrar por rol</label>
-          <select id="filtroRol" class="form-select">
-            <option value="">Todos los roles</option>
-          </select>
-        </div>
-      </div>
-
-      <div class="metrics-grid" id="metricasUsuarios"></div>
-    </section>
-
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>


### PR DESCRIPTION
## Summary
- keep the filter tools section within the main admin user layout to match the width of other cards

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddbee7b844832c89221fe612ee1d2a