### PR TITLE
Update critical stock alerts to omit location details

### DIFF
--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -986,16 +986,20 @@ function buildStockAlertEntries(productos, threshold) {
         const unidades = Number.isFinite(stockValue) ? stockValue : 0;
         const unidadesTexto = `${unidades} ${unidades === 1 ? 'unidad' : 'unidades'}`;
 
-        const locationParts = [];
-        if (prod && prod.zona_nombre) locationParts.push(prod.zona_nombre);
-        if (prod && prod.area_nombre) locationParts.push(prod.area_nombre);
-        const ubicacion = locationParts.filter(Boolean).join(' · ');
+        const detailSources = [
+            prod && typeof prod.descripcion === 'string' ? prod.descripcion.trim() : '',
+            prod && typeof prod.categoria_nombre === 'string' ? prod.categoria_nombre.trim() : '',
+            prod && typeof prod.subcategoria_nombre === 'string' ? prod.subcategoria_nombre.trim() : ''
+        ].filter(Boolean);
+
+        const detailFallback = 'Revisa el detalle del producto en el inventario.';
+        const detail = detailSources.length ? detailSources[0] : detailFallback;
 
         return {
             type: 'stock',
             iconClass: 'fas fa-box-open',
             title: ((prod && prod.nombre) || 'Producto sin nombre').trim(),
-            detail: ubicacion || 'Sin ubicación asignada',
+            detail,
             value: unidadesTexto,
             severity: Number.isFinite(stockValue) ? Math.max(0, threshold - stockValue) + 1 : 1,
             raw: prod


### PR DESCRIPTION
## Summary
- adjust the critical stock alert detail text to use product descriptions or catalog data instead of location fields
- add a friendly fallback message when no descriptive metadata is available

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0624d7cc4832c953cbfe73899cb46