### PR TITLE
Create interactive reports dashboard

### DIFF
--- a/docs/reportes_automaticos.md
+++ b/docs/reportes_automaticos.md
@@ -1,0 +1,72 @@
+# Propuesta de módulo de reportes automáticos
+
+Este documento detalla la organización y las funciones sugeridas para la página de reportes, incluyendo la generación automática de reportes con periodos personalizados. Se busca mantener el uso de herramientas básicas y almacenamiento local.
+
+## 1. Organización general de la página de reportes
+- **Secciones principales**:
+  - *Panel de carga manual*: formulario para subir archivos PDF generados en cualquier sección.
+  - *Panel de programación automática*: interfaz para que el usuario defina periodos y condiciones de generación automática.
+  - *Historial centralizado*: listado con filtros por fecha, área, tipo de documento y usuario que lo generó.
+  - *Detalle de reporte*: vista que muestre metadatos, vista previa del PDF y opciones de descarga.
+- **Diseño visual**:
+  - Reutilizar los componentes existentes del sitio para conservar la identidad visual.
+  - Cargar la paleta de colores definida en la configuración de la empresa y aplicarla a botones, tablas y paneles.
+  - Ofrecer la opción de colocar el logotipo de la empresa como marca de agua o en el pie de página del PDF generado.
+
+## 2. Almacenamiento y estructura de datos (local)
+- **Archivos**: guardar los PDFs en una estructura por año/mes/área/usuario dentro del servidor, por ejemplo `reportes/<año>/<mes>/<area>/<usuario>/`.
+- **Metadatos**: mantener un archivo SQLite o JSON que registre título, descripción, autor, área, fecha de generación, periodo cubierto, estado y ruta del archivo.
+- **Control de versiones**: incluir número de versión o un flag de "última versión" para los reportes que se regeneran automáticamente.
+
+## 3. Configuración de reportes automáticos
+- **Periodos disponibles**:
+  - Predefinidos: semanal, quincenal, mensual.
+  - Personalizados: selección de fecha inicial y final.
+- **Fuentes de datos**:
+  - Movimientos de productos (entradas/salidas, ajustes de inventario).
+  - Resumen por áreas o zonas (volumen, rotación, existencias críticas).
+  - Actividades de usuarios (acciones realizadas, aprobaciones, incidencias).
+- **Plantillas**:
+  - Definir plantillas base en HTML/CSS que respeten la paleta de colores actual.
+  - Incluir espacios reservados para logotipo (marca de agua o pie de página) y tablas con datos.
+- **Programación**:
+  - Formulario para seleccionar: tipo de reporte, periodo, área/zona, destinatarios internos y formato de entrega (descarga, correo interno).
+  - Guardar la configuración en la base de datos local para que el proceso programado la ejecute.
+
+## 4. Generación y entrega de reportes
+- **Motor de generación**:
+  - Script local (por ejemplo, Node.js con bibliotecas básicas como `pdf-lib` o `jspdf`) que toma los datos y arma el PDF con el estilo definido.
+  - Incorporar la marca de agua o logotipo al renderizado del PDF.
+- **Planificador**:
+  - Uso de `cron` del sistema operativo o un programador interno simple que revise cada hora si existe un reporte pendiente por generar según su configuración.
+  - Tras la generación, registrar el reporte en el historial con su metadato y ruta.
+- **Notificaciones**:
+  - Mostrar alertas dentro del dashboard o enviar correos mediante un servidor SMTP local si se dispone.
+
+## 5. Seguridad y control de acceso
+- Requerir autenticación antes de acceder a la página de reportes.
+- Gestionar roles: usuarios estándar pueden ver sus reportes; administradores o supervisores ven todos los reportes de sus áreas.
+- Validar tipo y tamaño de archivo al subir PDFs manualmente.
+- Mantener bitácora de quién programa, genera o descarga un reporte.
+
+## 6. Gestión del historial
+- Filtros avanzados (fecha, área, estado, autor, tipo de reporte).
+- Búsqueda por texto libre (título o descripción).
+- Exportación del listado a CSV o Excel con rutas de descarga.
+- Opción de archivar reportes antiguos manteniéndolos accesibles bajo una pestaña separada.
+
+## 7. Implementación gradual sugerida
+1. Crear la estructura de carpetas para almacenamiento local y la tabla/archivo de metadatos.
+2. Construir la vista centralizada de reportes con filtros.
+3. Implementar el módulo de subida manual con validaciones.
+4. Desarrollar el planificador básico con cron o un proceso Node.js que ejecute tareas periódicas.
+5. Añadir plantillas de reportes automáticos para inventario, áreas/zones y actividades de usuarios.
+6. Integrar opciones de personalización (periodos personalizados, logotipo como marca de agua o pie).
+7. Ajustar estilos para respetar la paleta de colores configurada y probar los flujos completos.
+
+## 8. Mantenimiento y respaldo
+- Generar copias de seguridad periódicas de la carpeta de reportes y del archivo de metadatos.
+- Documentar cómo agregar nuevos tipos de reportes automáticos.
+- Revisar logs para asegurar que el planificador se ejecuta correctamente y solucionar posibles fallos.
+
+Esta propuesta permite consolidar los reportes creados manualmente o de forma automática, manteniendo el uso de herramientas básicas y almacenamiento en el servidor local.

--- a/pages/reports/reportes.html
+++ b/pages/reports/reportes.html
@@ -4,7 +4,296 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Reportes · OptiStock</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
+    integrity="sha512-IvM3gXkZzm3UfFcGJE0E7E5Wdl66iRS0LlwM651c01qmPvvrLpzjAU6YewsGmmKzBSSMSmc5QdDFi1C5nUqXkg=="
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"
+  />
+  <link rel="stylesheet" href="../../styles/reports/reportes.css" />
 </head>
 <body>
+  <main class="report-layout">
+    <section class="report-hero">
+      <div class="report-hero__content">
+        <span class="report-hero__badge">Centro de reportes</span>
+        <h1 class="report-hero__title">Reportes inteligentes de OptiStock</h1>
+        <p class="report-hero__subtitle">
+          Genera, programa y resguarda todos los documentos PDF de tu operación. Personaliza periodos, zonas y módulos sin salir de la plataforma.
+        </p>
+        <div class="metrics-grid" id="metricas">
+          <p class="metrics-empty">Configura los filtros para ver el resumen de actividad.</p>
+        </div>
+      </div>
+      <img src="../../images/optistockLogo.png" alt="Logotipo de la empresa" class="report-hero__brand" id="heroBrand" />
+    </section>
+
+    <section class="report-panels">
+      <aside class="filter-panel" aria-labelledby="filtrosTitulo">
+        <div class="panel-heading">
+          <h2 id="filtrosTitulo">Filtros de consulta</h2>
+          <p>Define el alcance de tus reportes por módulo, fechas y responsables.</p>
+        </div>
+
+        <form class="filters-form" id="formFiltros">
+          <fieldset class="filters-form__group">
+            <legend>Módulos del sistema</legend>
+            <label class="chip">
+              <input type="checkbox" value="inventarios" class="modulo" checked /> Inventarios
+            </label>
+            <label class="chip">
+              <input type="checkbox" value="areas" class="modulo" checked /> Áreas
+            </label>
+            <label class="chip">
+              <input type="checkbox" value="zonas" class="modulo" checked /> Zonas
+            </label>
+            <label class="chip">
+              <input type="checkbox" value="usuarios" class="modulo" checked /> Usuarios
+            </label>
+          </fieldset>
+
+          <div class="filters-grid">
+            <label class="field">
+              <span>Fecha inicial</span>
+              <input type="date" id="fInicio" />
+            </label>
+            <label class="field">
+              <span>Fecha final</span>
+              <input type="date" id="fFin" />
+            </label>
+            <label class="field">
+              <span>Categoría</span>
+              <input type="text" id="fCategoria" placeholder="Refacciones, auditorías…" />
+            </label>
+            <label class="field">
+              <span>Zona o área</span>
+              <input type="text" id="fZona" placeholder="Norte, refrigerado…" />
+            </label>
+            <label class="field">
+              <span>Rol responsable</span>
+              <select id="fRol">
+                <option value="">Todos</option>
+                <option value="almacenista">Almacenista</option>
+                <option value="supervisor">Supervisor</option>
+                <option value="administrador">Administrador</option>
+                <option value="mantenimiento">Mantenimiento</option>
+              </select>
+            </label>
+          </div>
+
+          <fieldset class="filters-form__group">
+            <legend>Marca corporativa en reportes</legend>
+            <div class="brand-options">
+              <label class="chip">
+                <input type="radio" name="brandMode" value="marca" checked /> Marca de agua
+              </label>
+              <label class="chip">
+                <input type="radio" name="brandMode" value="pie-izq" /> Pie izquierdo
+              </label>
+              <label class="chip">
+                <input type="radio" name="brandMode" value="pie-der" /> Pie derecho
+              </label>
+              <label class="chip">
+                <input type="radio" name="brandMode" value="marca-pie" /> Marca + pie
+              </label>
+            </div>
+            <div class="brand-controls">
+              <label class="field brand-field">
+                <span>Logotipo personalizado</span>
+                <input type="file" id="logoPersonalizado" accept="image/png, image/jpeg" />
+              </label>
+              <label class="field brand-field">
+                <span>Opacidad de marca de agua</span>
+                <div class="brand-slider">
+                  <input type="range" id="brandOpacity" min="0.02" max="0.5" step="0.01" value="0.08" />
+                  <span id="brandOpacityValue">8%</span>
+                </div>
+              </label>
+              <div class="brand-preview" id="brandPreview" aria-live="polite">Sin logotipo personalizado</div>
+              <button type="button" class="btn btn--ghost" id="brandReset">Usar logotipo predeterminado</button>
+            </div>
+          </fieldset>
+
+          <div class="filters-actions">
+            <button type="button" class="btn btn--primary" id="generarPdf">
+              <i class="fas fa-file-pdf"></i> Generar PDF
+            </button>
+            <button type="button" class="btn" id="generarExcel">
+              <i class="fas fa-file-excel"></i> Exportar Excel
+            </button>
+            <button type="button" class="btn" id="programarBtn">
+              <i class="fas fa-clock"></i> Programar reporte
+            </button>
+          </div>
+
+          <p class="program-status" id="estadoProgramacion">Sin programación automática activa.</p>
+        </form>
+      </aside>
+
+      <div class="insight-columns">
+        <section class="chart-panel" aria-labelledby="tendenciasTitulo">
+          <div class="panel-heading">
+            <h2 id="tendenciasTitulo">Tendencias de movimientos</h2>
+            <p>Consulta cómo evolucionan los movimientos de inventario por periodo.</p>
+          </div>
+          <canvas id="graficaTendencias" height="220" role="img" aria-label="Gráfica de tendencias"></canvas>
+        </section>
+
+        <section class="report-results" aria-labelledby="resultadosTitulo">
+          <div class="panel-heading">
+            <h2 id="resultadosTitulo">Resultados detallados</h2>
+            <p id="estadoResultados">Selecciona filtros para ver los registros.</p>
+          </div>
+          <div class="table-wrapper">
+            <table class="data-table" id="tablaResultados">
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Módulo</th>
+                  <th>Fecha</th>
+                  <th>Categoría</th>
+                  <th>Zona</th>
+                  <th>Rol</th>
+                  <th>Descripción</th>
+                  <th class="text-end">Cantidad</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+          <p class="empty-message" id="sinDatos">No hay registros para los filtros seleccionados.</p>
+        </section>
+
+        <section class="upload-panel" aria-labelledby="repositorioTitulo">
+          <div class="panel-heading">
+            <h2 id="repositorioTitulo">Repositorio central de reportes</h2>
+            <p>Sube y organiza todos los PDFs generados en cualquier módulo.</p>
+          </div>
+          <form class="upload-form" id="formSubida">
+            <div class="form-grid">
+              <label class="field">
+                <span>Título del documento</span>
+                <input type="text" id="tituloReporte" required placeholder="Reporte mensual de inventario" />
+              </label>
+              <label class="field">
+                <span>Módulo origen</span>
+                <select id="moduloReporte" required>
+                  <option value="inventarios">Inventarios</option>
+                  <option value="areas">Áreas</option>
+                  <option value="zonas">Zonas</option>
+                  <option value="usuarios">Usuarios</option>
+                </select>
+              </label>
+              <label class="field">
+                <span>Área / Departamento</span>
+                <input type="text" id="areaReporte" placeholder="Almacén frío" />
+              </label>
+              <label class="field">
+                <span>Zona</span>
+                <input type="text" id="zonaReporte" placeholder="Zona norte" />
+              </label>
+              <label class="field">
+                <span>Responsable</span>
+                <input type="text" id="responsableReporte" placeholder="Nombre del responsable" />
+              </label>
+              <label class="field field--file">
+                <span>Archivo PDF</span>
+                <input type="file" id="archivoReporte" accept="application/pdf" required />
+              </label>
+              <label class="field field--full">
+                <span>Notas</span>
+                <textarea id="notasReporte" rows="2" placeholder="Observaciones opcionales"></textarea>
+              </label>
+            </div>
+            <div class="filters-actions">
+              <button type="submit" class="btn btn--primary">
+                <i class="fas fa-upload"></i> Guardar en repositorio
+              </button>
+              <button type="button" class="btn btn--ghost" id="limpiarFormulario">
+                <i class="fas fa-eraser"></i> Limpiar
+              </button>
+            </div>
+          </form>
+          <div class="table-wrapper">
+            <table class="data-table" id="tablaDocumentos">
+              <thead>
+                <tr>
+                  <th>Documento</th>
+                  <th>Origen</th>
+                  <th>Subido por</th>
+                  <th>Fecha</th>
+                  <th class="text-end">Acciones</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+          <p class="empty-message" id="repositorioVacio">Aún no hay documentos guardados.</p>
+        </section>
+
+        <section class="report-history" aria-labelledby="historialTitulo">
+          <div class="panel-heading">
+            <h2 id="historialTitulo">Historial de exportaciones</h2>
+            <p>Control de reportes generados y programados recientemente.</p>
+          </div>
+          <div class="table-wrapper">
+            <table class="data-table" id="tablaHistorial">
+              <thead>
+                <tr>
+                  <th>Folio</th>
+                  <th>Generado</th>
+                  <th>Resumen</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </section>
+  </main>
+
+  <div class="modal" id="modalProgramar" aria-hidden="true" role="dialog" aria-labelledby="modalProgramarTitulo">
+    <div class="modal__backdrop" data-close="modal"></div>
+    <div class="modal__content" tabindex="-1">
+      <div class="modal__header">
+        <h3 id="modalProgramarTitulo">Programar reportes automáticos</h3>
+        <p>Elige cada cuánto se generará un PDF con los filtros actuales.</p>
+      </div>
+      <label class="field">
+        <span>Frecuencia</span>
+        <select id="intervalo">
+          <option value="">Manual (sin programación)</option>
+          <option value="diario">Diario</option>
+          <option value="semanal">Semanal</option>
+          <option value="quincenal">Quincenal</option>
+          <option value="mensual">Mensual</option>
+          <option value="personalizado">Personalizado</option>
+        </select>
+      </label>
+      <div class="field" id="grupoPersonalizado" hidden>
+        <span>Cada cuántos días</span>
+        <input type="number" id="intervaloDias" min="1" max="180" placeholder="Ejemplo: 10" />
+      </div>
+      <div class="modal__actions">
+        <button type="button" class="btn btn--ghost" id="cancelarProgramacion">Cerrar</button>
+        <button type="button" class="btn btn--primary" id="guardarProgramacion">Guardar</button>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" integrity="sha512-8qgpnqC2Fvdl7GgToYtL6vhfVqlhK/SXxPxq8np5xpoE2mR7BncpsbR9f7DmqDvewW48UUfGzSy0RKZ77N8x7g==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.2/jspdf.plugin.autotable.min.js" integrity="sha512-5BHQYaWV7zX+13buJj3zCThJujOa3sZVFgmfaLw7fU0v1HVSdBNmsSSMOk5jaW9McP/12D/nBICmAIymFcpnGQ==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" integrity="sha512-6ELXFFitvolSF/GpNZgbf+5Q5e0siJmq9hw3rroWAt4EvsC0BpvyEukgqS0bkkCm1cW0XkyR3O6jwxKF1u9IiA==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
+  <script src="../../scripts/reports/reportes.js" defer></script>
 </body>
 </html>

--- a/styles/reports/reportes.css
+++ b/styles/reports/reportes.css
@@ -132,6 +132,7 @@ img {
 .filter-panel,
 .chart-panel,
 .report-results,
+.upload-panel,
 .report-history {
   background: var(--card-bg, #ffffff);
   border-radius: 20px;
@@ -187,6 +188,56 @@ img {
   color: var(--text-color, #1f2937);
 }
 
+.brand-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.brand-controls {
+  display: grid;
+  gap: 12px;
+}
+
+.brand-field input[type="file"] {
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px dashed var(--border-color, #e7e9f5);
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.brand-slider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.brand-slider input[type="range"] {
+  flex: 1;
+}
+
+.brand-preview {
+  border: 1px dashed var(--primary-border-strong, rgba(255, 111, 145, 0.22));
+  border-radius: 14px;
+  padding: 12px;
+  font-size: 0.9rem;
+  color: var(--muted-color, #6b7280);
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background-size: contain;
+  background-position: left center;
+  background-repeat: no-repeat;
+}
+
+.brand-preview img {
+  width: 48px;
+  height: 48px;
+  object-fit: contain;
+}
+
 .chip {
   display: inline-flex;
   align-items: center;
@@ -228,13 +279,28 @@ img {
 }
 
 .field input,
-.field select {
+.field select,
+.field textarea {
   padding: 10px 12px;
   border-radius: 10px;
   border: 1px solid var(--border-color, #e7e9f5);
   background: #ffffff;
   font: inherit;
   color: inherit;
+}
+
+.field textarea {
+  resize: vertical;
+  min-height: 92px;
+}
+
+.field--full {
+  grid-column: 1 / -1;
+}
+
+.field--file input[type="file"] {
+  border-style: dashed;
+  cursor: pointer;
 }
 
 .filters-actions {
@@ -255,6 +321,10 @@ img {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+.btn--ghost {
+  background: transparent;
+}
+
 .btn:hover {
   transform: translateY(-1px);
   box-shadow: 0 10px 20px -15px rgba(17, 25, 40, 0.35);
@@ -264,6 +334,37 @@ img {
   background: var(--primary-color, #ff6f91);
   border-color: transparent;
   color: #ffffff;
+}
+
+.btn--small {
+  padding: 6px 12px;
+  border-radius: 10px;
+  font-size: 0.85rem;
+}
+
+.btn-action {
+  border: 1px solid var(--border-color, #e7e9f5);
+  background: var(--primary-surface, rgba(255, 111, 145, 0.12));
+  color: var(--primary-color, #ff6f91);
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.btn-action:hover {
+  background: var(--primary-surface-strong, rgba(255, 111, 145, 0.18));
+}
+
+.btn-action--danger {
+  color: var(--danger-color, #ff6b6b);
+  background: rgba(255, 107, 107, 0.12);
+  border-color: rgba(255, 107, 107, 0.32);
+}
+
+.btn-action--danger:hover {
+  background: rgba(255, 107, 107, 0.2);
 }
 
 .btn--ghost {
@@ -307,6 +408,72 @@ img {
   background: rgba(17, 25, 40, 0.05);
   color: var(--muted-color, #6b7280);
   display: none;
+}
+
+.program-status {
+  margin: 0;
+  color: var(--muted-color, #6b7280);
+  font-size: 0.9rem;
+}
+
+.insight-columns {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.upload-form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.document-meta {
+  display: flex;
+  flex-direction: column;
+}
+
+.document-meta span:first-child {
+  font-weight: 600;
+  color: var(--text-color, #1f2937);
+}
+
+.document-meta span:last-child {
+  font-size: 0.85rem;
+  color: var(--muted-color, #6b7280);
+}
+
+.document-tags {
+  display: inline-flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--primary-surface, rgba(255, 111, 145, 0.12));
+  color: var(--primary-color, #ff6f91);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.document-actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
 }
 
 .results-summary {
@@ -401,5 +568,9 @@ img {
   .btn {
     width: 100%;
     text-align: center;
+  }
+
+  .brand-options {
+    flex-direction: column;
   }
 }


### PR DESCRIPTION
## Summary
- implement the reports page with hero overview, filters, and trend visualizations matching the existing theme
- add controls to upload, catalogue, and download stored PDF reports with customizable branding options
- enable programmable report exports with predefined or custom intervals persisted locally

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e453036bb4832cae426702554c9000