### PR TITLE
Add printable QR label download for products

### DIFF
--- a/pages/gest_inve/inventario_basico.html
+++ b/pages/gest_inve/inventario_basico.html
@@ -313,7 +313,7 @@
           </div>
         </div>
         <div class="modal-footer border-0 d-flex flex-column flex-sm-row gap-2">
-          <a id="productoQrDownload" class="btn btn-outline-primary flex-fill" download>Descargar QR</a>
+          <a id="productoQrDownload" class="btn btn-outline-primary flex-fill" download>Descargar etiqueta</a>
           <button class="btn btn-secondary flex-fill" type="button" data-bs-dismiss="modal">Cerrar</button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- generate a styled product label image with QR code and product metadata directly in the browser
- update the QR modal download control to trigger the new label export and clarify the action text

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e067d292a8832c940e69acb5e94706