### PR TITLE
Ensure global search history syncs reliably

### DIFF
--- a/scripts/main_menu/global_search.js
+++ b/scripts/main_menu/global_search.js
@@ -237,6 +237,12 @@
     let pendingQuery = '';
     let searchDataPromise = null;
 
+    const LOCAL_PENDING_SEARCHES_KEY = 'globalSearchPendingTerms';
+    let pendingSearchTerms = [];
+    let syncingPendingSearches = false;
+
+    cargarBusquedasPendientesLocales();
+
     function mostrarPlaceholder(titulo, descripcion = '', iconClass = 'fa-search') {
         if (!searchResultsContainer) return;
         searchResultsContainer.innerHTML = `
@@ -317,10 +323,110 @@
         }
     }
 
-    async function registrarBusqueda(consulta) {
-        const termino = (consulta || '').trim();
-        if (!termino || !empresaIdCache) {
+    function obtenerEmpresaIdActual() {
+        const cachedId = Number(empresaIdCache);
+        if (cachedId) {
+            return cachedId;
+        }
+
+        try {
+            const stored = Number(localStorage.getItem('id_empresa'));
+            if (stored) {
+                empresaIdCache = stored;
+                return stored;
+            }
+        } catch (error) {
+            console.warn('No se pudo leer el id de la empresa desde el almacenamiento local:', error);
+        }
+
+        return 0;
+    }
+
+    function cargarBusquedasPendientesLocales() {
+        try {
+            const stored = localStorage.getItem(LOCAL_PENDING_SEARCHES_KEY);
+            if (!stored) {
+                pendingSearchTerms = [];
+                return;
+            }
+
+            const parsed = JSON.parse(stored);
+            if (Array.isArray(parsed)) {
+                pendingSearchTerms = parsed
+                    .map(entry => (typeof entry === 'string' ? entry.trim() : ''))
+                    .filter(entry => entry.length > 0)
+                    .slice(-20);
+                return;
+            }
+        } catch (error) {
+            console.warn('No se pudieron recuperar las búsquedas pendientes:', error);
+        }
+
+        pendingSearchTerms = [];
+    }
+
+    function persistirBusquedasPendientes() {
+        try {
+            if (!pendingSearchTerms.length) {
+                localStorage.removeItem(LOCAL_PENDING_SEARCHES_KEY);
+                return;
+            }
+
+            localStorage.setItem(LOCAL_PENDING_SEARCHES_KEY, JSON.stringify(pendingSearchTerms.slice(-20)));
+        } catch (error) {
+            console.warn('No se pudieron guardar las búsquedas pendientes localmente:', error);
+        }
+    }
+
+    function agregarBusquedaPendiente(termino) {
+        pendingSearchTerms.push(termino);
+        if (pendingSearchTerms.length > 20) {
+            pendingSearchTerms = pendingSearchTerms.slice(-20);
+        }
+        persistirBusquedasPendientes();
+    }
+
+    async function sincronizarBusquedasPendientes(empresaId) {
+        if (syncingPendingSearches) {
             return;
+        }
+
+        const empresaIdNumero = Number(empresaId);
+        if (!empresaIdNumero) {
+            return;
+        }
+
+        if (!pendingSearchTerms.length) {
+            return;
+        }
+
+        syncingPendingSearches = true;
+
+        const termsToProcess = [...pendingSearchTerms];
+        pendingSearchTerms = [];
+        persistirBusquedasPendientes();
+
+        try {
+            for (let index = 0; index < termsToProcess.length; index += 1) {
+                const terminoPendiente = termsToProcess[index];
+                const exito = await guardarBusquedaRemota(terminoPendiente, empresaIdNumero);
+                if (!exito) {
+                    pendingSearchTerms = termsToProcess.slice(index);
+                    persistirBusquedasPendientes();
+                    break;
+                }
+            }
+        } finally {
+            syncingPendingSearches = false;
+        }
+    }
+
+    async function guardarBusquedaRemota(termino, empresaId) {
+        const terminoNormalizado = (termino || '').trim();
+        const empresaIdNumero = Number(empresaId);
+
+        if (!terminoNormalizado || !empresaIdNumero) {
+            return false;
         }
 
         try {
@@ -329,8 +435,8 @@
                 headers: { 'Content-Type': 'application/json' },
                 credentials: 'include',
                 body: JSON.stringify({
-                    termino,
-                    id_empresa: Number(empresaIdCache)
+                    termino: terminoNormalizado,
+                    id_empresa: empresaIdNumero
                 })
             });
 
@@ -343,10 +449,35 @@
             if (data.success && Array.isArray(data.historial)) {
                 renderHistorialBusquedas(data.historial);
             } else if (data.success) {
-                cargarHistorialBusquedas(empresaIdCache);
+                cargarHistorialBusquedas(empresaIdNumero);
             }
+
+            return !!data.success;
         } catch (error) {
             console.warn('No se pudo registrar la búsqueda:', error);
+            return false;
+        }
+    }
+
+    async function registrarBusqueda(consulta) {
+        const termino = (consulta || '').trim();
+        if (!termino) {
+            return;
+        }
+
+        const empresaId = obtenerEmpresaIdActual();
+
+        if (!empresaId) {
+            agregarBusquedaPendiente(termino);
+            return;
+        }
+
+        await sincronizarBusquedasPendientes(empresaId);
+
+        const exito = await guardarBusquedaRemota(termino, empresaId);
+
+        if (!exito) {
+            agregarBusquedaPendiente(termino);
         }
     }
 
@@ -632,6 +763,8 @@
                     cargarDatosBusqueda(empresaIdNumero),
                     cargarHistorialBusquedas(empresaIdNumero)
                 ]);
+
+                await sincronizarBusquedasPendientes(empresaIdNumero);
             })()
             .catch(error => {
                 console.error('No se pudo inicializar el buscador global:', error);


### PR DESCRIPTION
## Summary
- persist pending global search terms in local storage so they survive reloads until a company id is available
- synchronize cached searches as soon as the company context is known and before registering new entries, updating the shared history list on success
- trigger the pending search synchronization after initialization completes to push any queued terms once configuration and datasets are ready

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e44cf70448832ca8cbf86e07f51807