### PR TITLE
Display branded QR label preview and download

### DIFF
--- a/pages/gest_inve/inventario_basico.html
+++ b/pages/gest_inve/inventario_basico.html
@@ -132,6 +132,45 @@
       </section>
 
       <div class="inventory-card">
+        <section
+          id="etiquetaPreviewSection"
+          class="panel-card etiqueta-preview-section d-none"
+          aria-labelledby="productoEtiquetaHeading"
+          aria-live="polite"
+        >
+          <header class="panel-header">
+            <span class="panel-eyebrow">Etiqueta</span>
+            <h2 id="productoEtiquetaHeading" class="panel-title">Vista previa de la etiqueta</h2>
+            <p class="panel-description">
+              Visualiza la etiqueta con los colores corporativos de OptiStock y descárgala al instante.
+            </p>
+          </header>
+
+          <div class="etiqueta-preview__body">
+            <div id="productoEtiquetaPreview" class="etiqueta-preview__canvas qr-preview">
+              <div id="productoEtiquetaPlaceholder" class="qr-placeholder etiqueta-preview__placeholder">
+                Selecciona un producto para ver su etiqueta.
+              </div>
+              <img
+                id="productoEtiquetaImage"
+                class="qr-image etiqueta-preview__image d-none"
+                alt="Vista previa de la etiqueta del producto"
+                loading="lazy"
+              />
+            </div>
+            <div class="etiqueta-preview__actions">
+              <a
+                id="productoEtiquetaDownload"
+                class="btn btn-primary disabled"
+                download
+                aria-disabled="true"
+              >
+                Descargar etiqueta
+              </a>
+            </div>
+          </div>
+        </section>
+
         <section id="productoFormContainer" class="panel-card" aria-labelledby="btnProductos">
           <header class="panel-header panel-header--collapsible">
             <div class="panel-header__content">
@@ -308,8 +347,8 @@
         </div>
         <div class="modal-body">
           <div id="productoQrPreview" class="qr-preview">
-            <div id="productoQrPlaceholder" class="qr-placeholder">Generando código QR...</div>
-            <img id="productoQrImage" class="qr-image d-none" alt="Código QR del producto" />
+            <div id="productoQrPlaceholder" class="qr-placeholder">Genera la etiqueta del producto para verla aquí.</div>
+            <img id="productoQrImage" class="qr-image d-none" alt="Vista previa de la etiqueta del producto" />
           </div>
         </div>
         <div class="modal-footer border-0 d-flex flex-column flex-sm-row gap-2">

--- a/styles/gest_inve/inventario_basico.css
+++ b/styles/gest_inve/inventario_basico.css
@@ -367,22 +367,72 @@ img {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 1.5rem;
-  border-radius: var(--radius-md);
-  border: 1px dashed var(--border-color);
-  min-height: 220px;
-  background: rgba(245, 246, 251, 0.9);
+  flex-direction: column;
+  gap: 1rem;
+  padding: 2.5rem;
+  border-radius: 28px;
+  border: 1px solid var(--primary-border-soft);
+  min-height: 280px;
+  background: linear-gradient(160deg, rgba(23, 31, 52, 0.05), rgba(255, 111, 145, 0.06));
+  box-shadow: 0 28px 48px -34px rgba(23, 31, 52, 0.55);
 }
 
 .qr-image {
-  width: min(240px, 90%);
+  width: min(520px, 100%);
   height: auto;
+  border-radius: 24px;
+  box-shadow: 0 22px 48px -32px rgba(23, 31, 52, 0.45);
+  background: var(--card-bg);
+  border: 1px solid rgba(23, 31, 52, 0.08);
 }
 
 .qr-placeholder {
-  font-size: 0.95rem;
-  color: var(--muted-color);
+  font-size: 1rem;
+  color: var(--sidebar-color);
+  font-weight: 500;
   text-align: center;
+  background: rgba(255, 111, 145, 0.08);
+  border: 1px solid rgba(255, 111, 145, 0.18);
+  padding: 1.35rem 1.85rem;
+  border-radius: 22px;
+  box-shadow: inset 0 0 0 1px rgba(255, 111, 145, 0.12);
+  max-width: 520px;
+}
+
+.etiqueta-preview-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.etiqueta-preview__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.etiqueta-preview__canvas {
+  background: linear-gradient(145deg, rgba(23, 31, 52, 0.05), rgba(255, 111, 145, 0.05));
+  border: 1px solid rgba(23, 31, 52, 0.08);
+  min-height: 320px;
+}
+
+.etiqueta-preview__image {
+  width: min(960px, 100%);
+}
+
+.etiqueta-preview__placeholder {
+  color: var(--sidebar-color);
+}
+
+.etiqueta-preview__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.etiqueta-preview__actions .btn {
+  min-width: 200px;
 }
 
 @media (max-width: 576px) {


### PR DESCRIPTION
## Summary
- add a dedicated etiqueta preview card on the inventory page with a download action
- generate the etiqueta canvas with the current topbar and sidebar colors and reuse it for both the modal and on-page previews
- refresh the preview styling to match the OptiStock palette and highlight the branded label

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e16aba7d98832c859eff1074af4b52