### PR TITLE
Unify PDF exports with shared theme palette

### DIFF
--- a/pages/admin_usuar/administracion_usuarios.html
+++ b/pages/admin_usuar/administracion_usuarios.html
@@ -255,6 +255,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js"></script>
   <script src="../../scripts/reports/report-history-client.js"></script>
+  <script src="../../scripts/utils/report_export.js"></script>
   <script src="../../scripts/Admin_usuar/administracion_usuarios.js"></script>
 </body>
 </html>

--- a/pages/control_log/log.html
+++ b/pages/control_log/log.html
@@ -199,6 +199,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="../../scripts/reports/report-history-client.js"></script>
+  <script src="../../scripts/utils/report_export.js"></script>
   <script src="../../scripts/control_log/log.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load the shared report exporter on the user administration and control log views
- refactor both PDF export flows to leverage the centralized ReportExporter so the generated documents share the app theme and metadata
- add contextual subtitles that include company information, record counts, and active filters in the control log PDF

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e55713fdd4832ca8c48964179b3d1f