### PR TITLE
Ajusta selección de áreas y zonas en el registro de productos

### DIFF
--- a/pages/gest_inve/inventario_basico.html
+++ b/pages/gest_inve/inventario_basico.html
@@ -197,14 +197,14 @@
                 <select id="prodArea" class="form-select">
                   <option value="">Selecciona un área</option>
                 </select>
-                <div class="form-text">Primero elige el área general donde se guardará el producto.</div>
+                <div class="form-text">Selecciona el área general donde se guardará el producto. Este dato es obligatorio.</div>
               </div>
               <div class="col-md-6">
                 <label for="prodZona" class="form-label">Zona de almacén</label>
                 <select id="prodZona" class="form-select" disabled>
                   <option value="">Selecciona un área para ver zonas</option>
                 </select>
-                <div class="form-text">Después selecciona la zona disponible dentro del área.</div>
+                <div class="form-text">Si no eliges un área verás las zonas sin asignar. Puedes guardar el producto sin zona.</div>
               </div>
               <div class="col-md-6">
                 <label for="prodStock" class="form-label">Stock inicial</label>

--- a/scripts/gest_inve/inventario_basico.js
+++ b/scripts/gest_inve/inventario_basico.js
@@ -912,6 +912,14 @@ function actualizarSelectSubcategorias(categoriaId) {
     });
 }
 
+function normalizarAreaId(valor) {
+  if (valor === null || valor === undefined) return null;
+  if (valor === '' || valor === 'null' || valor === 'undefined') return null;
+  if (valor === 0 || valor === '0') return null;
+  const parsed = parseInt(valor, 10);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
 function actualizarSelectAreas(areaId = null, zonaId = null) {
   if (!prodArea) return;
 
@@ -939,7 +947,7 @@ function actualizarSelectZonas(areaId = null, zonaId = undefined) {
   if (!prodZona) return;
 
   const targetAreaValue = areaId !== null ? areaId : prodArea?.value || '';
-  const targetAreaId = targetAreaValue ? parseInt(targetAreaValue, 10) : null;
+  const targetAreaId = normalizarAreaId(targetAreaValue);
   const hasExplicitZona = zonaId !== undefined;
   const previousZona = hasExplicitZona ? String(zonaId ?? '') : prodZona.value;
 
@@ -948,20 +956,22 @@ function actualizarSelectZonas(areaId = null, zonaId = undefined) {
   const placeholder = document.createElement('option');
   placeholder.value = '';
 
-  const zonasFiltradas = targetAreaId
-    ? zonas.filter(zona => parseInt(zona.area_id, 10) === targetAreaId)
-    : [];
-  const hasArea = Boolean(targetAreaId);
+  const zonasSinArea = zonas.filter(zona => normalizarAreaId(zona.area_id) === null);
+  const zonasFiltradas = targetAreaId !== null
+    ? zonas.filter(zona => normalizarAreaId(zona.area_id) === targetAreaId)
+    : zonasSinArea;
+
+  const hasArea = targetAreaId !== null;
   const hasZonas = zonasFiltradas.length > 0;
 
   placeholder.textContent = hasArea
     ? (hasZonas ? 'Selecciona una zona' : 'No hay zonas registradas para esta área')
-    : 'Selecciona un área para ver zonas';
+    : (hasZonas ? 'Selecciona una zona sin área asignada' : 'No hay zonas sin área asignada');
   placeholder.selected = true;
-  placeholder.disabled = hasArea && hasZonas;
+  placeholder.disabled = false;
   prodZona.appendChild(placeholder);
 
-  prodZona.disabled = !hasArea || !hasZonas;
+  prodZona.disabled = !hasZonas;
 
   zonasFiltradas.forEach(z => {
     const opt = document.createElement('option');
@@ -1343,6 +1353,12 @@ prodForm?.addEventListener('submit', async e => {
 
     const area_id = prodArea ? (parseInt(prodArea.value, 10) || null) : null;
     const zona_id = prodZona ? (parseInt(prodZona.value, 10) || null) : null;
+
+    if (!area_id) {
+      showToast('Selecciona un área para el producto', 'error');
+      return;
+    }
+
     const data = {
       nombre,
       descripcion,


### PR DESCRIPTION
## Summary
- mostrar las zonas sin área asignada cuando no se ha elegido un área
- normalizar los identificadores de área en el listado de zonas y habilitar el selector sólo cuando existan opciones válidas
- exigir un área para registrar el producto y actualizar los textos de ayuda para aclarar que la zona es opcional

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df1062eec8832c853753df3d1833e2