### PR TITLE
Restyle product QR modal to match UI palette

### DIFF
--- a/pages/gest_inve/inventario_basico.html
+++ b/pages/gest_inve/inventario_basico.html
@@ -298,7 +298,7 @@
 
   <div class="modal fade" id="productoQrModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered">
-      <div class="modal-content shadow-lg">
+      <div class="modal-content qr-modal shadow-lg">
         <div class="modal-header border-0">
           <div>
             <span class="modal-eyebrow">Código QR</span>

--- a/styles/gest_inve/inventario_basico.css
+++ b/styles/gest_inve/inventario_basico.css
@@ -378,7 +378,7 @@ img {
 .qr-modal-content {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
 @media (min-width: 768px) {
@@ -390,39 +390,56 @@ img {
 
 .qr-modal-settings {
   flex: 1 1 260px;
-  background: linear-gradient(155deg, rgba(17, 24, 67, 0.08), rgba(255, 111, 145, 0.12));
-  border: 1px solid rgba(17, 24, 67, 0.08);
-  border-radius: 22px;
-  padding: 1.25rem 1.5rem;
-  box-shadow: 0 28px 48px -36px rgba(17, 24, 67, 0.65);
-  backdrop-filter: blur(2px);
+  background: #fff;
+  border: 1px solid var(--border-color);
+  border-radius: 24px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 40px -28px var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .qr-modal-settings__title {
   font-size: 1.05rem;
   font-weight: 700;
-  color: var(--primary-color);
-  margin-bottom: 0.35rem;
+  color: var(--sidebar-color);
+  margin: 0;
 }
 
 .qr-modal-settings__hint {
   font-size: 0.9rem;
-  color: var(--sidebar-color);
-  margin-bottom: 1.25rem;
+  color: var(--muted-color);
+  margin: 0;
+}
+
+.qr-orientation {
+  display: inline-flex;
+  padding: 0.4rem;
+  border-radius: 999px;
+  background: var(--primary-surface);
+  gap: 0.35rem;
 }
 
 .qr-orientation .btn {
   border-radius: 999px;
   font-weight: 600;
   padding: 0.45rem 1.4rem;
+  border: 1px solid transparent;
+  color: var(--muted-color);
+  background: transparent;
   transition: all 0.2s ease;
 }
 
+.qr-orientation .btn:hover {
+  color: var(--sidebar-color);
+}
+
 .qr-orientation .btn-check:checked + .btn {
-  background: var(--primary-color);
-  border-color: var(--primary-color);
-  color: #fff;
-  box-shadow: 0 16px 32px -24px rgba(255, 111, 145, 0.85);
+  background: var(--topbar-color);
+  border-color: var(--topbar-color);
+  color: var(--topbar-text-color);
+  box-shadow: 0 12px 24px -18px var(--primary-shadow-soft);
 }
 
 .qr-modal-visual {
@@ -435,11 +452,11 @@ img {
 .qr-visual {
   width: 100%;
   max-width: 420px;
-  padding: 2.75rem;
-  border-radius: 34px;
+  padding: 2.5rem;
+  border-radius: 32px;
   border: 1px solid var(--primary-border-soft);
-  background: radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.96), rgba(17, 24, 67, 0.08));
-  box-shadow: 0 42px 68px -40px rgba(17, 24, 67, 0.65);
+  background: #fff;
+  box-shadow: 0 24px 48px -32px var(--primary-shadow-soft);
   display: grid;
   place-items: center;
   position: relative;
@@ -448,32 +465,33 @@ img {
 .qr-visual::after {
   content: '';
   position: absolute;
-  inset: 12px;
-  border-radius: 28px;
-  border: 1px dashed rgba(17, 24, 67, 0.18);
+  inset: 14px;
+  border-radius: 26px;
+  border: 2px dashed var(--primary-border-strong);
+  opacity: 0.6;
   pointer-events: none;
 }
 
 .qr-image {
-  width: min(360px, 100%);
+  width: min(320px, 100%);
   aspect-ratio: 1 / 1;
   object-fit: contain;
-  border-radius: 24px;
+  border-radius: 20px;
+  border: 1px solid var(--primary-border-soft);
   background: #fff;
-  box-shadow: 0 32px 60px -42px rgba(17, 24, 67, 0.65);
-  padding: 1.1rem;
+  box-shadow: 0 18px 36px -28px var(--primary-shadow-soft);
+  padding: 0.75rem;
 }
 
 .qr-placeholder {
-  font-size: 1.05rem;
-  color: var(--sidebar-color);
+  font-size: 1rem;
+  color: var(--muted-color);
   font-weight: 600;
   text-align: center;
-  background: rgba(255, 111, 145, 0.12);
-  border: 1px solid rgba(255, 111, 145, 0.28);
-  padding: 1.65rem 2.1rem;
-  border-radius: 24px;
-  box-shadow: inset 0 0 0 1px rgba(255, 111, 145, 0.12);
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px dashed var(--primary-border-strong);
+  padding: 1.75rem 2.25rem;
+  border-radius: 22px;
 }
 
 .label-card {
@@ -887,7 +905,7 @@ img {
   padding: 0.3rem 0.7rem;
   border-radius: var(--radius-pill);
   background: var(--primary-surface);
-  color: var(--primary-color);
+  color: var(--topbar-color);
   font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -896,8 +914,79 @@ img {
 
 .qr-modal {
   background: var(--card-bg);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border-color);
+  border-radius: 28px;
+  border: 1px solid var(--primary-border-soft);
+  box-shadow: 0 36px 64px -36px var(--primary-shadow-soft);
+  overflow: hidden;
+}
+
+.qr-modal .modal-header {
+  padding: 1.5rem 1.75rem 0;
+  border-bottom: none;
+}
+
+.qr-modal .modal-title {
+  color: var(--sidebar-color);
+  font-weight: 700;
+}
+
+.qr-modal .modal-body {
+  padding: 1.75rem;
+  padding-top: 1.5rem;
+}
+
+.qr-modal .modal-footer {
+  border-top: none;
+  padding: 0 1.75rem 1.75rem;
+  gap: 0.75rem;
+}
+
+.qr-modal .btn-close {
+  --bs-btn-close-opacity: 1;
+  --bs-btn-close-bg: none;
+  display: grid;
+  place-items: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  background: var(--primary-surface);
+  opacity: 1;
+  transition: background var(--transition-speed) ease;
+}
+
+.qr-modal .btn-close:hover,
+.qr-modal .btn-close:focus {
+  background: var(--primary-surface-strong);
+  opacity: 1;
+}
+
+.qr-modal .btn-close:focus {
+  box-shadow: 0 0 0 3px rgba(255, 111, 145, 0.15);
+}
+
+#productoQrDownload.btn {
+  border-radius: var(--radius-pill);
+  background: var(--topbar-color);
+  border-color: var(--topbar-color);
+  color: var(--topbar-text-color);
+  font-weight: 600;
+  padding: 0.75rem 1rem;
+}
+
+#productoQrDownload.btn:hover {
+  background: #ff567e;
+  border-color: #ff567e;
+  color: var(--topbar-text-color);
+}
+
+#productoQrDownload.btn:focus {
+  box-shadow: 0 0 0 0.25rem rgba(255, 111, 145, 0.25);
+}
+
+.qr-modal .btn-secondary {
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  padding: 0.75rem 1rem;
 }
 
 .qr-reader {


### PR DESCRIPTION
## Summary
- restyle the product QR modal to reuse the existing qr-modal component and align the header with the brand colors
- refresh the QR preview, placeholder, and orientation selector styling to match the topbar/sidebar palette and rounded design
- update the modal action buttons to use pill shapes and the primary color for the download action

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e18ad8096c832c9c46568a45591f71