### PR TITLE
Add automatic reports section to reports page

### DIFF
--- a/pages/reports/reportes.html
+++ b/pages/reports/reportes.html
@@ -99,6 +99,58 @@
         </div>
       </div>
 
+      <section class="automatic-card" aria-labelledby="automaticReportsTitle">
+        <div class="automatic-card__header">
+          <div>
+            <span class="automatic-card__eyebrow">Automatización</span>
+            <h3 class="automatic-card__title" id="automaticReportsTitle">Reportes automáticos</h3>
+            <p class="automatic-card__subtitle">
+              Consulta los reportes programados que OptiStock genera de forma recurrente y verifica su próxima ejecución.
+            </p>
+          </div>
+          <button class="automatic-card__action" type="button">Configurar automatizaciones</button>
+        </div>
+
+        <ul class="automatic-list" aria-label="Lista de reportes automáticos">
+          <li class="automatic-item">
+            <div class="automatic-item__main">
+              <span class="automatic-item__name">Resumen semanal de inventario</span>
+              <span class="automatic-item__module">Gestión de inventario</span>
+            </div>
+            <div class="automatic-item__meta">
+              <span class="automatic-item__badge">PDF</span>
+              <span class="automatic-item__frequency">Semanal · Cada lunes 08:00 a. m.</span>
+              <span class="automatic-item__next">Próxima ejecución: 14 oct 2025</span>
+            </div>
+            <button class="automatic-item__action" type="button">Ver historial</button>
+          </li>
+          <li class="automatic-item">
+            <div class="automatic-item__main">
+              <span class="automatic-item__name">Alertas de ruptura de stock</span>
+              <span class="automatic-item__module">Control de registros</span>
+            </div>
+            <div class="automatic-item__meta">
+              <span class="automatic-item__badge">PDF</span>
+              <span class="automatic-item__frequency">Diario · 07:30 a. m.</span>
+              <span class="automatic-item__next">Próxima ejecución: 8 oct 2025</span>
+            </div>
+            <button class="automatic-item__action" type="button">Ver historial</button>
+          </li>
+          <li class="automatic-item">
+            <div class="automatic-item__main">
+              <span class="automatic-item__name">Rotación mensual de productos</span>
+              <span class="automatic-item__module">Análisis de ventas</span>
+            </div>
+            <div class="automatic-item__meta">
+              <span class="automatic-item__badge">Excel</span>
+              <span class="automatic-item__frequency">Mensual · Día 1 a las 09:00 a. m.</span>
+              <span class="automatic-item__next">Próxima ejecución: 1 nov 2025</span>
+            </div>
+            <button class="automatic-item__action" type="button">Ver historial</button>
+          </li>
+        </ul>
+      </section>
+
     </section>
   </div>
 

--- a/styles/reports/reportes.css
+++ b/styles/reports/reportes.css
@@ -237,7 +237,8 @@ body {
 }
 
 .history-card,
-.upload-card {
+.upload-card,
+.automatic-card {
   background: var(--card-bg);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-color);
@@ -246,6 +247,152 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.automatic-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem 1.5rem;
+  align-items: flex-start;
+}
+
+.automatic-card__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: var(--radius-pill);
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.automatic-card__title {
+  margin: 0.35rem 0 0.25rem;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.automatic-card__subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted-color);
+  max-width: 520px;
+}
+
+.automatic-card__action {
+  align-self: center;
+  padding: 0.55rem 1.1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  background: rgba(59, 130, 246, 0.08);
+  color: #1d4ed8;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-speed), color var(--transition-speed), transform var(--transition-speed);
+}
+
+.automatic-card__action:hover,
+.automatic-card__action:focus {
+  background: #1d4ed8;
+  color: #fff;
+  transform: translateY(-1px);
+}
+
+.automatic-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.automatic-item {
+  background: #fff;
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  padding: 1rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.automatic-item__main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.automatic-item__name {
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--text-color);
+}
+
+.automatic-item__module {
+  font-size: 0.85rem;
+  color: var(--muted-color);
+}
+
+.automatic-item__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  font-size: 0.85rem;
+  color: var(--muted-color);
+}
+
+.automatic-item__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.75rem;
+  background: rgba(59, 130, 246, 0.14);
+  color: #1d4ed8;
+}
+
+.automatic-item__action {
+  align-self: flex-start;
+  padding: 0.45rem 0.95rem;
+  border-radius: 10px;
+  border: 1px solid rgba(23, 31, 52, 0.08);
+  background: rgba(23, 31, 52, 0.04);
+  color: var(--text-color);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-speed), color var(--transition-speed), transform var(--transition-speed);
+}
+
+.automatic-item__action:hover,
+.automatic-item__action:focus {
+  background: var(--primary-color);
+  color: #fff;
+  transform: translateY(-1px);
+}
+
+@media (min-width: 768px) {
+  .automatic-item {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .automatic-item__main {
+    max-width: 280px;
+  }
+
+  .automatic-item__action {
+    align-self: center;
+  }
 }
 
 .history-card__header {


### PR DESCRIPTION
## Summary
- add a dedicated "Reportes automáticos" card to highlight scheduled exports
- style the automatic reports list and actions to match the existing reports UI

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e565cb678c832c887aedc71e917d0d