### PR TITLE
Simplify QR modal layout and ensure preview renders

### DIFF
--- a/pages/gest_inve/inventario_basico.html
+++ b/pages/gest_inve/inventario_basico.html
@@ -307,26 +307,27 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
         </div>
         <div class="modal-body">
-          <div class="d-flex flex-column gap-3">
-            <div class="d-flex align-items-center gap-2 justify-content-between">
-              <div class="d-flex align-items-center gap-2">
-                <label class="form-label mb-0">Orientación:</label>
-                <div class="btn-group" role="group" aria-label="Orientación etiqueta">
-                  <input type="radio" class="btn-check" name="etiquetaOrientacion" id="orientH" autocomplete="off" value="horizontal" checked>
-                  <label class="btn btn-outline-secondary btn-sm" for="orientH">Horizontal</label>
-                  <input type="radio" class="btn-check" name="etiquetaOrientacion" id="orientV" autocomplete="off" value="vertical">
-                  <label class="btn btn-outline-secondary btn-sm" for="orientV">Vertical</label>
-                </div>
+          <div class="qr-modal-layout">
+            <div class="qr-modal-controls">
+              <div>
+                <span class="qr-modal-eyebrow">Diseño de la etiqueta</span>
+                <h6 class="qr-modal-title">Elige cómo se acomodará la etiqueta al descargarla.</h6>
+              </div>
+              <div class="btn-group qr-orientation" role="group" aria-label="Orientación de la etiqueta">
+                <input type="radio" class="btn-check" name="etiquetaOrientacion" id="orientH" autocomplete="off" value="horizontal" checked>
+                <label class="btn btn-outline-secondary btn-sm" for="orientH">Horizontal</label>
+                <input type="radio" class="btn-check" name="etiquetaOrientacion" id="orientV" autocomplete="off" value="vertical">
+                <label class="btn btn-outline-secondary btn-sm" for="orientV">Vertical</label>
               </div>
             </div>
 
-            <div id="productoQrPreview" class="qr-preview label-preview p-3 d-flex align-items-center justify-content-center">
-              <div id="productoQrPlaceholder" class="qr-placeholder">Generando código QR...</div>
+            <div class="qr-display">
+              <div id="productoQrPlaceholder" class="qr-placeholder" role="status">Generando código QR...</div>
               <img id="productoQrImage" class="qr-image d-none" alt="Código QR del producto" />
-              <!-- Compact label container for rendering before download -->
-              <div id="productoLabelCompact" class="d-none" aria-hidden="true"></div>
             </div>
           </div>
+          <!-- Compact label container for rendering before download -->
+          <div id="productoLabelCompact" class="visually-hidden" aria-hidden="true"></div>
         </div>
         <div class="modal-footer border-0 d-flex flex-column flex-sm-row gap-2">
           <a id="productoQrDownload" class="btn btn-outline-primary flex-fill" download>Descargar QR</a>

--- a/styles/gest_inve/inventario_basico.css
+++ b/styles/gest_inve/inventario_basico.css
@@ -363,127 +363,254 @@ img {
   gap: 0.75rem;
 }
 
-.qr-preview {
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.qr-modal-layout {
   display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 576px) {
+  .qr-modal-layout {
+    gap: 1.5rem;
+  }
+}
+
+.qr-modal-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (min-width: 576px) {
+  .qr-modal-controls {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.qr-modal-eyebrow {
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  padding: 2.5rem;
-  border-radius: 28px;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  color: var(--primary-color);
+}
+
+.qr-modal-title {
+  margin: 0.15rem 0 0;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--muted-color);
+}
+
+.qr-orientation .btn {
+  font-weight: 600;
+}
+
+.qr-orientation .btn-check:checked + .btn {
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
+  color: #fff;
+}
+
+.qr-display {
+  min-height: 240px;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
   border: 1px solid var(--primary-border-soft);
-  min-height: 260px;
-  background: linear-gradient(160deg, rgba(23, 31, 52, 0.04), rgba(255, 111, 145, 0.04));
-  box-shadow: 0 28px 48px -38px rgba(23, 31, 52, 0.55);
+  border-radius: var(--radius-lg);
+  background: #fff;
+  box-shadow: inset 0 0 0 1px rgba(17, 24, 67, 0.04);
+  position: relative;
+  overflow: hidden;
 }
 
 .qr-image {
-  width: min(520px, 100%);
-  height: auto;
-  border-radius: 24px;
-  box-shadow: 0 18px 40px -28px rgba(23, 31, 52, 0.45);
-  background: var(--card-bg);
+  width: min(320px, 100%);
+  aspect-ratio: 1 / 1;
+  object-fit: contain;
 }
 
-/* Compact label preview styles */
-.label-preview {
-  padding: 1rem;
-  min-height: 200px;
+.qr-placeholder {
+  text-align: center;
+  font-weight: 600;
+  color: var(--muted-color);
+  background: rgba(255, 111, 145, 0.08);
+  border: 1px dashed rgba(255, 111, 145, 0.4);
+  padding: 1.5rem 2rem;
+  border-radius: var(--radius-md);
 }
-/* Redesigned compact label that matches the mockup style: header band, content area with left info and right QR, footer bar */
+
 .label-card {
   width: 100%;
-  background: linear-gradient(180deg,#ffffff,#fafafa);
-  border-radius: 14px;
+  background: linear-gradient(150deg, #ffffff 0%, #f6f7fb 100%);
+  border-radius: 24px;
   overflow: hidden;
-  border: 1px solid rgba(17,24,67,0.06);
-  box-shadow: 0 10px 30px rgba(17,24,67,0.06);
+  border: 1px solid rgba(17, 24, 67, 0.08);
+  box-shadow: 0 34px 64px -42px rgba(17, 24, 67, 0.55);
   display: flex;
-  flex-direction: row;
-  gap: 0;
+  flex-direction: column;
 }
 
-.label-card.vertical { flex-direction: column; }
+.label-card.horizontal .label-body {
+  flex-direction: row;
+}
+
+.label-card.vertical .label-body {
+  flex-direction: column;
+  align-items: center;
+}
 
 .label-header {
-  background: linear-gradient(90deg,#4b4f55,#8a8f94);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.75rem;
+  background: linear-gradient(90deg, #30374f, #505a76);
   color: #fff;
-  padding: 12px 16px;
   font-weight: 700;
-  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.92rem;
+}
+
+.label-header__brand {
+  font-weight: 800;
+  letter-spacing: 0.12em;
 }
 
 .label-body {
   display: flex;
-  gap: 1rem;
-  padding: 12px 14px;
+  gap: 1.75rem;
+  padding: 1.75rem 1.75rem 1.5rem;
   align-items: stretch;
-  width: 100%;
 }
 
-.label-left {
-  flex: 1 1 auto;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding-right: 6px;
-}
-
-.label-right {
-  flex: 0 0 180px;
+.label-qr {
+  flex: 1.1 1 320px;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-.label-qr-box {
-  width: 140px;
-  height: 140px;
-  background: #f3f4f6;
-  border-radius: 12px;
+.label-qr__canvas {
+  width: min(320px, 100%);
+  aspect-ratio: 1 / 1;
+  border-radius: 30px;
+  background: radial-gradient(circle at 30% 20%, #ffffff 0%, #e4e8ff 100%);
+  border: 1px solid rgba(17, 24, 67, 0.1);
+  box-shadow: 0 32px 56px -40px rgba(17, 24, 67, 0.55);
+  padding: 1.4rem;
   display: grid;
   place-items: center;
-  border: 1px solid rgba(17,24,67,0.06);
 }
 
-.label-qr-box img { width: 92%; height: 92%; object-fit: contain; }
+.label-qr__canvas img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  border-radius: 20px;
+}
+
+.label-info {
+  flex: 1 1 260px;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.label-info__name {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: #111827;
+  line-height: 1.2;
+}
+
+.label-info__meta {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.label-card.vertical .label-info__meta {
+  grid-template-columns: 1fr;
+  width: 100%;
+}
 
 .label-field {
-  display:flex; flex-direction:column; gap:4px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding-left: 0.65rem;
+  border-left: 3px solid rgba(80, 90, 118, 0.35);
 }
 
-.label-field .label-field__key {
-  font-size:0.72rem; color:#6b7280; text-transform:uppercase; font-weight:700; letter-spacing:0.06em;
+.label-field__key {
+  font-size: 0.72rem;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
 }
-.label-field .label-field__value {
-  font-size:0.95rem; color:#111827; font-weight:600;
+
+.label-field__value {
+  font-size: 0.98rem;
+  color: #111827;
+  font-weight: 600;
 }
 
 .label-footer {
-  background: linear-gradient(90deg,#6b6f74,#d1d5db);
+  background: linear-gradient(90deg, #4c5168, #79829e);
   color: #fff;
-  padding: 10px 14px;
-  font-weight:600;
-  display:flex; justify-content:space-between; align-items:center;
+  padding: 0.85rem 1.5rem;
+  font-weight: 600;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
 }
 
-/* Vertical variations */
-.label-card.vertical .label-right { flex: 0 0 auto; order: 0; padding-top: 8px; }
-.label-card.vertical .label-body { flex-direction: column; align-items: stretch; }
-
-@media (max-width:540px) {
-  .label-right { flex: 0 0 120px; }
-  .label-qr-box { width: 100px; height: 100px; }
+.label-card.vertical .label-body {
+  width: 100%;
+  gap: 1.5rem;
 }
 
-.qr-placeholder {
-  font-size: 1rem;
-  color: var(--sidebar-color);
-  font-weight: 500;
-  text-align: center;
-  background: rgba(255, 111, 145, 0.08);
-  border: 1px solid rgba(255, 111, 145, 0.18);
-  padding: 1.25rem 1.75rem;
-  border-radius: 20px;
-  box-shadow: inset 0 0 0 1px rgba(255, 111, 145, 0.12);
+@media (max-width: 540px) {
+  .qr-modal-layout {
+    gap: 1.25rem;
+  }
+
+  .qr-display {
+    padding: 1.25rem;
+  }
+
+  .label-info__name {
+    font-size: 1.15rem;
+  }
+
+  .label-info__meta {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 576px) {


### PR DESCRIPTION
## Summary
- simplify the QR modal markup so the orientation controls sit beside a single, prominent QR display and the placeholder carries a status role
- refresh the modal CSS with lighter styling that emphasizes the QR image while keeping the control layout responsive
- wire the orientation radios at load time and reset the hidden label markup on modal close so preview updates work reliably

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e182b830cc832c967ad8de1173c731