### PR TITLE
Fix low stock card showing zone capacity alerts

### DIFF
--- a/scripts/main_menu/main_menu.js
+++ b/scripts/main_menu/main_menu.js
@@ -1852,20 +1852,15 @@ async function loadStockAlerts() {
 
         const normalizedAreas = normalizeAreaData(areasRaw);
         const normalizedZonas = normalizeZoneData(zonasRaw);
-        const capacityAlerts = buildCapacityAlertEntries(normalizedAreas, normalizedZonas);
-        updateCapacityAlertNotifications(capacityAlerts.notifications);
+        const { notifications: capacityAlertNotifications = [] } = buildCapacityAlertEntries(normalizedAreas, normalizedZonas);
+        updateCapacityAlertNotifications(capacityAlertNotifications);
 
-        const combinedAlerts = [
-            ...stockAlerts,
-            ...(capacityAlerts.alerts || [])
-        ];
-
-        const stockDisplay = combinedAlerts
+        const stockDisplay = stockAlerts
             .slice()
             .sort((a, b) => (Number(b.severity) || 0) - (Number(a.severity) || 0))
             .slice(0, 8);
 
-        updateDashboardStat('alerts', combinedAlerts.length);
+        updateDashboardStat('alerts', stockAlerts.length);
 
         if (!stockDisplay.length) {
             setListState(stockAlertList, 'No hay alertas activas en este momento.', 'fas fa-check-circle', 'card-empty-state');


### PR DESCRIPTION
## Summary
- ensure the low stock alerts card only renders product stock alerts
- keep capacity alerts limited to notification handling so they no longer appear mixed with stock items

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e064a682b0832cb116eaf88a60f1f8