### PR TITLE
Guardar exportaciones de reportes por 60 días

### DIFF
--- a/pages/reports/reportes.html
+++ b/pages/reports/reportes.html
@@ -241,7 +241,7 @@
         <section class="report-history" aria-labelledby="historialTitulo">
           <div class="panel-heading">
             <h2 id="historialTitulo">Historial de exportaciones</h2>
-            <p>Control de reportes generados y programados recientemente.</p>
+            <p>Control de reportes generados y programados recientemente. Los archivos se conservan 60 días para descarga.</p>
           </div>
           <div class="table-wrapper">
             <table class="data-table" id="tablaHistorial">
@@ -250,6 +250,7 @@
                   <th>Folio</th>
                   <th>Generado</th>
                   <th>Resumen</th>
+                  <th>Archivo</th>
                   <th></th>
                 </tr>
               </thead>


### PR DESCRIPTION
## Summary
- agrega almacenamiento local para los PDF y Excel generados desde la vista de reportes
- depura automáticamente los archivos y registros de historial que superen 60 días y muestra controles de descarga
- actualiza la tabla del historial con tipo de archivo, botones de descarga y aviso de conservación temporal

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e45e3c5a28832cae335267fde5182e