### PR TITLE
Refine product QR label styling

### DIFF
--- a/pages/gest_inve/inventario_basico.html
+++ b/pages/gest_inve/inventario_basico.html
@@ -313,7 +313,7 @@
           </div>
         </div>
         <div class="modal-footer border-0 d-flex flex-column flex-sm-row gap-2">
-          <a id="productoQrDownload" class="btn btn-outline-primary flex-fill" download>Descargar QR</a>
+          <a id="productoQrDownload" class="btn btn-outline-primary flex-fill" download>Descargar etiqueta</a>
           <button class="btn btn-secondary flex-fill" type="button" data-bs-dismiss="modal">Cerrar</button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add measurement and chip helpers to support a richer QR label layout
- refresh the exported QR label design with gradient header, description panel, and detail cards
- highlight zone and pricing data alongside the QR code for a cleaner presentation

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e067d292a8832c940e69acb5e94706