### PR TITLE
Redesign QR label modal to highlight QR code

### DIFF
--- a/pages/gest_inve/inventario_basico.html
+++ b/pages/gest_inve/inventario_basico.html
@@ -307,26 +307,27 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
         </div>
         <div class="modal-body">
-          <div class="d-flex flex-column gap-3">
-            <div class="d-flex align-items-center gap-2 justify-content-between">
-              <div class="d-flex align-items-center gap-2">
-                <label class="form-label mb-0">Orientación:</label>
-                <div class="btn-group" role="group" aria-label="Orientación etiqueta">
-                  <input type="radio" class="btn-check" name="etiquetaOrientacion" id="orientH" autocomplete="off" value="horizontal" checked>
-                  <label class="btn btn-outline-secondary btn-sm" for="orientH">Horizontal</label>
-                  <input type="radio" class="btn-check" name="etiquetaOrientacion" id="orientV" autocomplete="off" value="vertical">
-                  <label class="btn btn-outline-secondary btn-sm" for="orientV">Vertical</label>
-                </div>
+          <div class="qr-modal-content">
+            <div class="qr-modal-settings">
+              <h6 class="qr-modal-settings__title">Diseño de la etiqueta</h6>
+              <p class="qr-modal-settings__hint">Selecciona la orientación para ajustar la posición del QR cuando descargues la etiqueta.</p>
+              <div class="btn-group qr-orientation" role="group" aria-label="Orientación de la etiqueta">
+                <input type="radio" class="btn-check" name="etiquetaOrientacion" id="orientH" autocomplete="off" value="horizontal" checked>
+                <label class="btn btn-outline-secondary btn-sm" for="orientH">Horizontal</label>
+                <input type="radio" class="btn-check" name="etiquetaOrientacion" id="orientV" autocomplete="off" value="vertical">
+                <label class="btn btn-outline-secondary btn-sm" for="orientV">Vertical</label>
               </div>
             </div>
 
-            <div id="productoQrPreview" class="qr-preview label-preview p-3 d-flex align-items-center justify-content-center">
-              <div id="productoQrPlaceholder" class="qr-placeholder">Generando código QR...</div>
-              <img id="productoQrImage" class="qr-image d-none" alt="Código QR del producto" />
-              <!-- Compact label container for rendering before download -->
-              <div id="productoLabelCompact" class="d-none" aria-hidden="true"></div>
+            <div class="qr-modal-visual">
+              <div class="qr-visual">
+                <div id="productoQrPlaceholder" class="qr-placeholder">Generando código QR...</div>
+                <img id="productoQrImage" class="qr-image d-none" alt="Código QR del producto" />
+              </div>
             </div>
           </div>
+          <!-- Compact label container for rendering before download -->
+          <div id="productoLabelCompact" class="visually-hidden" aria-hidden="true"></div>
         </div>
         <div class="modal-footer border-0 d-flex flex-column flex-sm-row gap-2">
           <a id="productoQrDownload" class="btn btn-outline-primary flex-fill" download>Descargar QR</a>

--- a/scripts/gest_inve/inventario_basico.js
+++ b/scripts/gest_inve/inventario_basico.js
@@ -43,71 +43,102 @@ const EMP_ID = parseInt(localStorage.getItem('id_empresa'),10) || 0;
 
   // (sanitizer defined later)
 
-  // Build compact label DOM for preview (horizontal or vertical)
+  // Build compact label DOM for orientation selection (hidden in modal)
   function buildCompactLabel(producto, qrSrc, orientation = 'horizontal') {
     const wrapper = document.createElement('div');
-    wrapper.className = 'label-card' + (orientation === 'vertical' ? ' vertical' : '');
+    wrapper.className = `label-card ${orientation === 'vertical' ? 'vertical' : 'horizontal'}`.trim();
 
-    // header
     const header = document.createElement('div');
     header.className = 'label-header';
-    header.textContent = 'Código QR';
+    const headerTitle = document.createElement('span');
+    headerTitle.textContent = 'Etiqueta QR';
+    const headerBrand = document.createElement('span');
+    headerBrand.className = 'label-header__brand';
+    headerBrand.textContent = 'OptiStock';
+    header.appendChild(headerTitle);
+    header.appendChild(headerBrand);
     wrapper.appendChild(header);
 
-    // body
     const body = document.createElement('div');
     body.className = 'label-body';
 
-    const left = document.createElement('div');
-    left.className = 'label-left';
-    // title
-    const titleF = document.createElement('div'); titleF.className = 'label-field';
-    const tkey = document.createElement('div'); tkey.className = 'label-field__key'; tkey.textContent = '';
-    const tval = document.createElement('div'); tval.className = 'label-field__value'; tval.textContent = producto?.nombre || 'Nombre del producto';
-    titleF.appendChild(tkey); titleF.appendChild(tval);
-    left.appendChild(titleF);
+    const qrColumn = document.createElement('div');
+    qrColumn.className = 'label-qr';
+    const qrCanvas = document.createElement('div');
+    qrCanvas.className = 'label-qr__canvas';
+    const img = document.createElement('img');
+    img.alt = producto?.nombre ? `Código QR de ${producto.nombre}` : 'Código QR del producto';
+    img.src = qrSrc;
+    qrCanvas.appendChild(img);
+    qrColumn.appendChild(qrCanvas);
 
-    // descriptive fields (zone, category, subcategory, volume, price)
+    const infoColumn = document.createElement('div');
+    infoColumn.className = 'label-info';
+    const title = document.createElement('div');
+    title.className = 'label-info__name';
+    title.textContent = producto?.nombre || 'Nombre del producto';
+    infoColumn.appendChild(title);
+
+    const meta = document.createElement('div');
+    meta.className = 'label-info__meta';
     const fields = [
-      {k: 'Zona asignada', v: producto?.zona_nombre || producto?.area_nombre || ''},
-      {k: 'Categoría', v: producto?.categoria_nombre || ''},
-      {k: 'Subcategoría', v: producto?.subcategoria_nombre || ''},
-      {k: 'Descripción', v: producto?.descripcion || ''},
-      {k: 'Precio unitario', v: producto?.precio_compra ? `$${Number(producto.precio_compra).toFixed(2)}` : ''}
-    ];
-    fields.forEach(f => {
-      const node = document.createElement('div'); node.className = 'label-field';
-      const key = document.createElement('div'); key.className = 'label-field__key'; key.textContent = f.k;
-      const val = document.createElement('div'); val.className = 'label-field__value'; val.textContent = f.v;
-      node.appendChild(key); node.appendChild(val);
-      left.appendChild(node);
-    });
+      { k: 'Zona', v: producto?.zona_nombre || producto?.area_nombre || '' },
+      { k: 'Categoría', v: producto?.categoria_nombre || '' },
+      { k: 'Subcategoría', v: producto?.subcategoria_nombre || '' },
+      { k: 'Descripción', v: producto?.descripcion || '' },
+      { k: 'Precio', v: producto?.precio_compra ? `$${Number(producto.precio_compra).toFixed(2)}` : '' }
+    ].filter(f => Boolean(f.v));
 
-    const right = document.createElement('div'); right.className = 'label-right';
-    const qrBox = document.createElement('div'); qrBox.className = 'label-qr-box';
-    const img = document.createElement('img'); img.alt = 'QR'; img.src = qrSrc;
-    qrBox.appendChild(img);
-    right.appendChild(qrBox);
+    if (fields.length === 0) {
+      const placeholderField = document.createElement('div');
+      placeholderField.className = 'label-field';
+      const pk = document.createElement('div');
+      pk.className = 'label-field__key';
+      pk.textContent = 'Información';
+      const pv = document.createElement('div');
+      pv.className = 'label-field__value';
+      pv.textContent = 'Completa los datos del producto para mostrarlos en la etiqueta.';
+      placeholderField.appendChild(pk);
+      placeholderField.appendChild(pv);
+      meta.appendChild(placeholderField);
+    } else {
+      fields.forEach(f => {
+        const node = document.createElement('div');
+        node.className = 'label-field';
+        const key = document.createElement('div');
+        key.className = 'label-field__key';
+        key.textContent = f.k;
+        const val = document.createElement('div');
+        val.className = 'label-field__value';
+        val.textContent = f.v;
+        node.appendChild(key);
+        node.appendChild(val);
+        meta.appendChild(node);
+      });
+    }
+
+    infoColumn.appendChild(meta);
 
     if (orientation === 'vertical') {
-      body.appendChild(right);
-      body.appendChild(left);
+      body.appendChild(qrColumn);
+      body.appendChild(infoColumn);
     } else {
-      body.appendChild(left);
-      body.appendChild(right);
+      body.appendChild(qrColumn);
+      body.appendChild(infoColumn);
     }
 
     wrapper.appendChild(body);
 
-    const footer = document.createElement('div'); footer.className = 'label-footer';
-    footer.innerHTML = '<span>Etiqueta generada con OptiStock</span><span>OptiStock</span>';
+    const footer = document.createElement('div');
+    footer.className = 'label-footer';
+    footer.innerHTML = '<span>Etiqueta generada con OptiStock</span><span>optistock.com</span>';
     wrapper.appendChild(footer);
 
     return wrapper;
   }
 
-  // Render simple PNG from label DOM: draw to canvas (text + QR image). Returns dataURL.
-  async function renderLabelToPng(producto, qrSrc, orientation = 'horizontal', width = 800, dpi = 2) {
+  // Render label to PNG with emphasis on QR visibility.
+  async function renderLabelToPng(producto, qrSrc, orientation = 'horizontal', width = 900, dpi = 2) {
     // load QR image (fallback resolves to null)
     const qrImg = await new Promise((resolve) => {
       const img = new Image();
@@ -117,9 +148,8 @@ const EMP_ID = parseInt(localStorage.getItem('id_empresa'),10) || 0;
       img.src = qrSrc;
     });
 
-    // Define canvas size to mimic card
-    const w = orientation === 'vertical' ? Math.round(width * 0.6) : width;
-    const h = orientation === 'vertical' ? Math.round(width * 1.1) : Math.round(width * 0.55);
+    const w = orientation === 'vertical' ? Math.round(width * 0.68) : width;
+    const h = orientation === 'vertical' ? Math.round(width * 1.18) : Math.round(width * 0.6);
     const canvas = document.createElement('canvas');
     canvas.width = w * dpi;
     canvas.height = h * dpi;
@@ -129,62 +159,198 @@ const EMP_ID = parseInt(localStorage.getItem('id_empresa'),10) || 0;
     ctx.fillStyle = '#fff';
     ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-    // header
-    const headerH = 56 * dpi;
-    const grd = ctx.createLinearGradient(0,0,canvas.width,0);
-    grd.addColorStop(0,'#4b4f55'); grd.addColorStop(1,'#8a8f94');
-    ctx.fillStyle = grd;
-    ctx.fillRect(0,0,canvas.width,headerH);
-    ctx.fillStyle = '#fff';
-    ctx.font = `${18 * dpi}px Poppins, sans-serif`;
-    ctx.textBaseline = 'middle';
-    ctx.fillText('Código QR', 16 * dpi, headerH/2);
-
-    // body layout
+    const headerH = 70 * dpi;
+    const footerH = 54 * dpi;
     const bodyY = headerH;
-    const bodyH = canvas.height - headerH - (40 * dpi);
-    const gap = 16 * dpi;
-    const leftW = orientation === 'vertical' ? canvas.width - gap*2 : canvas.width - (180 * dpi) - gap*3;
-    const rightW = orientation === 'vertical' ? canvas.width - gap*2 : (180 * dpi);
+    const bodyH = canvas.height - headerH - footerH;
+    const gap = 24 * dpi;
 
-    // draw QR box on right (or top for vertical)
-    const qrBoxSize = Math.min(rightW - 16 * dpi, bodyH - 16 * dpi, 360 * dpi);
-    const qrX = orientation === 'vertical' ? (canvas.width - qrBoxSize) / 2 : canvas.width - gap - qrBoxSize;
-    const qrY = orientation === 'vertical' ? bodyY + 12 * dpi : bodyY + (bodyH - qrBoxSize) / 2;
-    // qr backdrop
-    ctx.fillStyle = '#f3f4f6';
-    roundRect(ctx, qrX, qrY, qrBoxSize, qrBoxSize, 12 * dpi, true, false);
-    if (qrImg) ctx.drawImage(qrImg, qrX + (qrBoxSize*0.04), qrY + (qrBoxSize*0.04), qrBoxSize*0.92, qrBoxSize*0.92);
+    // header with gradient
+    const headerGradient = ctx.createLinearGradient(0, 0, canvas.width, 0);
+    headerGradient.addColorStop(0, '#30374f');
+    headerGradient.addColorStop(1, '#505a76');
+    ctx.fillStyle = headerGradient;
+    ctx.fillRect(0, 0, canvas.width, headerH);
+    ctx.fillStyle = '#fff';
+    ctx.textBaseline = 'middle';
+    ctx.font = `700 ${18 * dpi}px Poppins, sans-serif`;
+    ctx.textAlign = 'left';
+    ctx.fillText('Etiqueta QR', 24 * dpi, headerH / 2);
+    ctx.textAlign = 'right';
+    ctx.font = `600 ${16 * dpi}px Poppins, sans-serif`;
+    ctx.fillText('OptiStock', canvas.width - 24 * dpi, headerH / 2);
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
 
-    // left content
-    const textX = 16 * dpi;
-    let cursorY = bodyY + 16 * dpi;
-    ctx.fillStyle = '#111827';
-    ctx.font = `700 ${16 * dpi}px Poppins, sans-serif`;
-    wrapText(ctx, producto?.nombre || 'Nombre del producto', textX, cursorY, leftW - 16 * dpi, 20 * dpi, 3);
-    cursorY += 64 * dpi;
+    const blocks = [
+      { label: 'Zona', value: producto?.zona_nombre || producto?.area_nombre || '' },
+      { label: 'Categoría', value: producto?.categoria_nombre || '' },
+      { label: 'Subcategoría', value: producto?.subcategoria_nombre || '' },
+      { label: 'Descripción', value: producto?.descripcion || '' },
+      { label: 'Precio', value: producto?.precio_compra ? `$${Number(producto.precio_compra).toFixed(2)}` : '' }
+    ].filter(item => item.value);
 
-    ctx.font = `${12 * dpi}px Poppins, sans-serif`;
-    ctx.fillStyle = '#6b7280';
-    const infoLines = [];
-    if (producto?.zona_nombre || producto?.area_nombre) infoLines.push('Zona: ' + (producto?.zona_nombre || producto?.area_nombre));
-    if (producto?.categoria_nombre) infoLines.push('Categoría: ' + producto.categoria_nombre);
-    if (producto?.subcategoria_nombre) infoLines.push('Subcategoría: ' + producto.subcategoria_nombre);
-    if (producto?.descripcion) infoLines.push('Descripción: ' + producto.descripcion);
-    if (producto?.precio_compra) infoLines.push('Precio: $' + Number(producto.precio_compra).toFixed(2));
-    infoLines.forEach((ln, i) => {
-      wrapText(ctx, ln, textX, cursorY + i*(18*dpi), leftW - 16 * dpi, 18 * dpi, 2);
-    });
+    const drawParagraph = (text, startX, startY, maxWidth, lineHeight, maxLines = 4) => {
+      const words = String(text ?? '').trim().split(/\s+/).filter(Boolean);
+      if (words.length === 0) {
+        ctx.fillText('—', startX, startY);
+        return startY + lineHeight;
+      }
+      let line = '';
+      let y = startY;
+      let lines = 0;
+      for (const word of words) {
+        const testLine = line ? `${line} ${word}` : word;
+        if (ctx.measureText(testLine).width > maxWidth && line) {
+          ctx.fillText(line, startX, y);
+          line = word;
+          y += lineHeight;
+          lines += 1;
+          if (lines >= maxLines - 1) {
+            ctx.fillText(`${line}…`, startX, y);
+            return y + lineHeight;
+          }
+        } else {
+          line = testLine;
+        }
+      }
+      if (line) {
+        ctx.fillText(line, startX, y);
+        y += lineHeight;
+      }
+      return y;
+    };
+
+    const drawField = (label, value, startX, startY, maxWidth) => {
+      ctx.fillStyle = '#6b7280';
+      ctx.font = `600 ${12 * dpi}px Poppins, sans-serif`;
+      ctx.fillText(label.toUpperCase(), startX, startY);
+      ctx.fillStyle = '#111827';
+      ctx.font = `500 ${15 * dpi}px Poppins, sans-serif`;
+      const nextY = drawParagraph(value, startX, startY + 18 * dpi, maxWidth, 22 * dpi, 4);
+      return nextY + 10 * dpi;
+    };
+
+    if (orientation === 'horizontal') {
+      const qrAreaWidth = Math.round(canvas.width * 0.46);
+      const infoAreaWidth = canvas.width - qrAreaWidth - gap * 3;
+      const infoX = gap * 2;
+      const infoY = bodyY + gap;
+      const infoHeight = bodyH - gap * 2;
+
+      ctx.save();
+      ctx.fillStyle = 'rgba(255, 255, 255, 0.97)';
+      roundRect(ctx, infoX, infoY, infoAreaWidth, infoHeight, 32 * dpi, true, false);
+      ctx.lineWidth = 2;
+      ctx.strokeStyle = 'rgba(17, 24, 67, 0.08)';
+      roundRect(ctx, infoX, infoY, infoAreaWidth, infoHeight, 32 * dpi, false, true);
+      ctx.restore();
+
+      const textX = infoX + 32 * dpi;
+      let cursorY = infoY + 34 * dpi;
+
+      ctx.fillStyle = '#101828';
+      ctx.font = `700 ${24 * dpi}px Poppins, sans-serif`;
+      cursorY = drawParagraph(producto?.nombre || 'Nombre del producto', textX, cursorY, infoAreaWidth - 64 * dpi, 30 * dpi, 3) + 8 * dpi;
+
+      if (blocks.length > 0) {
+        blocks.forEach(block => {
+          cursorY = drawField(block.label, block.value, textX, cursorY, infoAreaWidth - 64 * dpi);
+        });
+      } else {
+        cursorY = drawField('Información', 'Completa los datos del producto para mostrarlos en la etiqueta.', textX, cursorY, infoAreaWidth - 64 * dpi);
+      }
+
+      const qrAreaX = canvas.width - qrAreaWidth - gap;
+      const qrAreaY = bodyY + gap;
+      const qrAreaHeight = bodyH - gap * 2;
+      const qrGradient = ctx.createLinearGradient(qrAreaX, qrAreaY, qrAreaX + qrAreaWidth, qrAreaY + qrAreaHeight);
+      qrGradient.addColorStop(0, '#eef2ff');
+      qrGradient.addColorStop(1, '#dbe2ff');
+      ctx.fillStyle = qrGradient;
+      roundRect(ctx, qrAreaX, qrAreaY, qrAreaWidth, qrAreaHeight, 36 * dpi, true, false);
+
+      const qrSize = Math.min(qrAreaWidth - gap * 2, qrAreaHeight - gap * 2);
+      const qrInnerX = qrAreaX + (qrAreaWidth - qrSize) / 2;
+      const qrInnerY = qrAreaY + (qrAreaHeight - qrSize) / 2;
+      ctx.fillStyle = '#fff';
+      roundRect(ctx, qrInnerX - 12 * dpi, qrInnerY - 12 * dpi, qrSize + 24 * dpi, qrSize + 24 * dpi, 28 * dpi, true, false);
+      if (qrImg) {
+        ctx.drawImage(qrImg, qrInnerX, qrInnerY, qrSize, qrSize);
+      } else {
+        ctx.strokeStyle = '#c7cffc';
+        ctx.lineWidth = 4;
+        roundRect(ctx, qrInnerX, qrInnerY, qrSize, qrSize, 20 * dpi, false, true);
+      }
+    } else {
+      const qrAreaWidth = canvas.width - gap * 4;
+      const qrAreaHeight = Math.min(bodyH * 0.55, qrAreaWidth);
+      const qrAreaX = (canvas.width - qrAreaWidth) / 2;
+      const qrAreaY = bodyY + gap;
+
+      const qrGradient = ctx.createLinearGradient(qrAreaX, qrAreaY, qrAreaX, qrAreaY + qrAreaHeight);
+      qrGradient.addColorStop(0, '#eef2ff');
+      qrGradient.addColorStop(1, '#d6defc');
+      ctx.fillStyle = qrGradient;
+      roundRect(ctx, qrAreaX, qrAreaY, qrAreaWidth, qrAreaHeight, 36 * dpi, true, false);
+
+      const qrSize = Math.min(qrAreaWidth - gap * 2, qrAreaHeight - gap * 2);
+      const qrInnerX = qrAreaX + (qrAreaWidth - qrSize) / 2;
+      const qrInnerY = qrAreaY + (qrAreaHeight - qrSize) / 2;
+      ctx.fillStyle = '#fff';
+      roundRect(ctx, qrInnerX - 12 * dpi, qrInnerY - 12 * dpi, qrSize + 24 * dpi, qrSize + 24 * dpi, 28 * dpi, true, false);
+      if (qrImg) {
+        ctx.drawImage(qrImg, qrInnerX, qrInnerY, qrSize, qrSize);
+      } else {
+        ctx.strokeStyle = '#c7cffc';
+        ctx.lineWidth = 4;
+        roundRect(ctx, qrInnerX, qrInnerY, qrSize, qrSize, 20 * dpi, false, true);
+      }
+
+      const infoX = gap * 2;
+      const infoY = qrAreaY + qrAreaHeight + gap;
+      const infoWidth = canvas.width - infoX * 2;
+      const infoHeight = bodyY + bodyH - infoY - gap;
+
+      ctx.save();
+      ctx.fillStyle = 'rgba(255, 255, 255, 0.97)';
+      roundRect(ctx, infoX, infoY, infoWidth, infoHeight, 32 * dpi, true, false);
+      ctx.lineWidth = 2;
+      ctx.strokeStyle = 'rgba(17, 24, 67, 0.08)';
+      roundRect(ctx, infoX, infoY, infoWidth, infoHeight, 32 * dpi, false, true);
+      ctx.restore();
+
+      let cursorY = infoY + 28 * dpi;
+      const textX = infoX + 32 * dpi;
+
+      ctx.fillStyle = '#101828';
+      ctx.font = `700 ${24 * dpi}px Poppins, sans-serif`;
+      cursorY = drawParagraph(producto?.nombre || 'Nombre del producto', textX, cursorY, infoWidth - 64 * dpi, 30 * dpi, 3) + 12 * dpi;
+
+      if (blocks.length > 0) {
+        blocks.forEach(block => {
+          cursorY = drawField(block.label, block.value, textX, cursorY, infoWidth - 64 * dpi);
+        });
+      } else {
+        cursorY = drawField('Información', 'Completa los datos del producto para mostrarlos en la etiqueta.', textX, cursorY, infoWidth - 64 * dpi);
+      }
+    }
 
     // footer
-    const footerH = 40 * dpi;
     const footerY = canvas.height - footerH;
-    const fGrd = ctx.createLinearGradient(0,footerY,canvas.width,footerY);
-    fGrd.addColorStop(0,'#6b6f74'); fGrd.addColorStop(1,'#d1d5db');
-    ctx.fillStyle = fGrd; ctx.fillRect(0, footerY, canvas.width, footerH);
-    ctx.fillStyle = '#fff'; ctx.font = `${12 * dpi}px Poppins, sans-serif`;
-    ctx.fillText('Etiqueta generada con OptiStock', 16 * dpi, footerY + footerH/2 - 6 * dpi);
-    ctx.fillText('OptiStock', canvas.width - (90 * dpi), footerY + footerH/2 - 6 * dpi);
+    const footerGradient = ctx.createLinearGradient(0, footerY, canvas.width, footerY);
+    footerGradient.addColorStop(0, '#4c5168');
+    footerGradient.addColorStop(1, '#79829e');
+    ctx.fillStyle = footerGradient;
+    ctx.fillRect(0, footerY, canvas.width, footerH);
+    ctx.fillStyle = '#fff';
+    ctx.textBaseline = 'middle';
+    ctx.font = `600 ${13 * dpi}px Poppins, sans-serif`;
+    ctx.textAlign = 'left';
+    ctx.fillText('Etiqueta generada con OptiStock', 24 * dpi, footerY + footerH / 2);
+    ctx.textAlign = 'right';
+    ctx.fillText('optistock.com', canvas.width - 24 * dpi, footerY + footerH / 2);
+    ctx.textAlign = 'left';
 
     return canvas.toDataURL('image/png');
   }
@@ -2269,10 +2435,6 @@ if (editProdId) {
     productoLabelCompact.innerHTML = '';
     const node = buildCompactLabel(qrModalProducto, qrModalSrc, orient);
     productoLabelCompact.appendChild(node);
-    productoLabelCompact.classList.remove('d-none');
-    // ensure visible in preview area
-    if (qrModalPlaceholder) qrModalPlaceholder.classList.add('d-none');
-    if (qrModalImage) qrModalImage.classList.add('d-none');
   }
 
   for (const r of orientRadios) {

--- a/styles/gest_inve/inventario_basico.css
+++ b/styles/gest_inve/inventario_basico.css
@@ -363,127 +363,272 @@ img {
   gap: 0.75rem;
 }
 
-.qr-preview {
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.qr-modal-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .qr-modal-content {
+    flex-direction: row;
+    align-items: stretch;
+  }
+}
+
+.qr-modal-settings {
+  flex: 1 1 260px;
+  background: linear-gradient(155deg, rgba(17, 24, 67, 0.08), rgba(255, 111, 145, 0.12));
+  border: 1px solid rgba(17, 24, 67, 0.08);
+  border-radius: 22px;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 28px 48px -36px rgba(17, 24, 67, 0.65);
+  backdrop-filter: blur(2px);
+}
+
+.qr-modal-settings__title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--primary-color);
+  margin-bottom: 0.35rem;
+}
+
+.qr-modal-settings__hint {
+  font-size: 0.9rem;
+  color: var(--sidebar-color);
+  margin-bottom: 1.25rem;
+}
+
+.qr-orientation .btn {
+  border-radius: 999px;
+  font-weight: 600;
+  padding: 0.45rem 1.4rem;
+  transition: all 0.2s ease;
+}
+
+.qr-orientation .btn-check:checked + .btn {
+  background: var(--primary-color);
+  border-color: var(--primary-color);
+  color: #fff;
+  box-shadow: 0 16px 32px -24px rgba(255, 111, 145, 0.85);
+}
+
+.qr-modal-visual {
+  flex: 1.35;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 2.5rem;
-  border-radius: 28px;
+}
+
+.qr-visual {
+  width: 100%;
+  max-width: 420px;
+  padding: 2.75rem;
+  border-radius: 34px;
   border: 1px solid var(--primary-border-soft);
-  min-height: 260px;
-  background: linear-gradient(160deg, rgba(23, 31, 52, 0.04), rgba(255, 111, 145, 0.04));
-  box-shadow: 0 28px 48px -38px rgba(23, 31, 52, 0.55);
+  background: radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.96), rgba(17, 24, 67, 0.08));
+  box-shadow: 0 42px 68px -40px rgba(17, 24, 67, 0.65);
+  display: grid;
+  place-items: center;
+  position: relative;
+}
+
+.qr-visual::after {
+  content: '';
+  position: absolute;
+  inset: 12px;
+  border-radius: 28px;
+  border: 1px dashed rgba(17, 24, 67, 0.18);
+  pointer-events: none;
 }
 
 .qr-image {
-  width: min(520px, 100%);
-  height: auto;
+  width: min(360px, 100%);
+  aspect-ratio: 1 / 1;
+  object-fit: contain;
   border-radius: 24px;
-  box-shadow: 0 18px 40px -28px rgba(23, 31, 52, 0.45);
-  background: var(--card-bg);
+  background: #fff;
+  box-shadow: 0 32px 60px -42px rgba(17, 24, 67, 0.65);
+  padding: 1.1rem;
 }
 
-/* Compact label preview styles */
-.label-preview {
-  padding: 1rem;
-  min-height: 200px;
+.qr-placeholder {
+  font-size: 1.05rem;
+  color: var(--sidebar-color);
+  font-weight: 600;
+  text-align: center;
+  background: rgba(255, 111, 145, 0.12);
+  border: 1px solid rgba(255, 111, 145, 0.28);
+  padding: 1.65rem 2.1rem;
+  border-radius: 24px;
+  box-shadow: inset 0 0 0 1px rgba(255, 111, 145, 0.12);
 }
-/* Redesigned compact label that matches the mockup style: header band, content area with left info and right QR, footer bar */
+
 .label-card {
   width: 100%;
-  background: linear-gradient(180deg,#ffffff,#fafafa);
-  border-radius: 14px;
+  background: linear-gradient(150deg, #ffffff 0%, #f6f7fb 100%);
+  border-radius: 24px;
   overflow: hidden;
-  border: 1px solid rgba(17,24,67,0.06);
-  box-shadow: 0 10px 30px rgba(17,24,67,0.06);
+  border: 1px solid rgba(17, 24, 67, 0.08);
+  box-shadow: 0 34px 64px -42px rgba(17, 24, 67, 0.55);
   display: flex;
-  flex-direction: row;
-  gap: 0;
+  flex-direction: column;
 }
 
-.label-card.vertical { flex-direction: column; }
+.label-card.horizontal .label-body {
+  flex-direction: row;
+}
+
+.label-card.vertical .label-body {
+  flex-direction: column;
+  align-items: center;
+}
 
 .label-header {
-  background: linear-gradient(90deg,#4b4f55,#8a8f94);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.75rem;
+  background: linear-gradient(90deg, #30374f, #505a76);
   color: #fff;
-  padding: 12px 16px;
   font-weight: 700;
-  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.92rem;
+}
+
+.label-header__brand {
+  font-weight: 800;
+  letter-spacing: 0.12em;
 }
 
 .label-body {
   display: flex;
-  gap: 1rem;
-  padding: 12px 14px;
+  gap: 1.75rem;
+  padding: 1.75rem 1.75rem 1.5rem;
   align-items: stretch;
-  width: 100%;
 }
 
-.label-left {
-  flex: 1 1 auto;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding-right: 6px;
-}
-
-.label-right {
-  flex: 0 0 180px;
+.label-qr {
+  flex: 1.1 1 320px;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-.label-qr-box {
-  width: 140px;
-  height: 140px;
-  background: #f3f4f6;
-  border-radius: 12px;
+.label-qr__canvas {
+  width: min(320px, 100%);
+  aspect-ratio: 1 / 1;
+  border-radius: 30px;
+  background: radial-gradient(circle at 30% 20%, #ffffff 0%, #e4e8ff 100%);
+  border: 1px solid rgba(17, 24, 67, 0.1);
+  box-shadow: 0 32px 56px -40px rgba(17, 24, 67, 0.55);
+  padding: 1.4rem;
   display: grid;
   place-items: center;
-  border: 1px solid rgba(17,24,67,0.06);
 }
 
-.label-qr-box img { width: 92%; height: 92%; object-fit: contain; }
+.label-qr__canvas img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  border-radius: 20px;
+}
+
+.label-info {
+  flex: 1 1 260px;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.label-info__name {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: #111827;
+  line-height: 1.2;
+}
+
+.label-info__meta {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.label-card.vertical .label-info__meta {
+  grid-template-columns: 1fr;
+  width: 100%;
+}
 
 .label-field {
-  display:flex; flex-direction:column; gap:4px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding-left: 0.65rem;
+  border-left: 3px solid rgba(80, 90, 118, 0.35);
 }
 
-.label-field .label-field__key {
-  font-size:0.72rem; color:#6b7280; text-transform:uppercase; font-weight:700; letter-spacing:0.06em;
+.label-field__key {
+  font-size: 0.72rem;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
 }
-.label-field .label-field__value {
-  font-size:0.95rem; color:#111827; font-weight:600;
+
+.label-field__value {
+  font-size: 0.98rem;
+  color: #111827;
+  font-weight: 600;
 }
 
 .label-footer {
-  background: linear-gradient(90deg,#6b6f74,#d1d5db);
+  background: linear-gradient(90deg, #4c5168, #79829e);
   color: #fff;
-  padding: 10px 14px;
-  font-weight:600;
-  display:flex; justify-content:space-between; align-items:center;
+  padding: 0.85rem 1.5rem;
+  font-weight: 600;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
 }
 
-/* Vertical variations */
-.label-card.vertical .label-right { flex: 0 0 auto; order: 0; padding-top: 8px; }
-.label-card.vertical .label-body { flex-direction: column; align-items: stretch; }
-
-@media (max-width:540px) {
-  .label-right { flex: 0 0 120px; }
-  .label-qr-box { width: 100px; height: 100px; }
+.label-card.vertical .label-body {
+  width: 100%;
+  gap: 1.5rem;
 }
 
-.qr-placeholder {
-  font-size: 1rem;
-  color: var(--sidebar-color);
-  font-weight: 500;
-  text-align: center;
-  background: rgba(255, 111, 145, 0.08);
-  border: 1px solid rgba(255, 111, 145, 0.18);
-  padding: 1.25rem 1.75rem;
-  border-radius: 20px;
-  box-shadow: inset 0 0 0 1px rgba(255, 111, 145, 0.12);
+@media (max-width: 540px) {
+  .qr-modal-content {
+    gap: 1rem;
+  }
+
+  .qr-visual {
+    padding: 2.1rem;
+  }
+
+  .label-info__name {
+    font-size: 1.15rem;
+  }
+
+  .label-info__meta {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 576px) {


### PR DESCRIPTION
## Summary
- reorganized the QR configuration modal so orientation controls sit beside a larger QR display without showing the label preview
- refreshed label CSS and PNG rendering so generated tags emphasise the QR image while keeping product details accessible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e182b830cc832c967ad8de1173c731