### PR TITLE
Show day-over-day changes in dashboard stats

### DIFF
--- a/pages/main_menu/main_menu.html
+++ b/pages/main_menu/main_menu.html
@@ -115,20 +115,20 @@
 
                 <div class="header-bottom">
                     <div class="header-stats">
-                        <article class="stat-card">
+                        <article class="stat-card" data-stat="alerts">
                             <span class="stat-label">Alertas activas</span>
-                            <span class="stat-value">4</span>
-                            <span class="stat-trend negative"><i class="fas fa-arrow-up"></i> +12%</span>
+                            <span class="stat-value" data-stat-value>--</span>
+                            <span class="stat-trend neutral" data-stat-trend><i class="fas fa-minus"></i> Sin datos previos</span>
                         </article>
-                        <article class="stat-card">
+                        <article class="stat-card" data-stat="movements">
                             <span class="stat-label">Movimientos hoy</span>
-                            <span class="stat-value">128</span>
-                            <span class="stat-trend positive"><i class="fas fa-arrow-up"></i> +8%</span>
+                            <span class="stat-value" data-stat-value>--</span>
+                            <span class="stat-trend neutral" data-stat-trend><i class="fas fa-minus"></i> Sin datos previos</span>
                         </article>
-                        <article class="stat-card">
+                        <article class="stat-card" data-stat="criticalZones">
                             <span class="stat-label">Zonas críticas</span>
-                            <span class="stat-value">2</span>
-                            <span class="stat-trend neutral"><i class="fas fa-minus"></i> Sin cambios</span>
+                            <span class="stat-value" data-stat-value>--</span>
+                            <span class="stat-trend neutral" data-stat-trend><i class="fas fa-minus"></i> Sin datos previos</span>
                         </article>
                     </div>
 


### PR DESCRIPTION
## Summary
- add data attributes to dashboard stat cards so their values and trend labels can be updated from script
- persist daily metric counts in local storage and refresh the header stats with the change versus the previous day
- extend the recent movements endpoint to expose today and yesterday totals for accurate comparisons

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e014352f90832c800e1523a56acc8a