### PR TITLE
Implement configurable automatic report scheduling

### DIFF
--- a/pages/reports/reportes.html
+++ b/pages/reports/reportes.html
@@ -99,7 +99,113 @@
         </div>
       </div>
 
+      <section class="automatic-card" aria-labelledby="automaticReportsTitle">
+        <div class="automatic-card__header">
+          <div>
+            <span class="automatic-card__eyebrow">Automatización</span>
+            <h3 class="automatic-card__title" id="automaticReportsTitle">Reportes automáticos</h3>
+            <p class="automatic-card__subtitle">
+              Configura reportes programados y OptiStock se encargará de generarlos automáticamente siguiendo la frecuencia que
+              definas.
+            </p>
+          </div>
+          <button id="automationConfigBtn" class="automatic-card__action" type="button">Configurar automatizaciones</button>
+        </div>
+
+        <div id="automaticEmpty" class="automatic-empty d-none">
+          <p class="automatic-empty__title">Aún no has programado automatizaciones.</p>
+          <p class="automatic-empty__subtitle">
+            Crea tu primer reporte automático para recibir exportaciones recurrentes sin intervención manual.
+          </p>
+        </div>
+
+        <ul id="automaticList" class="automatic-list" aria-label="Lista de reportes automáticos"></ul>
+      </section>
+
     </section>
+  </div>
+
+  <div class="modal fade" id="automationModal" tabindex="-1" aria-labelledby="automationModalTitle" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+      <div class="modal-content">
+        <form id="automationForm" novalidate>
+          <div class="modal-header">
+            <h5 class="modal-title" id="automationModalTitle">Nueva automatización</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+          </div>
+          <div class="modal-body">
+            <input id="automationId" type="hidden" />
+            <div class="row g-3">
+              <div class="col-md-6">
+                <label class="form-label" for="automationName">Nombre del reporte</label>
+                <input id="automationName" class="form-control" type="text" required maxlength="80"
+                  placeholder="Ej. Resumen semanal de inventario" />
+                <div class="invalid-feedback">Escribe un nombre para identificar el reporte.</div>
+              </div>
+              <div class="col-md-6">
+                <label class="form-label" for="automationModule">Módulo origen</label>
+                <input id="automationModule" class="form-control" type="text" maxlength="80"
+                  placeholder="Ej. Gestión de inventario" />
+              </div>
+              <div class="col-md-6">
+                <label class="form-label" for="automationFormat">Formato del archivo</label>
+                <select id="automationFormat" class="form-select" required>
+                  <option value="pdf">PDF</option>
+                  <option value="excel">Excel (CSV)</option>
+                </select>
+              </div>
+              <div class="col-md-6">
+                <label class="form-label" for="automationFrequency">Frecuencia</label>
+                <select id="automationFrequency" class="form-select" required>
+                  <option value="daily">Diario</option>
+                  <option value="weekly">Semanal</option>
+                  <option value="monthly">Mensual</option>
+                </select>
+              </div>
+              <div id="automationWeekdayWrapper" class="col-md-6 d-none">
+                <label class="form-label" for="automationWeekday">Día de la semana</label>
+                <select id="automationWeekday" class="form-select">
+                  <option value="1">Lunes</option>
+                  <option value="2">Martes</option>
+                  <option value="3">Miércoles</option>
+                  <option value="4">Jueves</option>
+                  <option value="5">Viernes</option>
+                  <option value="6">Sábado</option>
+                  <option value="0">Domingo</option>
+                </select>
+              </div>
+              <div id="automationMonthdayWrapper" class="col-md-6 d-none">
+                <label class="form-label" for="automationMonthday">Día del mes</label>
+                <input id="automationMonthday" class="form-control" type="number" min="1" max="31" value="1" />
+              </div>
+              <div class="col-md-6">
+                <label class="form-label" for="automationTime">Hora de ejecución</label>
+                <input id="automationTime" class="form-control" type="time" required value="08:00" />
+                <div class="form-text">La generación se ejecutará en hora local.</div>
+              </div>
+              <div class="col-12">
+                <label class="form-label" for="automationNotes">Notas internas</label>
+                <textarea id="automationNotes" class="form-control" rows="2" maxlength="160"
+                  placeholder="Describe qué información debe contener el reporte o filtros aplicados."></textarea>
+              </div>
+              <div class="col-12">
+                <div class="form-check form-switch">
+                  <input id="automationActive" class="form-check-input" type="checkbox" checked />
+                  <label class="form-check-label" for="automationActive">Activar generación automática al guardar</label>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="modal-footer justify-content-between">
+            <button id="automationDeleteBtn" type="button" class="btn btn-outline-danger d-none">Eliminar automatización</button>
+            <div class="d-flex gap-2">
+              <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+              <button id="automationSubmitBtn" type="submit" class="btn btn-primary">Guardar automatización</button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>

--- a/scripts/reports/reportes.js
+++ b/scripts/reports/reportes.js
@@ -27,15 +27,41 @@
     uploadSourceInput: document.getElementById('uploadSourceInput'),
     uploadNotesInput: document.getElementById('uploadNotesInput'),
     uploadSubmitBtn: document.getElementById('uploadSubmitBtn'),
-    uploadHint: document.getElementById('uploadHint')
+    uploadHint: document.getElementById('uploadHint'),
+    automationList: document.getElementById('automaticList'),
+    automationEmpty: document.getElementById('automaticEmpty'),
+    automationConfigBtn: document.getElementById('automationConfigBtn'),
+    automationModal: document.getElementById('automationModal'),
+    automationForm: document.getElementById('automationForm'),
+    automationIdInput: document.getElementById('automationId'),
+    automationNameInput: document.getElementById('automationName'),
+    automationModuleInput: document.getElementById('automationModule'),
+    automationFormatSelect: document.getElementById('automationFormat'),
+    automationFrequencySelect: document.getElementById('automationFrequency'),
+    automationWeekdayWrapper: document.getElementById('automationWeekdayWrapper'),
+    automationWeekdaySelect: document.getElementById('automationWeekday'),
+    automationMonthdayWrapper: document.getElementById('automationMonthdayWrapper'),
+    automationMonthdayInput: document.getElementById('automationMonthday'),
+    automationTimeInput: document.getElementById('automationTime'),
+    automationNotesInput: document.getElementById('automationNotes'),
+    automationActiveInput: document.getElementById('automationActive'),
+    automationModalTitle: document.getElementById('automationModalTitle'),
+    automationSubmitBtn: document.getElementById('automationSubmitBtn'),
+    automationDeleteBtn: document.getElementById('automationDeleteBtn')
   };
 
   const state = {
     reports: [],
+    serverReports: [],
+    localAutomationReports: [],
     filteredReports: [],
     retentionDays: RETENTION_DAYS_FALLBACK,
     loading: false,
-    alertTimerId: null
+    alertTimerId: null,
+    activeEmpresaId: null,
+    automations: [],
+    automationTimerId: null,
+    automationModalInstance: null
   };
 
   function setHistoryUnavailableState(message) {
@@ -64,6 +90,10 @@
   const BYTES_UNITS = ['B', 'KB', 'MB', 'GB'];
   const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
   const EXPIRING_THRESHOLD_MS = 10 * 24 * 60 * 60 * 1000;
+  const AUTOMATION_STORAGE_PREFIX = 'optistock:automations:';
+  const AUTOMATION_REPORTS_PREFIX = 'optistock:automationReports:';
+  const MAX_AUTOMATION_CATCHUP = 4;
+  const LOCAL_AUTOMATION_HISTORY_LIMIT = 30;
 
   function escapeHtml(text) {
     if (text === null || text === undefined) {
@@ -75,6 +105,56 @@
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&#39;');
+  }
+
+  function encodeBase64(uint8Array) {
+    if (!(uint8Array instanceof Uint8Array)) {
+      return '';
+    }
+
+    let binary = '';
+    const chunkSize = 0x8000;
+    for (let i = 0; i < uint8Array.length; i += chunkSize) {
+      const chunk = uint8Array.subarray(i, i + chunkSize);
+      binary += String.fromCharCode.apply(null, chunk);
+    }
+
+    try {
+      return window.btoa(binary);
+    } catch (error) {
+      console.warn('No se pudo convertir a base64:', error);
+      return '';
+    }
+  }
+
+  function decodeBase64(base64) {
+    if (!base64) {
+      return new Uint8Array();
+    }
+
+    try {
+      const binary = window.atob(base64);
+      const output = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i += 1) {
+        output[i] = binary.charCodeAt(i);
+      }
+      return output;
+    } catch (error) {
+      console.warn('No se pudo decodificar base64:', error);
+      return new Uint8Array();
+    }
+  }
+
+  function encodeText(text) {
+    if (typeof TextEncoder !== 'undefined') {
+      return new TextEncoder().encode(text);
+    }
+    const normalized = String(text);
+    const buffer = new Uint8Array(normalized.length);
+    for (let i = 0; i < normalized.length; i += 1) {
+      buffer[i] = normalized.charCodeAt(i) & 0xff;
+    }
+    return buffer;
   }
 
   function getActiveEmpresaId() {
@@ -171,8 +251,30 @@
     }
   }
 
-  function downloadReportFromServer(reportId) {
+  function downloadReport(reportId) {
     if (!reportId) {
+      return;
+    }
+
+    if (typeof reportId === 'string' && reportId.startsWith('local-auto:')) {
+      const report = state.localAutomationReports.find((item) => item.id === reportId);
+      if (!report) {
+        showAlert('No encontramos el archivo generado automáticamente.', 'warning');
+        return;
+      }
+
+      const bytes = decodeBase64(report.fileContent);
+      const blob = new Blob([bytes], { type: report.mimeType || 'application/octet-stream' });
+      const objectUrl = URL.createObjectURL(blob);
+
+      const link = document.createElement('a');
+      link.href = objectUrl;
+      link.download = report.originalName || 'reporte-automatico';
+      link.rel = 'noopener';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(objectUrl);
       return;
     }
 
@@ -292,6 +394,109 @@
       clearTimeout(state.alertTimerId);
       state.alertTimerId = null;
     }
+  }
+
+  function getAutomationStorageKey(empresaId) {
+    return `${AUTOMATION_STORAGE_PREFIX}${empresaId}`;
+  }
+
+  function getAutomationReportsKey(empresaId) {
+    return `${AUTOMATION_REPORTS_PREFIX}${empresaId}`;
+  }
+
+  function loadAutomationsFromStorage() {
+    const empresaId = state.activeEmpresaId;
+    if (!empresaId || !window.localStorage) {
+      return [];
+    }
+    try {
+      const raw = window.localStorage.getItem(getAutomationStorageKey(empresaId));
+      if (!raw) {
+        return [];
+      }
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (error) {
+      console.warn('No se pudieron leer las automatizaciones almacenadas:', error);
+      return [];
+    }
+  }
+
+  function saveAutomationsToStorage() {
+    const empresaId = state.activeEmpresaId;
+    if (!empresaId || !window.localStorage) {
+      return;
+    }
+    try {
+      const payload = JSON.stringify(state.automations);
+      window.localStorage.setItem(getAutomationStorageKey(empresaId), payload);
+    } catch (error) {
+      console.warn('No se pudieron guardar las automatizaciones:', error);
+    }
+  }
+
+  function loadLocalAutomationReports() {
+    const empresaId = state.activeEmpresaId;
+    if (!empresaId || !window.localStorage) {
+      state.localAutomationReports = [];
+      return;
+    }
+    try {
+      const raw = window.localStorage.getItem(getAutomationReportsKey(empresaId));
+      if (!raw) {
+        state.localAutomationReports = [];
+        return;
+      }
+      const parsed = JSON.parse(raw);
+      state.localAutomationReports = Array.isArray(parsed)
+        ? parsed
+            .map((item) => ({
+              id: item.id,
+              automationId: item.automationId,
+              originalName: item.originalName,
+              mimeType: item.mimeType,
+              source: item.source,
+              notes: item.notes,
+              createdAt: item.createdAt,
+              expiresAt: item.expiresAt || null,
+              size: item.size || 0,
+              fileContent: item.fileContent,
+              fileExtension: item.fileExtension || ''
+            }))
+            .filter((item) => item.id && item.fileContent)
+        : [];
+      if (state.localAutomationReports.length > LOCAL_AUTOMATION_HISTORY_LIMIT) {
+        state.localAutomationReports = state.localAutomationReports.slice(-LOCAL_AUTOMATION_HISTORY_LIMIT);
+      }
+    } catch (error) {
+      console.warn('No se pudieron leer los reportes automáticos locales:', error);
+      state.localAutomationReports = [];
+    }
+  }
+
+  function saveLocalAutomationReports() {
+    const empresaId = state.activeEmpresaId;
+    if (!empresaId || !window.localStorage) {
+      return;
+    }
+    try {
+      const payload = JSON.stringify(state.localAutomationReports);
+      window.localStorage.setItem(getAutomationReportsKey(empresaId), payload);
+    } catch (error) {
+      console.warn('No se pudieron guardar los reportes automáticos locales:', error);
+    }
+  }
+
+  function rebuildReportCollection() {
+    const combined = [...state.serverReports, ...state.localAutomationReports];
+    combined.sort((a, b) => {
+      const aTime = new Date(a.createdAt || 0).getTime();
+      const bTime = new Date(b.createdAt || 0).getTime();
+      return bTime - aTime;
+    });
+    state.reports = combined;
+    updateSummary();
+    applyFilters();
   }
 
   function setLoading(isLoading) {
@@ -472,15 +677,16 @@
 
     try {
       const response = await fetchHistoryFromServer();
-      state.reports = Array.isArray(response.reports) ? response.reports : [];
+      state.serverReports = Array.isArray(response.reports) ? response.reports : [];
       state.retentionDays = typeof response.retentionDays === 'number' ? response.retentionDays : state.retentionDays;
-      updateSummary();
-      applyFilters();
+      loadLocalAutomationReports();
+      rebuildReportCollection();
     } catch (error) {
       console.error('No se pudo cargar el historial de reportes:', error);
       showAlert(error.message || 'No se pudo cargar el historial de reportes.', 'danger', true);
-      state.reports = [];
-      applyFilters();
+      state.serverReports = [];
+      loadLocalAutomationReports();
+      rebuildReportCollection();
     } finally {
       if (showSpinner) {
         setLoading(false);
@@ -531,7 +737,7 @@
     const dl = target.closest('[data-download-id]');
     if (dl) {
       const reportId = dl.getAttribute('data-download-id');
-      downloadReportFromServer(reportId);
+      downloadReport(reportId);
       return;
     }
 
@@ -546,6 +752,14 @@
     if (!ok1) return;
     const ok2 = window.confirm('Por favor confirma de nuevo. Esta eliminación es permanente. ¿Deseas continuar?');
     if (!ok2) return;
+
+    if (reportId && reportId.startsWith('local-auto:')) {
+      state.localAutomationReports = state.localAutomationReports.filter((item) => item.id !== reportId);
+      saveLocalAutomationReports();
+      rebuildReportCollection();
+      showAlert('Reporte automático eliminado correctamente.', 'success');
+      return;
+    }
 
     const empresaId = getActiveEmpresaId();
     if (!empresaId) {
@@ -577,12 +791,657 @@
     }
   }
 
-  function bootstrap() {
-    const empresaId = getActiveEmpresaId();
-    if (!empresaId) {
-      setHistoryUnavailableState('Inicia sesión o selecciona una empresa para ver el historial.');
+  function getTimeParts(value) {
+    if (typeof value !== 'string') {
+      return { hours: 8, minutes: 0 };
+    }
+    const [rawHours, rawMinutes] = value.split(':');
+    const hours = Number.isFinite(Number(rawHours)) ? Math.min(Math.max(parseInt(rawHours, 10), 0), 23) : 8;
+    const minutes = Number.isFinite(Number(rawMinutes)) ? Math.min(Math.max(parseInt(rawMinutes, 10), 0), 59) : 0;
+    return { hours, minutes };
+  }
+
+  function getWeekdayName(index) {
+    const names = ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'];
+    return names[index] || 'Día';
+  }
+
+  function formatTimeLabel(timeValue) {
+    const { hours, minutes } = getTimeParts(timeValue);
+    const reference = new Date();
+    reference.setHours(hours, minutes, 0, 0);
+    try {
+      return new Intl.DateTimeFormat('es-MX', { hour: 'numeric', minute: '2-digit' }).format(reference);
+    } catch (error) {
+      return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+    }
+  }
+
+  function computeMonthDate(year, month, day, hours, minutes) {
+    const lastDay = new Date(year, month + 1, 0).getDate();
+    const safeDay = Math.min(Math.max(day, 1), lastDay);
+    return new Date(year, month, safeDay, hours, minutes, 0, 0);
+  }
+
+  function computeNextRunAt(automation, reference = new Date()) {
+    const { hours, minutes } = getTimeParts(automation.time || '08:00');
+    const now = new Date(reference.getTime());
+    now.setSeconds(0, 0);
+
+    if (automation.frequency === 'weekly') {
+      const desiredDay = Number.isFinite(Number(automation.weekday)) ? parseInt(automation.weekday, 10) : 1;
+      const base = new Date(now.getTime());
+      base.setHours(hours, minutes, 0, 0);
+      const currentDay = base.getDay();
+      let diff = desiredDay - currentDay;
+      if (diff < 0 || (diff === 0 && base <= now)) {
+        diff += 7;
+      }
+      base.setDate(base.getDate() + diff);
+      return base.toISOString();
+    }
+
+    if (automation.frequency === 'monthly') {
+      const desiredDay = Number.isFinite(Number(automation.monthday)) ? parseInt(automation.monthday, 10) : 1;
+      const base = computeMonthDate(now.getFullYear(), now.getMonth(), desiredDay, hours, minutes);
+      if (base <= now) {
+        const next = computeMonthDate(now.getFullYear(), now.getMonth() + 1, desiredDay, hours, minutes);
+        return next.toISOString();
+      }
+      return base.toISOString();
+    }
+
+    const base = new Date(now.getTime());
+    base.setHours(hours, minutes, 0, 0);
+    if (base <= now) {
+      base.setDate(base.getDate() + 1);
+    }
+    return base.toISOString();
+  }
+
+  function formatAutomationFrequency(automation) {
+    const timeLabel = formatTimeLabel(automation.time || '08:00');
+    if (automation.frequency === 'weekly') {
+      const dayName = getWeekdayName(Number.isFinite(Number(automation.weekday)) ? parseInt(automation.weekday, 10) : 1);
+      return `Semanal · ${dayName} · ${timeLabel}`;
+    }
+    if (automation.frequency === 'monthly') {
+      const day = Number.isFinite(Number(automation.monthday)) ? parseInt(automation.monthday, 10) : 1;
+      return `Mensual · Día ${day} · ${timeLabel}`;
+    }
+    return `Diario · ${timeLabel}`;
+  }
+
+  function formatAutomationNextRun(automation) {
+    if (!automation.active) {
+      return 'Automatización en pausa';
+    }
+    if (!automation.nextRunAt) {
+      return 'Calculando siguiente ejecución…';
+    }
+    const date = new Date(automation.nextRunAt);
+    if (!Number.isFinite(date.getTime())) {
+      return 'Próxima ejecución pendiente de programar';
+    }
+    try {
+      const formatted = new Intl.DateTimeFormat('es-MX', {
+        dateStyle: 'medium',
+        timeStyle: 'short'
+      }).format(date);
+      return `Próxima ejecución: ${formatted}`;
+    } catch (error) {
+      return `Próxima ejecución: ${date.toLocaleString()}`;
+    }
+  }
+
+  function formatAutomationLastRun(automation) {
+    if (!automation.lastRunAt) {
+      return 'Aún no se ha ejecutado';
+    }
+    try {
+      const formatted = new Intl.DateTimeFormat('es-MX', {
+        dateStyle: 'medium',
+        timeStyle: 'short'
+      }).format(new Date(automation.lastRunAt));
+      return `Última ejecución: ${formatted}`;
+    } catch (error) {
+      return `Última ejecución: ${new Date(automation.lastRunAt).toLocaleString()}`;
+    }
+  }
+
+  function renderAutomations() {
+    if (!elements.automationList || !elements.automationEmpty) {
       return;
     }
+
+    if (!state.automations.length) {
+      elements.automationList.innerHTML = '';
+      elements.automationEmpty.classList.remove('d-none');
+      return;
+    }
+
+    elements.automationEmpty.classList.add('d-none');
+
+    const itemsHtml = state.automations
+      .sort((a, b) => {
+        const aNext = a.active ? new Date(a.nextRunAt || 0).getTime() : Infinity;
+        const bNext = b.active ? new Date(b.nextRunAt || 0).getTime() : Infinity;
+        return aNext - bNext;
+      })
+      .map((automation) => {
+        const formatLabel = automation.format === 'excel' ? 'Excel' : 'PDF';
+        const moduleText = automation.module
+          ? `<span class="automatic-item__module">${escapeHtml(automation.module)}</span>`
+          : '<span class="automatic-item__module text-muted">Sin módulo asignado</span>';
+        const lastRun = formatAutomationLastRun(automation);
+        return `
+          <li class="automatic-item" data-automation-id="${escapeHtml(automation.id)}">
+            <div class="automatic-item__main">
+              <span class="automatic-item__name">${escapeHtml(automation.name)}</span>
+              ${moduleText}
+            </div>
+            <div class="automatic-item__meta">
+              <span class="automatic-item__badge">${formatLabel}</span>
+              <span class="automatic-item__frequency">${escapeHtml(formatAutomationFrequency(automation))}</span>
+              <span class="automatic-item__next">${escapeHtml(formatAutomationNextRun(automation))}</span>
+            </div>
+            <div class="automatic-item__footer">
+              <div class="automatic-item__controls">
+                <label class="automatic-toggle">
+                  <input type="checkbox" ${automation.active ? 'checked' : ''} data-automation-toggle="${escapeHtml(
+          automation.id
+        )}" />
+                  <span>${automation.active ? 'Activa' : 'Pausada'}</span>
+                </label>
+                <span class="automatic-item__status">${escapeHtml(lastRun)}</span>
+              </div>
+              <div class="automatic-item__actions">
+                <button class="automatic-item__action" type="button" data-automation-run="${escapeHtml(
+          automation.id
+        )}">Generar ahora</button>
+                <button class="automatic-item__ghost" type="button" data-automation-edit="${escapeHtml(
+          automation.id
+        )}">Editar</button>
+              </div>
+            </div>
+          </li>
+        `;
+      })
+      .join('');
+
+    elements.automationList.innerHTML = itemsHtml;
+  }
+
+  function resetAutomationForm() {
+    if (!elements.automationForm) {
+      return;
+    }
+    elements.automationForm.reset();
+    if (elements.automationIdInput) {
+      elements.automationIdInput.value = '';
+    }
+    if (elements.automationFrequencySelect) {
+      elements.automationFrequencySelect.value = 'daily';
+    }
+    if (elements.automationTimeInput) {
+      elements.automationTimeInput.value = '08:00';
+    }
+    if (elements.automationActiveInput) {
+      elements.automationActiveInput.checked = true;
+    }
+    if (elements.automationNotesInput) {
+      elements.automationNotesInput.value = '';
+    }
+    updateFrequencyFields();
+    elements.automationForm.classList.remove('was-validated');
+  }
+
+  function updateFrequencyFields() {
+    if (!elements.automationFrequencySelect) {
+      return;
+    }
+    const value = elements.automationFrequencySelect.value;
+    if (elements.automationWeekdayWrapper) {
+      elements.automationWeekdayWrapper.classList.toggle('d-none', value !== 'weekly');
+    }
+    if (elements.automationMonthdayWrapper) {
+      elements.automationMonthdayWrapper.classList.toggle('d-none', value !== 'monthly');
+    }
+  }
+
+  function openAutomationModal(automation = null) {
+    if (!elements.automationModal) {
+      return;
+    }
+
+    if (!state.automationModalInstance) {
+      state.automationModalInstance = window.bootstrap
+        ? window.bootstrap.Modal.getOrCreateInstance(elements.automationModal)
+        : null;
+    }
+
+    if (!state.automationModalInstance) {
+      return;
+    }
+
+    resetAutomationForm();
+
+    if (elements.automationModalTitle) {
+      elements.automationModalTitle.textContent = automation ? 'Editar automatización' : 'Nueva automatización';
+    }
+    if (elements.automationDeleteBtn) {
+      elements.automationDeleteBtn.classList.toggle('d-none', !automation);
+    }
+
+    if (automation) {
+      if (elements.automationIdInput) {
+        elements.automationIdInput.value = automation.id;
+      }
+      if (elements.automationNameInput) {
+        elements.automationNameInput.value = automation.name || '';
+      }
+      if (elements.automationModuleInput) {
+        elements.automationModuleInput.value = automation.module || '';
+      }
+      if (elements.automationFormatSelect) {
+        elements.automationFormatSelect.value = automation.format || 'pdf';
+      }
+      if (elements.automationFrequencySelect) {
+        elements.automationFrequencySelect.value = automation.frequency || 'daily';
+      }
+      updateFrequencyFields();
+      if (elements.automationWeekdaySelect && typeof automation.weekday !== 'undefined') {
+        elements.automationWeekdaySelect.value = String(automation.weekday);
+      }
+      if (elements.automationMonthdayInput && typeof automation.monthday !== 'undefined') {
+        elements.automationMonthdayInput.value = String(automation.monthday);
+      }
+      if (elements.automationTimeInput) {
+        elements.automationTimeInput.value = automation.time || '08:00';
+      }
+      if (elements.automationNotesInput) {
+        elements.automationNotesInput.value = automation.notes || '';
+      }
+      if (elements.automationActiveInput) {
+        elements.automationActiveInput.checked = Boolean(automation.active);
+      }
+    } else {
+      updateFrequencyFields();
+    }
+
+    state.automationModalInstance.show();
+  }
+
+  function upsertAutomation(automationData) {
+    const existingIndex = state.automations.findIndex((item) => item.id === automationData.id);
+    if (existingIndex >= 0) {
+      state.automations[existingIndex] = { ...state.automations[existingIndex], ...automationData, updatedAt: new Date().toISOString() };
+    } else {
+      state.automations.push({ ...automationData, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() });
+    }
+    saveAutomationsToStorage();
+    renderAutomations();
+  }
+
+  function handleAutomationFormSubmit(event) {
+    event.preventDefault();
+    if (!elements.automationForm) {
+      return;
+    }
+
+    elements.automationForm.classList.add('was-validated');
+
+    if (!elements.automationForm.checkValidity()) {
+      return;
+    }
+
+    const id = elements.automationIdInput && elements.automationIdInput.value ? elements.automationIdInput.value : `auto-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const name = elements.automationNameInput ? elements.automationNameInput.value.trim() : '';
+    const module = elements.automationModuleInput ? elements.automationModuleInput.value.trim() : '';
+    const format = elements.automationFormatSelect ? elements.automationFormatSelect.value : 'pdf';
+    const frequency = elements.automationFrequencySelect ? elements.automationFrequencySelect.value : 'daily';
+    const time = elements.automationTimeInput ? elements.automationTimeInput.value : '08:00';
+    const rawWeekday = elements.automationWeekdaySelect ? parseInt(elements.automationWeekdaySelect.value, 10) : 1;
+    const weekday = Number.isFinite(rawWeekday) ? Math.min(Math.max(rawWeekday, 0), 6) : 1;
+    const rawMonthday = elements.automationMonthdayInput ? parseInt(elements.automationMonthdayInput.value, 10) : 1;
+    const monthday = Number.isFinite(rawMonthday) ? Math.min(Math.max(rawMonthday, 1), 31) : 1;
+    const notes = elements.automationNotesInput ? elements.automationNotesInput.value.trim() : '';
+    const active = elements.automationActiveInput ? elements.automationActiveInput.checked : true;
+
+    if (!name) {
+      elements.automationNameInput.focus();
+      return;
+    }
+
+    const target = state.automations.find((item) => item.id === id);
+    const nextRunAt = computeNextRunAt({ frequency, time, weekday, monthday }, new Date());
+
+    const automationPayload = {
+      id,
+      name,
+      module,
+      format,
+      frequency,
+      time,
+      weekday,
+      monthday,
+      notes,
+      active,
+      nextRunAt,
+      lastRunAt: target ? target.lastRunAt : null
+    };
+
+    upsertAutomation(automationPayload);
+
+    if (state.automationModalInstance) {
+      state.automationModalInstance.hide();
+    }
+
+    showAlert(`Automatización "${name}" guardada correctamente.`, 'success');
+
+    if (active) {
+      runPendingAutomations({ catchUp: true });
+    } else {
+      renderAutomations();
+    }
+  }
+
+  function deleteAutomation(automationId) {
+    const index = state.automations.findIndex((item) => item.id === automationId);
+    if (index < 0) {
+      return;
+    }
+    state.automations.splice(index, 1);
+    saveAutomationsToStorage();
+    renderAutomations();
+    showAlert('Automatización eliminada correctamente.', 'success');
+  }
+
+  function generateAutomationCsv(automation, executedAt) {
+    const executedDate = new Date(executedAt);
+    let generatedAt;
+    try {
+      generatedAt = new Intl.DateTimeFormat('es-MX', { dateStyle: 'full', timeStyle: 'short' }).format(executedDate);
+    } catch (error) {
+      generatedAt = executedDate.toLocaleString();
+    }
+    const rows = [
+      ['Nombre del reporte', automation.name],
+      ['Módulo', automation.module || 'No especificado'],
+      ['Generado automáticamente', generatedAt],
+      ['Frecuencia', formatAutomationFrequency(automation)],
+      ['Notas', automation.notes || '']
+    ];
+    const csv = rows
+      .map((row) => row.map((cell) => `"${String(cell || '').replace(/"/g, '""')}"`).join(','))
+      .join('\r\n');
+    const bytes = encodeText(csv);
+    return { bytes, mimeType: 'text/csv', extension: 'csv' };
+  }
+
+  function generateAutomationPdf(automation, executedAt) {
+    const executedDate = new Date(executedAt);
+    let generatedAt;
+    try {
+      generatedAt = new Intl.DateTimeFormat('es-MX', { dateStyle: 'full', timeStyle: 'short' }).format(executedDate);
+    } catch (error) {
+      generatedAt = executedDate.toLocaleString();
+    }
+    const lines = [
+      automation.name,
+      '',
+      `Generado automáticamente el ${generatedAt}`,
+      automation.module ? `Módulo origen: ${automation.module}` : null,
+      `Frecuencia: ${formatAutomationFrequency(automation)}`,
+      automation.notes ? `Notas: ${automation.notes}` : null
+    ].filter(Boolean);
+
+    const sanitizedLines = lines.map((line) =>
+      String(line)
+        .replace(/\\/g, '\\\\')
+        .replace(/\(/g, '\\(')
+        .replace(/\)/g, '\\)')
+    );
+    let stream = 'BT /F1 16 Tf 72 760 Td ';
+    sanitizedLines.forEach((line, index) => {
+      if (index === 0) {
+        stream += `(${line}) Tj`;
+      } else {
+        stream += ` T* (${line}) Tj`;
+      }
+    });
+    stream += ' ET';
+
+    const offsets = [];
+    let pdf = '%PDF-1.4\n';
+
+    function addObject(content) {
+      offsets.push(pdf.length);
+      pdf += content;
+    }
+
+    addObject('1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n');
+    addObject('2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n');
+    addObject('3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>\nendobj\n');
+    addObject(`4 0 obj\n<< /Length ${stream.length} >>\nstream\n${stream}\nendstream\nendobj\n`);
+    addObject('5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n');
+
+    const xrefOffset = pdf.length;
+    pdf += 'xref\n0 6\n0000000000 65535 f \n';
+    offsets.forEach((offset) => {
+      pdf += `${String(offset).padStart(10, '0')} 00000 n \n`;
+    });
+    pdf += 'trailer\n<< /Root 1 0 R /Size 6 >>\nstartxref\n';
+    pdf += `${xrefOffset}\n%%EOF`;
+
+    const bytes = encodeText(pdf);
+    return { bytes, mimeType: 'application/pdf', extension: 'pdf' };
+  }
+
+  function createAutomationFile(automation, executedAt) {
+    if (automation.format === 'excel') {
+      return generateAutomationCsv(automation, executedAt);
+    }
+    return generateAutomationPdf(automation, executedAt);
+  }
+
+  function registerAutomationReport(automation, executedAt) {
+    const file = createAutomationFile(automation, executedAt);
+    const fileNameDate = new Date(executedAt);
+    const safeDate = Number.isFinite(fileNameDate.getTime()) ? fileNameDate : new Date();
+    const iso = safeDate.toISOString();
+    const formattedDate = `${safeDate.getFullYear()}-${String(safeDate.getMonth() + 1).padStart(2, '0')}-${String(
+      safeDate.getDate()
+    ).padStart(2, '0')} ${String(safeDate.getHours()).padStart(2, '0')}-${String(safeDate.getMinutes()).padStart(2, '0')}`;
+    const extension = file.extension || (automation.format === 'excel' ? 'csv' : 'pdf');
+    const originalName = `${automation.name} - ${formattedDate}.${extension}`;
+    const base64Content = encodeBase64(file.bytes);
+
+    const reportRecord = {
+      id: `local-auto:${automation.id}:${safeDate.getTime()}`,
+      automationId: automation.id,
+      originalName,
+      mimeType: file.mimeType,
+      source: automation.module ? `Automatización · ${automation.module}` : 'Automatización',
+      notes: automation.notes ? `Notas: ${automation.notes}` : 'Generado automáticamente',
+      createdAt: iso,
+      expiresAt: null,
+      size: file.bytes.length,
+      fileContent: base64Content,
+      fileExtension: extension
+    };
+
+    state.localAutomationReports.push(reportRecord);
+    if (state.localAutomationReports.length > LOCAL_AUTOMATION_HISTORY_LIMIT) {
+      state.localAutomationReports.splice(0, state.localAutomationReports.length - LOCAL_AUTOMATION_HISTORY_LIMIT);
+    }
+    saveLocalAutomationReports();
+    rebuildReportCollection();
+  }
+
+  function runPendingAutomations({ catchUp = false } = {}) {
+    if (!state.automations.length) {
+      return;
+    }
+
+    const now = new Date();
+    let changed = false;
+
+    state.automations.forEach((automation) => {
+      if (!automation.nextRunAt) {
+        automation.nextRunAt = computeNextRunAt(automation, now);
+        changed = true;
+      }
+
+      if (!automation.active) {
+        return;
+      }
+
+      let iterations = 0;
+      while (automation.nextRunAt) {
+        const nextRun = new Date(automation.nextRunAt);
+        if (!Number.isFinite(nextRun.getTime())) {
+          automation.nextRunAt = computeNextRunAt(automation, now);
+          changed = true;
+          break;
+        }
+
+        if (nextRun > now && !catchUp) {
+          break;
+        }
+
+        registerAutomationReport(automation, nextRun);
+        if (!catchUp) {
+          showAlert(`Se generó el reporte automático "${automation.name}".`, 'success');
+        }
+        automation.lastRunAt = nextRun.toISOString();
+        automation.nextRunAt = computeNextRunAt(automation, new Date(nextRun.getTime() + 60 * 1000));
+        changed = true;
+        iterations += 1;
+        if (!catchUp || iterations >= MAX_AUTOMATION_CATCHUP) {
+          break;
+        }
+      }
+    });
+
+    if (changed) {
+      saveAutomationsToStorage();
+      renderAutomations();
+    }
+  }
+
+  function handleAutomationListClick(event) {
+    const target = event.target instanceof HTMLElement ? event.target : null;
+    if (!target) {
+      return;
+    }
+
+    const runBtn = target.closest('[data-automation-run]');
+    if (runBtn) {
+      const automationId = runBtn.getAttribute('data-automation-run');
+      const automation = state.automations.find((item) => item.id === automationId);
+      if (!automation) {
+        return;
+      }
+      const executedAt = new Date();
+      registerAutomationReport(automation, executedAt);
+      automation.lastRunAt = executedAt.toISOString();
+      automation.nextRunAt = computeNextRunAt(automation, new Date(executedAt.getTime() + 60 * 1000));
+      saveAutomationsToStorage();
+      renderAutomations();
+      showAlert(`Se generó el reporte automático "${automation.name}".`, 'success');
+      return;
+    }
+
+    const editBtn = target.closest('[data-automation-edit]');
+    if (editBtn) {
+      const automationId = editBtn.getAttribute('data-automation-edit');
+      const automation = state.automations.find((item) => item.id === automationId);
+      if (automation) {
+        openAutomationModal(automation);
+      }
+      return;
+    }
+
+  }
+
+  function startAutomationScheduler() {
+    if (state.automationTimerId) {
+      window.clearInterval(state.automationTimerId);
+    }
+    runPendingAutomations({ catchUp: true });
+    state.automationTimerId = window.setInterval(() => {
+      runPendingAutomations();
+    }, 60 * 1000);
+  }
+
+  function handleAutomationToggleChange(event) {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement) || !target.matches('[data-automation-toggle]')) {
+      return;
+    }
+
+    const automationId = target.getAttribute('data-automation-toggle');
+    const automation = state.automations.find((item) => item.id === automationId);
+    if (!automation) {
+      return;
+    }
+
+    automation.active = target.checked;
+    if (automation.active && !automation.nextRunAt) {
+      automation.nextRunAt = computeNextRunAt(automation, new Date());
+    }
+    saveAutomationsToStorage();
+    renderAutomations();
+    if (automation.active) {
+      runPendingAutomations({ catchUp: true });
+    }
+  }
+
+  function initializeAutomations() {
+    state.automations = loadAutomationsFromStorage().map((item) => {
+      const storedWeekday = Number.isFinite(Number(item.weekday)) ? parseInt(item.weekday, 10) : 1;
+      const storedMonthday = Number.isFinite(Number(item.monthday)) ? parseInt(item.monthday, 10) : 1;
+      return {
+        id: item.id,
+        name: item.name || 'Reporte automatizado',
+        module: item.module || '',
+        format: item.format === 'excel' ? 'excel' : 'pdf',
+        frequency: item.frequency === 'weekly' || item.frequency === 'monthly' ? item.frequency : 'daily',
+        time: item.time || '08:00',
+        weekday: Math.min(Math.max(storedWeekday, 0), 6),
+        monthday: Math.min(Math.max(storedMonthday, 1), 31),
+        notes: item.notes || '',
+        active: !(item.active === false || item.active === 'false'),
+        nextRunAt: item.nextRunAt || null,
+        lastRunAt: item.lastRunAt || null,
+        createdAt: item.createdAt || new Date().toISOString(),
+        updatedAt: item.updatedAt || new Date().toISOString()
+      };
+    });
+
+    const now = new Date();
+    let needsSave = false;
+    state.automations.forEach((automation) => {
+      if (!automation.nextRunAt) {
+        automation.nextRunAt = computeNextRunAt(automation, now);
+        needsSave = true;
+      }
+    });
+
+    if (needsSave) {
+      saveAutomationsToStorage();
+    }
+
+    renderAutomations();
+    loadLocalAutomationReports();
+    rebuildReportCollection();
+    startAutomationScheduler();
+  }
+
+  function bootstrap() {
+    const empresaId = getActiveEmpresaId();
+    state.activeEmpresaId = empresaId || 'local';
 
     if (elements.searchInput) {
       elements.searchInput.addEventListener('input', () => applyFilters());
@@ -599,8 +1458,53 @@
     if (elements.historyTableBody) {
       elements.historyTableBody.addEventListener('click', handleTableActionClick);
     }
+    if (elements.automationConfigBtn) {
+      elements.automationConfigBtn.addEventListener('click', () => openAutomationModal());
+    }
+    if (elements.automationFrequencySelect) {
+      elements.automationFrequencySelect.addEventListener('change', updateFrequencyFields);
+    }
+    if (elements.automationForm) {
+      elements.automationForm.addEventListener('submit', handleAutomationFormSubmit);
+    }
+    if (elements.automationDeleteBtn) {
+      elements.automationDeleteBtn.addEventListener('click', () => {
+        const automationId = elements.automationIdInput ? elements.automationIdInput.value : '';
+        if (!automationId) {
+          return;
+        }
+        const automation = state.automations.find((item) => item.id === automationId);
+        const confirmation = automation
+          ? window.confirm(`¿Eliminar la automatización "${automation.name}"? Esta acción no se puede deshacer.`)
+          : false;
+        if (!confirmation) {
+          return;
+        }
+        deleteAutomation(automationId);
+        if (state.automationModalInstance) {
+          state.automationModalInstance.hide();
+        }
+      });
+    }
+    if (elements.automationModal) {
+      elements.automationModal.addEventListener('hidden.bs.modal', () => {
+        resetAutomationForm();
+      });
+    }
+    if (elements.automationList) {
+      elements.automationList.addEventListener('click', handleAutomationListClick);
+      elements.automationList.addEventListener('change', handleAutomationToggleChange);
+    }
 
-    loadHistory();
+    updateFrequencyFields();
+    initializeAutomations();
+
+    if (empresaId) {
+      loadHistory();
+    } else {
+      setLoading(false);
+      showAlert('Los reportes automáticos se guardan en este navegador hasta que vincules una empresa.', 'info', true);
+    }
   }
 
   if (document.readyState === 'loading') {

--- a/styles/reports/reportes.css
+++ b/styles/reports/reportes.css
@@ -237,7 +237,8 @@ body {
 }
 
 .history-card,
-.upload-card {
+.upload-card,
+.automatic-card {
   background: var(--card-bg);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-color);
@@ -246,6 +247,235 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.automatic-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem 1.5rem;
+  align-items: flex-start;
+}
+
+.automatic-card__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: var(--radius-pill);
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.automatic-card__title {
+  margin: 0.35rem 0 0.25rem;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.automatic-card__subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted-color);
+  max-width: 520px;
+}
+
+.automatic-card__action {
+  align-self: center;
+  padding: 0.55rem 1.1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  background: rgba(59, 130, 246, 0.08);
+  color: #1d4ed8;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-speed), color var(--transition-speed), transform var(--transition-speed);
+}
+
+.automatic-card__action:hover,
+.automatic-card__action:focus {
+  background: #1d4ed8;
+  color: #fff;
+  transform: translateY(-1px);
+}
+
+.automatic-empty {
+  border: 1px dashed rgba(59, 130, 246, 0.35);
+  border-radius: 16px;
+  padding: 1.25rem 1.35rem;
+  background: rgba(59, 130, 246, 0.05);
+  color: var(--muted-color);
+}
+
+.automatic-empty__title {
+  margin: 0 0 0.35rem;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.automatic-empty__subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.automatic-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.automatic-item {
+  background: #fff;
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  padding: 1rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.automatic-item__main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.automatic-item__name {
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--text-color);
+}
+
+.automatic-item__module {
+  font-size: 0.85rem;
+  color: var(--muted-color);
+}
+
+.automatic-item__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  font-size: 0.85rem;
+  color: var(--muted-color);
+}
+
+.automatic-item__status {
+  font-size: 0.8rem;
+  color: var(--muted-color);
+}
+
+.automatic-item__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.75rem;
+  background: rgba(59, 130, 246, 0.14);
+  color: #1d4ed8;
+}
+
+.automatic-item__action {
+  align-self: flex-start;
+  padding: 0.45rem 0.95rem;
+  border-radius: 10px;
+  border: 1px solid rgba(23, 31, 52, 0.08);
+  background: rgba(23, 31, 52, 0.04);
+  color: var(--text-color);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-speed), color var(--transition-speed), transform var(--transition-speed);
+}
+
+.automatic-item__action:hover,
+.automatic-item__action:focus {
+  background: var(--primary-color);
+  color: #fff;
+  transform: translateY(-1px);
+}
+
+.automatic-item__ghost {
+  padding: 0.45rem 0.95rem;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--muted-color);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color var(--transition-speed), background var(--transition-speed), border-color var(--transition-speed);
+}
+
+.automatic-item__ghost:hover,
+.automatic-item__ghost:focus {
+  color: var(--primary-color);
+  border-color: rgba(59, 130, 246, 0.25);
+  background: rgba(59, 130, 246, 0.08);
+}
+
+.automatic-item__footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem 1rem;
+  justify-content: space-between;
+}
+
+.automatic-item__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.automatic-item__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.automatic-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--muted-color);
+  cursor: pointer;
+}
+
+.automatic-toggle input[type='checkbox'] {
+  width: 2.25rem;
+  height: 1.15rem;
+  cursor: pointer;
+}
+
+@media (min-width: 768px) {
+  .automatic-item {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .automatic-item__main {
+    max-width: 280px;
+  }
+
+  .automatic-item__action {
+    align-self: center;
+  }
+
+  .automatic-item__footer {
+    width: 100%;
+    justify-content: space-between;
+  }
 }
 
 .history-card__header {


### PR DESCRIPTION
## Summary
- replace the static "Reportes automáticos" list with a dynamic scheduler backed by local storage
- add a configuration modal to create, edit, pause, or trigger automatic exports with computed next runs
- surface locally generated files inside the history table with download support and status updates

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e565cb678c832c887aedc71e917d0d