### PR TITLE
Refine QR label styling with brand colors

### DIFF
--- a/styles/gest_inve/inventario_basico.css
+++ b/styles/gest_inve/inventario_basico.css
@@ -367,22 +367,32 @@ img {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 1.5rem;
-  border-radius: var(--radius-md);
-  border: 1px dashed var(--border-color);
-  min-height: 220px;
-  background: rgba(245, 246, 251, 0.9);
+  padding: 2.5rem;
+  border-radius: 28px;
+  border: 1px solid var(--primary-border-soft);
+  min-height: 260px;
+  background: linear-gradient(160deg, rgba(23, 31, 52, 0.04), rgba(255, 111, 145, 0.04));
+  box-shadow: 0 28px 48px -38px rgba(23, 31, 52, 0.55);
 }
 
 .qr-image {
-  width: min(240px, 90%);
+  width: min(520px, 100%);
   height: auto;
+  border-radius: 24px;
+  box-shadow: 0 18px 40px -28px rgba(23, 31, 52, 0.45);
+  background: var(--card-bg);
 }
 
 .qr-placeholder {
-  font-size: 0.95rem;
-  color: var(--muted-color);
+  font-size: 1rem;
+  color: var(--sidebar-color);
+  font-weight: 500;
   text-align: center;
+  background: rgba(255, 111, 145, 0.08);
+  border: 1px solid rgba(255, 111, 145, 0.18);
+  padding: 1.25rem 1.75rem;
+  border-radius: 20px;
+  box-shadow: inset 0 0 0 1px rgba(255, 111, 145, 0.12);
 }
 
 @media (max-width: 576px) {


### PR DESCRIPTION
## Summary
- redesign the QR etiqueta canvas so it uses the sidebar/topbar color palette, adds branded header and footer bands, and improves the information layout
- refresh the QR preview container styles to better showcase the etiqueta and match the updated brand look

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e16aba7d98832c859eff1074af4b52