### PR TITLE
Fix global search history persistence

### DIFF
--- a/scripts/main_menu/global_search.js
+++ b/scripts/main_menu/global_search.js
@@ -478,57 +478,8 @@
 
         if (!exito) {
             agregarBusquedaPendiente(termino);
+            window.setTimeout(() => sincronizarBusquedasPendientes(empresaId), 5000);
         }
-    }
-
-    function procesarBusquedasPendientes() {
-        if (processingPendingSearches) {
-            return;
-        }
-
-        const empresaIdNumero = Number(empresaIdCache);
-        if (!empresaIdNumero || !pendingSearchTerms.length) {
-            return;
-        }
-
-        processingPendingSearches = true;
-        let procesamientoCompleto = true;
-
-        (async () => {
-            while (pendingSearchTerms.length && Number(empresaIdCache) === empresaIdNumero) {
-                const terminoPendiente = pendingSearchTerms[0];
-                const exito = await guardarBusquedaRemota(terminoPendiente, empresaIdNumero);
-                if (!exito) {
-                    procesamientoCompleto = false;
-                    break;
-                }
-                pendingSearchTerms.shift();
-            }
-        })()
-        .catch(error => {
-            procesamientoCompleto = false;
-            console.warn('No se pudo procesar las búsquedas pendientes:', error);
-        })
-        .finally(() => {
-            processingPendingSearches = false;
-
-            if (!Number(empresaIdCache) || !pendingSearchTerms.length) {
-                return;
-            }
-
-            const delay = procesamientoCompleto ? 0 : 5000;
-            window.setTimeout(procesarBusquedasPendientes, delay);
-        });
-    }
-
-    async function registrarBusqueda(consulta) {
-        const termino = (consulta || '').trim();
-        if (!termino) {
-            return;
-        }
-
-        pendingSearchTerms.push(termino);
-        procesarBusquedasPendientes();
     }
 
     function normalizarTexto(texto) {


### PR DESCRIPTION
## Summary
- ensure the global search input registers terms for the signed-in company when a search is submitted
- update the retry flow so pending terms are re-synced and the quick link chips render the five most recent searches

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e458a01d28832cb2c10f1df39570ea