### PR TITLE
Allow products to use zones without an area

### DIFF
--- a/scripts/gest_inve/inventario_basico.js
+++ b/scripts/gest_inve/inventario_basico.js
@@ -1351,10 +1351,22 @@ prodForm?.addEventListener('submit', async e => {
       return;
     }
 
-    const area_id = prodArea ? (parseInt(prodArea.value, 10) || null) : null;
+    let area_id = prodArea ? (parseInt(prodArea.value, 10) || null) : null;
     const zona_id = prodZona ? (parseInt(prodZona.value, 10) || null) : null;
 
-    if (!area_id) {
+    const zonaSeleccionada = zona_id
+      ? zonas.find(z => parseInt(z.id, 10) === zona_id) || null
+      : null;
+    const zonaAreaId = zonaSeleccionada
+      ? normalizarAreaId(zonaSeleccionada.area_id)
+      : null;
+    const zonaSinArea = zonaSeleccionada ? zonaAreaId === null : false;
+
+    if (!zonaSinArea && zonaAreaId !== null && area_id === null) {
+      area_id = zonaAreaId;
+    }
+
+    if (!area_id && !zonaSinArea) {
       showToast('Selecciona un área para el producto', 'error');
       return;
     }


### PR DESCRIPTION
## Summary
- infer the area from the selected zone when available and permit saving products linked to zones without área asignada

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df1edb4be8832cb73a9e744cedc40c