### PR TITLE
Simplify global search quick access

### DIFF
--- a/pages/main_menu/global_search.html
+++ b/pages/main_menu/global_search.html
@@ -56,13 +56,18 @@
             <article class="search-summary-card">
                 <div class="summary-label">Coincidencias encontradas</div>
                 <div class="summary-value" id="resultsCount">0</div>
-                <p class="summary-description">Actualiza en tiempo real mientras escribes.</p>
+                <p class="summary-description">Escribe para buscar o usa las etiquetas rápidas disponibles.</p>
             </article>
             <article class="search-summary-card">
                 <div class="summary-label">Atajos destacados</div>
-                <ul class="summary-links" id="quickLinks">
-                    <li class="empty-message">Aún no hay búsquedas recientes.</li>
-                </ul>
+                <div class="summary-links">
+                    <select id="quickTagSelect" class="quick-tag-select">
+                        <option value="" selected>Selecciona un acceso rápido</option>
+                    </select>
+                    <ul class="quick-history" id="quickHistoryList">
+                        <li class="empty-message">Aún no hay búsquedas recientes.</li>
+                    </ul>
+                </div>
             </article>
         </section>
 

--- a/styles/main_menu/main_menu.css
+++ b/styles/main_menu/main_menu.css
@@ -276,6 +276,30 @@ img {
 }
 
 .summary-links {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.quick-tag-select {
+    width: 100%;
+    padding: 0.65rem 1rem;
+    border-radius: var(--radius-pill);
+    border: 1px solid rgba(15, 180, 212, 0.25);
+    background: #ffffff;
+    color: #0f172a;
+    font-weight: 600;
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.quick-tag-select:focus {
+    border-color: rgba(15, 180, 212, 0.55);
+    box-shadow: 0 0 0 3px rgba(15, 180, 212, 0.2);
+    outline: none;
+}
+
+.quick-history {
     list-style: none;
     display: flex;
     flex-wrap: wrap;
@@ -284,7 +308,7 @@ img {
     padding: 0;
 }
 
-.summary-links .empty-message {
+.quick-history .empty-message {
     padding: 0.6rem 1.3rem;
     border-radius: var(--radius-pill);
     background: rgba(15, 180, 212, 0.08);
@@ -293,7 +317,7 @@ img {
     font-weight: 500;
 }
 
-.summary-links button {
+.quick-history button {
     border: 1px solid rgba(15, 180, 212, 0.25);
     border-radius: var(--radius-pill);
     padding: 0.6rem 1.3rem;
@@ -304,7 +328,7 @@ img {
     transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, border-color 0.2s ease;
 }
 
-.summary-links button:hover {
+.quick-history button:hover {
     background: rgba(15, 180, 212, 0.18);
     border-color: rgba(15, 180, 212, 0.45);
     transform: translateY(-2px);


### PR DESCRIPTION
## Summary
- replace the global search quick tag chips with a select-based shortcut picker plus a separate recent history list
- refresh the related styles so the dropdown and history chips fit the dashboard look and feel
- update the global search script to populate the select options, handle change events, and rebuild the history chips

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68e57cd92200832cb1e2896da3a06baf