### PR TITLE
Add descriptive product and area details to activity logs

### DIFF
--- a/scripts/php/get_logs.php
+++ b/scripts/php/get_logs.php
@@ -5,6 +5,317 @@ header("Content-Type: application/json");
 require_once __DIR__ . '/log_utils.php';
 require_once __DIR__ . '/accesos_utils.php';
 
+function normalizarListaIds(array $ids): array
+{
+    $filtrados = array_filter(array_map('intval', $ids), static function ($id) {
+        return $id > 0;
+    });
+
+    return array_values(array_unique($filtrados));
+}
+
+function formatearUbicacionProducto(array $producto): string
+{
+    $partes = [];
+
+    if (!empty($producto['zona_nombre'])) {
+        $partes[] = 'Zona: ' . $producto['zona_nombre'];
+    }
+
+    if (!empty($producto['area_nombre'])) {
+        $partes[] = 'Área: ' . $producto['area_nombre'];
+    }
+
+    return $partes ? implode(' · ', $partes) : '';
+}
+
+function formatearProductoConNombre(array $producto): string
+{
+    $nombre = trim((string)($producto['nombre'] ?? ''));
+    $resultado = $nombre;
+
+    $ubicacion = formatearUbicacionProducto($producto);
+    if ($ubicacion !== '') {
+        $resultado .= ' (' . $ubicacion . ')';
+    }
+
+    $descripcion = trim((string)($producto['descripcion'] ?? ''));
+    if ($descripcion !== '') {
+        $resultado .= ' — Descripción: ' . $descripcion;
+    }
+
+    return trim($resultado);
+}
+
+function formatearDetalleProducto(array $producto): string
+{
+    $partes = [];
+
+    $ubicacion = formatearUbicacionProducto($producto);
+    if ($ubicacion !== '') {
+        $partes[] = $ubicacion;
+    }
+
+    $descripcion = trim((string)($producto['descripcion'] ?? ''));
+    if ($descripcion !== '') {
+        $partes[] = 'Descripción: ' . $descripcion;
+    }
+
+    return implode(' — ', $partes);
+}
+
+function extraerReferenciasDesdeAccion(string $accion): array
+{
+    $productos = [];
+    $areas = [];
+    $zonas = [];
+
+    if (preg_match_all('/producto\s*(?:ID[:\s]*|#\s*|n[úu]mero\s*)?(\d+)/iu', $accion, $productoMatches)) {
+        foreach ($productoMatches[1] as $id) {
+            $productos[] = (int) $id;
+        }
+    }
+
+    if (preg_match_all('/producto[^()]*\(\s*ID\s*(\d+)\s*\)/iu', $accion, $productoIdMatches)) {
+        foreach ($productoIdMatches[1] as $id) {
+            $productos[] = (int) $id;
+        }
+    }
+
+    if (preg_match_all('/(área|area)\s*(?:con\s+)?(?:id|n[úu]mero|#)\s*[:#-]?\s*(\d+)/iu', $accion, $areaMatches)) {
+        foreach ($areaMatches[2] as $id) {
+            $areas[] = (int) $id;
+        }
+    }
+
+    if (preg_match_all('/(zona)\s*(?:con\s+)?(?:id|n[úu]mero|#)\s*[:#-]?\s*(\d+)/iu', $accion, $zonaMatches)) {
+        foreach ($zonaMatches[2] as $id) {
+            $zonas[] = (int) $id;
+        }
+    }
+
+    return [
+        'productos' => $productos,
+        'areas'     => $areas,
+        'zonas'     => $zonas,
+    ];
+}
+
+function extraerReferenciasDesdeLogs(array $logs): array
+{
+    $productos = [];
+    $areas = [];
+    $zonas = [];
+
+    foreach ($logs as $log) {
+        $accion = isset($log['accion']) && is_string($log['accion']) ? $log['accion'] : '';
+        if ($accion === '') {
+            continue;
+        }
+
+        $referencias = extraerReferenciasDesdeAccion($accion);
+        $productos    = array_merge($productos, $referencias['productos']);
+        $areas        = array_merge($areas, $referencias['areas']);
+        $zonas        = array_merge($zonas, $referencias['zonas']);
+    }
+
+    return [
+        'productos' => normalizarListaIds($productos),
+        'areas'     => normalizarListaIds($areas),
+        'zonas'     => normalizarListaIds($zonas),
+    ];
+}
+
+function obtenerDatosProductos(mysqli $conn, array $ids): array
+{
+    $ids = normalizarListaIds($ids);
+    if (empty($ids)) {
+        return [];
+    }
+
+    $placeholders = implode(',', array_fill(0, count($ids), '?'));
+    $types = str_repeat('i', count($ids));
+
+    $sql = "SELECT p.id, p.nombre, p.descripcion, z.nombre AS zona_nombre, a.nombre AS area_nombre
+            FROM productos p
+            LEFT JOIN zonas z ON p.zona_id = z.id
+            LEFT JOIN areas a ON z.area_id = a.id
+            WHERE p.id IN ($placeholders)";
+
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param($types, ...$ids);
+    $stmt->execute();
+    $result = $stmt->get_result();
+
+    $datos = [];
+    while ($row = $result->fetch_assoc()) {
+        $datos[(int) $row['id']] = $row;
+    }
+
+    $stmt->close();
+
+    return $datos;
+}
+
+function obtenerDatosAreas(mysqli $conn, array $ids): array
+{
+    $ids = normalizarListaIds($ids);
+    if (empty($ids)) {
+        return [];
+    }
+
+    $placeholders = implode(',', array_fill(0, count($ids), '?'));
+    $types = str_repeat('i', count($ids));
+
+    $sql = "SELECT id, nombre, descripcion FROM areas WHERE id IN ($placeholders)";
+
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param($types, ...$ids);
+    $stmt->execute();
+    $result = $stmt->get_result();
+
+    $datos = [];
+    while ($row = $result->fetch_assoc()) {
+        $datos[(int) $row['id']] = $row;
+    }
+
+    $stmt->close();
+
+    return $datos;
+}
+
+function obtenerDatosZonas(mysqli $conn, array $ids): array
+{
+    $ids = normalizarListaIds($ids);
+    if (empty($ids)) {
+        return [];
+    }
+
+    $placeholders = implode(',', array_fill(0, count($ids), '?'));
+    $types = str_repeat('i', count($ids));
+
+    $sql = "SELECT z.id, z.nombre, z.descripcion, a.nombre AS area_nombre
+            FROM zonas z
+            LEFT JOIN areas a ON z.area_id = a.id
+            WHERE z.id IN ($placeholders)";
+
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param($types, ...$ids);
+    $stmt->execute();
+    $result = $stmt->get_result();
+
+    $datos = [];
+    while ($row = $result->fetch_assoc()) {
+        $datos[(int) $row['id']] = $row;
+    }
+
+    $stmt->close();
+
+    return $datos;
+}
+
+function enriquecerAccionConDetalles(string $accion, array $productosInfo, array $areasInfo, array $zonasInfo): string
+{
+    if ($accion === '') {
+        return $accion;
+    }
+
+    $resultado = $accion;
+
+    $resultado = preg_replace_callback(
+        '/(producto\s*)(?:ID[:\s]*|#\s*|n[úu]mero\s*)?(\d+)/iu',
+        static function ($matches) use ($productosInfo) {
+            $prefijo = rtrim($matches[1]);
+            $id = (int) $matches[2];
+
+            if (!isset($productosInfo[$id])) {
+                return $prefijo;
+            }
+
+            $detalle = formatearProductoConNombre($productosInfo[$id]);
+            return trim($prefijo . ' ' . $detalle);
+        },
+        $resultado
+    );
+
+    $resultado = preg_replace_callback(
+        '/(producto[^()]*)\(\s*ID\s*(\d+)\s*\)/iu',
+        static function ($matches) use ($productosInfo) {
+            $texto = rtrim($matches[1]);
+            $id = (int) $matches[2];
+
+            if (!isset($productosInfo[$id])) {
+                return $texto;
+            }
+
+            $detalle = formatearDetalleProducto($productosInfo[$id]);
+            if ($detalle === '') {
+                return $texto;
+            }
+
+            return $texto . ' — ' . $detalle;
+        },
+        $resultado
+    );
+
+    $resultado = preg_replace_callback(
+        '/(área|area)\s*(?:con\s+)?(?:id|n[úu]mero|#)\s*[:#-]?\s*(\d+)/iu',
+        static function ($matches) use ($areasInfo) {
+            $id = (int) $matches[2];
+
+            if (!isset($areasInfo[$id])) {
+                return 'Área sin información disponible';
+            }
+
+            $area = $areasInfo[$id];
+            $descripcion = trim((string)($area['descripcion'] ?? ''));
+
+            $texto = 'Área ' . $area['nombre'];
+            if ($descripcion !== '') {
+                $texto .= ' — Descripción: ' . $descripcion;
+            }
+
+            return $texto;
+        },
+        $resultado
+    );
+
+    $resultado = preg_replace_callback(
+        '/(zona)\s*(?:con\s+)?(?:id|n[úu]mero|#)\s*[:#-]?\s*(\d+)/iu',
+        static function ($matches) use ($zonasInfo) {
+            $id = (int) $matches[2];
+
+            if (!isset($zonasInfo[$id])) {
+                return 'Zona sin información disponible';
+            }
+
+            $zona = $zonasInfo[$id];
+            $texto = 'Zona ' . $zona['nombre'];
+
+            $detalles = [];
+            if (!empty($zona['area_nombre'])) {
+                $detalles[] = 'Área: ' . $zona['area_nombre'];
+            }
+
+            $descripcion = trim((string)($zona['descripcion'] ?? ''));
+            if ($descripcion !== '') {
+                $detalles[] = 'Descripción: ' . $descripcion;
+            }
+
+            if ($detalles) {
+                $texto .= ' — ' . implode(' · ', $detalles);
+            }
+
+            return $texto;
+        },
+        $resultado
+    );
+
+    $resultado = preg_replace('/\s{2,}/', ' ', trim($resultado));
+
+    return $resultado;
+}
+
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
 $servername = "localhost";
@@ -90,6 +401,17 @@ while ($row = $result->fetch_assoc()) {
     $logs[] = $row;
 }
 $stmt->close();
+
+$referencias = extraerReferenciasDesdeLogs($logs);
+$productosInfo = obtenerDatosProductos($conn, $referencias['productos']);
+$areasInfo = obtenerDatosAreas($conn, $referencias['areas']);
+$zonasInfo = obtenerDatosZonas($conn, $referencias['zonas']);
+
+foreach ($logs as &$log) {
+    $accion = isset($log['accion']) && is_string($log['accion']) ? $log['accion'] : '';
+    $log['accion'] = enriquecerAccionConDetalles($accion, $productosInfo, $areasInfo, $zonasInfo);
+}
+unset($log);
 
 $usuariosSql = "SELECT DISTINCT u.id_usuario, CONCAT(u.nombre, ' ', u.apellido) AS nombre, u.rol
         FROM usuario u


### PR DESCRIPTION
## Summary
- enrich the activity log API so product, area, and zone actions show descriptive names instead of IDs
- fetch related product, area, and zone data and format log messages with location and description details

## Testing
- php -l scripts/php/get_logs.php

------
https://chatgpt.com/codex/tasks/task_e_68e1bd1c13b4832c9c1a8ccb598cc51f